### PR TITLE
Fix: allow num_envs override from trainer config

### DIFF
--- a/embodichain/agents/rl/train.py
+++ b/embodichain/agents/rl/train.py
@@ -139,7 +139,7 @@ def train_from_config(config_path: str):
 
     if num_envs is not None:
         gym_env_cfg.num_envs = num_envs
-        
+
     # Ensure sim configuration mirrors runtime overrides
     if gym_env_cfg.sim_cfg is None:
         gym_env_cfg.sim_cfg = SimulationManagerCfg()


### PR DESCRIPTION
# Description

When num_envs is set in trainer config, it overrides gym_config's num_envs
so users can change parallel env count without editing gym config.

## Type of change


- Bug fix (non-breaking change which fixes an issue)


## Screenshots


| Before | After |
| ------ | ----- |
| <img width="1097" height="244" alt="Screenshot from 2026-02-26 12-49-37" src="https://github.com/user-attachments/assets/cab619f3-c949-4a49-abd7-05030817ee4f" />|<img width="1097" height="262" alt="Screenshot from 2026-02-26 12-51-16" src="https://github.com/user-attachments/assets/05878fe6-c6b2-4081-b8c5-df592e2a828a" />|


## Checklist

- [x] I have run the `black .` command to format the code base.
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Dependencies have been updated, if applicable.
