### PR TITLE
Fix default window control issue 

### DIFF
--- a/embodichain/lab/sim/sim_manager.py
+++ b/embodichain/lab/sim/sim_manager.py
@@ -1515,6 +1515,11 @@ class SimulationManager:
         """Register default window controls for better simulation interaction."""
         from dexsim.types import InputKey
 
+        # TODO: window control has stucking issue with extra sensor under Raster renderer backend.
+        # Will be fixed in next dexsim release.
+        if self.is_rt_enabled is False:
+            return
+
         if self._is_registered_window_control:
             return
 


### PR DESCRIPTION
# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

💡 Please try to keep PRs small and focused. Large PRs are harder to review and merge.
-->

Currently, the default window control register will cause stucking. Fix the issue by moving the register at the end of simulation manager constructor.

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [x] I have run the `black .` command to format the code base.
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Dependencies have been updated, if applicable.

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
