### PR TITLE
Fix: add component type check on add_component

### DIFF
--- a/embodichain/toolkits/urdf_assembly/urdf_assembly_manager.py
+++ b/embodichain/toolkits/urdf_assembly/urdf_assembly_manager.py
@@ -230,6 +230,11 @@ class URDFAssemblyManager:
                 raise ValueError("component_type must be a string")
             if not isinstance(urdf_path, (str, Path)):
                 raise ValueError("urdf_path must be a string or Path")
+            if component_type not in self.SUPPORTED_COMPONENTS:
+                raise ValueError(
+                    f"Unsupported component_type: {component_type}. "
+                    f"Supported types: {self.SUPPORTED_COMPONENTS}"
+                )
 
             component = URDFComponent(
                 urdf_path=urdf_path, params=params, transform=transform


### PR DESCRIPTION
# Description

-  Add component type check on `add_component` on `URDFAssemblyManager`.

## Checklist

- [x] I have run the `black .` command to format the code base.