### PR TITLE
upgrade pytorch kinematic to 076

### DIFF
--- a/embodichain/lab/sim/utility/import_utils.py
+++ b/embodichain/lab/sim/utility/import_utils.py
@@ -33,7 +33,7 @@ def lazy_import_pytorch_kinematics():
         return pk
     except ImportError as e:
         logger.log_warning(
-            "pytorch_kinematics not installed. Install with `pip install pytorch_kinematics==0.7.5`"
+            "pytorch_kinematics not installed. Install with `pip install pytorch_kinematics==0.7.6`"
         )
         raise e
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
   "qpsolvers==4.8.1",
   "pin-pink==3.4.0",
   "py_opw_kinematics==0.1.6",
-  "pytorch_kinematics==0.7.5",
+  "pytorch_kinematics==0.7.6",
   "polars==1.31.0",
   "PyYAML>=6.0",
   "accelerate==1.2.1",


### PR DESCRIPTION
# Description

upgrade pytorch kinematic to 0.7.6, to fix bugs when using numpy > 2.

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] I have run the `black .` command to format the code base.
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Dependencies have been updated, if applicable.

