### PR TITLE
Fix: srs solover cpu batch ik failed

### DIFF
--- a/embodichain/lab/sim/solvers/srs_solver.py
+++ b/embodichain/lab/sim/solvers/srs_solver.py
@@ -568,7 +568,7 @@ class _CPUSRSSolverImpl(_BaseSRSSolverImpl):
             return (
                 torch.zeros(num_targets, dtype=torch.bool, device=self.device),
                 torch.zeros(
-                    (num_targets, num_targets, 7),
+                    (num_targets, 7),
                     dtype=qpos_seed.dtype,
                     device=self.device,
                 ),


### PR DESCRIPTION
# Description
Fix crash when srs solver cpu batch ik failed.

Fixes # (issue)

- Crash when srs solver cpu batch ik failed.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the `black .` command to format the code base.
- [x I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Dependencies have been updated, if applicable.
