### PR TITLE
Update CobotMagic default safe margin

### DIFF
--- a/embodichain/lab/sim/robots/cobotmagic.py
+++ b/embodichain/lab/sim/robots/cobotmagic.py
@@ -115,7 +115,7 @@ class CobotMagicCfg(RobotCfg):
                     tcp=np.array(
                         [[-1, 0, 0, 0], [0, -1, 0, 0], [0, 0, 1, 0.143], [0, 0, 0, 1]]
                     ),
-                    safe_margin=5.0 * np.pi / 180.0,
+                    safe_margin=0.0,
                 ),
                 "right_arm": OPWSolverCfg(
                     end_link_name="right_link6",
@@ -123,7 +123,7 @@ class CobotMagicCfg(RobotCfg):
                     tcp=np.array(
                         [[-1, 0, 0, 0], [0, -1, 0, 0], [0, 0, 1, 0.143], [0, 0, 0, 1]]
                     ),
-                    safe_margin=5.0 * np.pi / 180.0,
+                    safe_margin=0.0,
                 ),
             },
             "min_position_iters": 8,

--- a/embodichain/lab/sim/robots/cobotmagic.py
+++ b/embodichain/lab/sim/robots/cobotmagic.py
@@ -114,16 +114,14 @@ class CobotMagicCfg(RobotCfg):
                     root_link_name="left_arm_base",
                     tcp=np.array(
                         [[-1, 0, 0, 0], [0, -1, 0, 0], [0, 0, 1, 0.143], [0, 0, 0, 1]]
-                    ),
-                    safe_margin=0.0,
+                    )
                 ),
                 "right_arm": OPWSolverCfg(
                     end_link_name="right_link6",
                     root_link_name="right_arm_base",
                     tcp=np.array(
                         [[-1, 0, 0, 0], [0, -1, 0, 0], [0, 0, 1, 0.143], [0, 0, 0, 1]]
-                    ),
-                    safe_margin=0.0,
+                    )
                 ),
             },
             "min_position_iters": 8,

--- a/embodichain/lab/sim/solvers/opw_solver.py
+++ b/embodichain/lab/sim/solvers/opw_solver.py
@@ -73,7 +73,7 @@ class OPWSolverCfg(SolverCfg):
     ik_params: dict | None = None
 
     # safe margin for joint limits, in radians
-    safe_margin: float = 5.0 * np.pi / 180.0
+    safe_margin: float = 0.0  # 5.0 * np.pi / 180.0
 
     def init_solver(
         self, device: torch.device = torch.device("cpu"), **kwargs


### PR DESCRIPTION
# Description

Update CobotMagic default safe margin: `5.0 degrees` -> `0 degrees`, in order to avoid ik failed near joint limits.

Fixes # (issue)


## Type of change

- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] I have run the `black .` command to format the code base.
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Dependencies have been updated, if applicable.
