### PR TITLE
Fix: Add CPU Version Limits Check for SRS Solver

### DIFF
--- a/embodichain/lab/sim/solvers/srs_solver.py
+++ b/embodichain/lab/sim/solvers/srs_solver.py
@@ -512,13 +512,12 @@ class _CPUSRSSolverImpl(_BaseSRSSolverImpl):
         joints_output[6] = (angle7 - dh_params[6, 3]) * rotation_directions[6]
 
         # Check if the calculated joint angles are within the limits
-        for i in range(len(joints_output)):
-            if not (
-                self.qpos_limits_np[i, 0]
-                <= joints_output[i]
-                <= self.qpos_limits_np[i, 1]
-            ):
-                return False, None
+        in_range = (joints_output >= self.qpos_limits_np[:, 0]) & (
+            joints_output <= self.qpos_limits_np[:, 1]
+        )
+
+        if not np.all(in_range):
+            return False, None
 
         return True, joints_output
 


### PR DESCRIPTION
# Description
Add CPU Version Limits Check for SRS Solver.

```
In [2]:     solver = robot.get_solver("left_arm")
   ...:
   ...:     solver.cfg.qpos_limits
Out[2]: 
array([[-2.96706,  2.96706],
       [-2.0944 ,  1.5708 ],
       [-2.96706,  2.96706],
       [-2.35619,  1.5708 ],
       [-2.96706,  2.96706],
       [-0.7854 ,  0.7854 ],
       [-1.5708 ,  1.0472 ]])

In [3]:     qpos_fk_list = [
   ...:         torch.tensor([3.0, 3.5, 2.0, 2.0, 2.0, 1.0, 3.0], dtype=torch.float32),
   ...:     ]
   ...:     fk_xpos_batch = torch.cat(qpos_fk_list, dim=0)
   ...:
   ...:     fk_xpos_list = robot.compute_fk(qpos=fk_xpos_batch, name=arm_name, to_matrix=True)
   ...:
   ...:     res, ik_qpos = robot.compute_ik(
   ...:         pose=fk_xpos_list,
   ...:         name=arm_name,
   ...:         # joint_seed=qpos_fk_list[0],
   ...:         return_all_solutions=True,
   ...:     )
11:32:08 [EmbodiChain WARNING]: Failed to calculate IK solutions.
Target pose: tensor([[[-0.58668, -0.02473,  0.80944,  0.29731],
         [-0.08532,  0.99586, -0.03142,  0.05593],
         [-0.80531, -0.08749, -0.58636, -0.00833],
         [ 0.00000, -0.00000,  0.00000,  1.00000]]])
Seed: tensor([[0., 0., 0., 0., 0., 0., 0.]])
```

## Checklist

- [x] I have run the `black .` command to format the code base.
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Dependencies have been updated, if applicable.

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
