### PR TITLE
fix setting drive none

### DIFF
--- a/embodichain/lab/sim/utility/sim_utils.py
+++ b/embodichain/lab/sim/utility/sim_utils.py
@@ -100,7 +100,7 @@ def set_dexsim_articulation_cfg(arts: List[Articulation], cfg: ArticulationCfg) 
     elif drive_type == "acceleration":
         drive_type = DriveType.ACCELERATION
     elif drive_type == "none":
-        return DriveType.NONE
+        drive_type = DriveType.NONE
     else:
         logger.log_error(f"Unknow drive type {drive_type}")
 


### PR DESCRIPTION
# Description

Fix setting drive none.

Fixes # (issue)

- Setting drive type to none will ignore `set_body_scale`  to articulation.

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] I have run the `black .` command to format the code base.
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Dependencies have been updated, if applicable.

