### PR TITLE
Refine URDF assembly component prefixes and name casing policy

### DIFF
--- a/docs/source/features/toolkits/urdf_assembly.md
+++ b/docs/source/features/toolkits/urdf_assembly.md
@@ -246,17 +246,15 @@ Semantics:
 ##### Name casing policy (`name_case`)
 
 `URDFAssemblyManager` supports a global name casing policy that controls how
-link and joint names are normalized during assembly. This is configured via
-the optional `name_case` argument in the constructor:
+link and joint names are normalized during assembly. This is configured on
+the manager instance after construction:
 
 ```python
-manager = URDFAssemblyManager(
-        name_case={
-                "joint": "upper",  # or "lower" / "none"
-                "link": "lower",  # or "upper" / "none"
-        }
-)
-```
+manager = URDFAssemblyManager()
+manager.name_case = {
+        "joint": "upper",  # or "lower" / "none"
+        "link": "lower",  # or "upper" / "none"
+}
 
 Semantics:
 
@@ -454,7 +452,7 @@ def create_robot(sim):
                     "transform": hand_transform,
                 },
             ],
-            component_prefix=[("left_arm", "L_"), ("right_arm", "R_"), ("right_hand", "left_"), ("right_hand", "right_")],
+            component_prefix=[("left_arm", "L_"), ("right_arm", "R_"), ("left_hand", "left_"), ("right_hand", "right_")],
             name_case={
                 "joint": "lower",
                 "link": "lower",

--- a/docs/source/features/toolkits/urdf_assembly.md
+++ b/docs/source/features/toolkits/urdf_assembly.md
@@ -18,7 +18,7 @@ The tool provides a programmatic way to:
 ```python
 from pathlib import Path
 import numpy as np
-from embedichain.toolkits.urdf_assembly import URDFAssemblyManager
+from embodichain.toolkits.urdf_assembly import URDFAssemblyManager
 
 # Initialize the assembly manager
 manager = URDFAssemblyManager()
@@ -201,6 +201,74 @@ Get all attached sensors.
 manager.get_attached_sensors() -> dict
 ```
 
+##### Component name prefixes (`component_prefix`)
+
+`URDFAssemblyManager` uses `component_prefix` to configure name prefixes for
+each supported component type. This attribute is a list of 2-tuples:
+
+- Form: `[(component_name, prefix), ...]`
+- The default value is:
+
+    ```python
+    [
+        ("chassis", None),
+        ("legs", None),
+        ("torso", None),
+        ("head", None),
+        ("left_arm", "left_"),
+        ("right_arm", "right_"),
+        ("left_hand", "left_"),
+        ("right_hand", "right_"),
+        ("arm", None),
+        ("hand", None),
+    ]
+    ```
+
+You can configure it in a *patch-style* manner via the property:
+
+```python
+# Only override prefixes for existing components; do not introduce
+# new component names.
+manager.component_prefix = [
+    ("left_arm", "L_"),
+    ("right_arm", "R_"),
+    ("left_hand", "L_"),
+    ("right_hand", "R_"),
+]
+```
+
+Semantics:
+
+- Only components that already exist in the default configuration (e.g. `chassis/torso/left_arm/...`) may be overridden; new component names are not allowed.
+- Components not listed in `new_prefixes` keep their original prefix.
+- If `new_prefixes` contains an unknown component name, a `ValueError` is raised indicating that new component types cannot be introduced.
+
+##### Name casing policy (`name_case`)
+
+`URDFAssemblyManager` supports a global name casing policy that controls how
+link and joint names are normalized during assembly. This is configured via
+the optional `name_case` argument in the constructor:
+
+```python
+manager = URDFAssemblyManager(
+        name_case={
+                "joint": "upper",  # or "lower" / "none"
+                "link": "lower",  # or "upper" / "none"
+        }
+)
+```
+
+Semantics:
+
+- Valid keys: `"joint"`, `"link"`.
+- Valid values: `"upper"`, `"lower"`, `"none"`.
+- Default behavior matches the legacy implementation:
+  - joints are normalized to **UPPERCASE**,
+  - links are normalized to **lowercase**.
+- This policy is propagated to the internal component and connection managers,
+    and is also included in the assembly signature. Changing `name_case` will
+    therefore force a rebuild of the assembled URDF.
+
 ## Using with URDFCfg for Robot Creation
 
 The URDF Assembly Tool can be used directly with `URDFCfg` to create robots with multiple components in the simulation. This is the recommended approach when building robots from assembled URDF files.
@@ -210,7 +278,7 @@ The URDF Assembly Tool can be used directly with `URDFCfg` to create robots with
 The `URDFCfg` class provides a convenient way to define multi-component robots:
 
 ```python
-from embedichain.lab.sim.cfg import RobotCfg, URDFCfg
+from embodichain.lab.sim.cfg import RobotCfg, URDFCfg
 
 cfg = RobotCfg(
     uid="my_robot",
@@ -232,6 +300,27 @@ cfg = RobotCfg(
 )
 ```
 
+When using `URDFCfg` to build multi-component robots, you can pass custom
+component prefixes to the internal `URDFAssemblyManager` via
+`URDFCfg.component_prefix`. Its semantics are identical to
+`URDFAssemblyManager.component_prefix`:
+
+- Each element is a `(component_name, prefix)` tuple.
+- Only prefixes for components that exist in the default configuration may be overridden; no new component names can be added.
+- Components not explicitly listed keep their original prefix.
+
+Example:
+
+```python
+urdf_cfg = URDFCfg(
+    components=[...],
+)
+urdf_cfg.component_prefix = [
+    ("left_arm", "L_"),
+    ("right_arm", "R_"),
+]
+```
+
 ### Complete Example
 
 Here's a complete example from `scripts/tutorials/sim/create_robot.py`:
@@ -241,14 +330,14 @@ import numpy as np
 import torch
 from scipy.spatial.transform import Rotation as R
 
-from embedichain.lab.sim import SimulationManager, SimulationManagerCfg
-from embedichain.lab.sim.objects import Robot
-from embedichain.lab.sim.cfg import (
+from embodichain.lab.sim import SimulationManager, SimulationManagerCfg
+from embodichain.lab.sim.objects import Robot
+from embodichain.lab.sim.cfg import (
     JointDrivePropertiesCfg,
     RobotCfg,
     URDFCfg,
 )
-from embedichain.data import get_data_path
+from embodichain.data import get_data_path
 
 
 def create_robot(sim):
@@ -269,7 +358,6 @@ def create_robot(sim):
     # Define transformation for hand attachment
     hand_transform = np.eye(4)
     hand_transform[:3, :3] = R.from_rotvec([90, 0, 0], degrees=True).as_matrix()
-    hand_transform[2, 3] = 0.02  # 2cm offset along z-axis
 
     # Create robot configuration
     cfg = RobotCfg(
@@ -291,6 +379,86 @@ def create_robot(sim):
         drive_pros=JointDrivePropertiesCfg(
             stiffness={"JOINT[1-6]": 1e4, "LEFT_.*": 1e3},
             damping={"JOINT[1-6]": 1e3, "LEFT_.*": 1e2},
+        ),
+    )
+
+    # Add robot to simulation
+    robot: Robot = sim.add_robot(cfg=cfg)
+
+    return robot
+
+
+# Initialize simulation and create robot
+sim = SimulationManager(SimulationManagerCfg(headless=True, num_envs=4))
+robot = create_robot(sim)
+print(f"Robot created with {robot.dof} joints")
+```
+
+```python
+import numpy as np
+import torch
+from scipy.spatial.transform import Rotation as R
+
+from embodichain.lab.sim import SimulationManager, SimulationManagerCfg
+from embodichain.lab.sim.objects import Robot
+from embodichain.lab.sim.cfg import (
+    JointDrivePropertiesCfg,
+    RobotCfg,
+    URDFCfg,
+)
+from embodichain.data import get_data_path
+
+
+def create_robot(sim):
+    """Create and configure a robot with arm and hand components."""
+
+    # Get URDF paths for robot components
+    arm_urdf_path = get_data_path("Rokae/SR5/SR5.urdf")
+    hand_urdf_path = get_data_path(
+        "BrainCoHandRevo1/BrainCoLeftHand/BrainCoLeftHand.urdf"
+    )
+
+    # Define transformation for hand attachment
+    hand_transform = np.eye(4)
+    hand_transform[:3, :3] = R.from_rotvec([90, 0, 0], degrees=True).as_matrix()
+
+    left_arm_base_xpos = np.eye(4)
+    left_arm_base_xpos[1, 3] = 0.3
+
+    right_arm_base_xpos = np.eye(4)
+    right_arm_base_xpos[1, 3] = -0.3
+
+    # Create robot configuration
+    cfg = RobotCfg(
+        uid="dual_sr5",
+        urdf_cfg=URDFCfg(
+            components=[
+                {
+                    "component_type": "left_arm",
+                    "urdf_path": arm_urdf_path,
+                    "transform": left_arm_base_xpos,
+                },
+                {
+                    "component_type": "right_arm",
+                    "urdf_path": arm_urdf_path,
+                    "transform": right_arm_base_xpos,
+                },
+                {
+                    "component_type": "left_hand",
+                    "urdf_path": hand_urdf_path,
+                    "transform": hand_transform,
+                },
+                {
+                    "component_type": "right_hand",
+                    "urdf_path": hand_urdf_path,
+                    "transform": hand_transform,
+                },
+            ],
+            component_prefix=[("left_arm", "L_"), ("right_arm", "R_"), ("right_hand", "left_"), ("right_hand", "right_")],
+            name_case={
+                "joint": "lower",
+                "link": "lower",
+            }
         ),
     )
 

--- a/embodichain/lab/sim/cfg.py
+++ b/embodichain/lab/sim/cfg.py
@@ -1119,11 +1119,6 @@ class URDFCfg:
 
         if self.name_case is not None:
             manager.name_case = self.name_case
-        else:
-            manager.name_case = {
-                "joint": "upper",
-                "link": "lower",
-            }
 
         for comp_type, comp_config in components:
             params = comp_config.get("params", {})

--- a/embodichain/lab/sim/cfg.py
+++ b/embodichain/lab/sim/cfg.py
@@ -846,6 +846,34 @@ class URDFCfg:
     fpath_prefix: str = EMBODICHAIN_DEFAULT_DATA_ROOT + "/assembled"
     """Output directory prefix for the assembled URDF file."""
 
+    component_prefix: List[tuple[str, Union[str, None]]] = field(
+        default_factory=lambda: [
+            ("chassis", None),
+            ("legs", None),
+            ("torso", None),
+            ("head", None),
+            ("left_arm", "left_"),
+            ("right_arm", "right_"),
+            ("left_hand", "left_"),
+            ("right_hand", "right_"),
+            ("arm", None),
+            ("hand", None),
+        ]
+    )
+    """Component name prefixes used during URDF assembly.
+
+    Preferred form is a list of ``(component_name, prefix)`` tuples. For
+    convenience, a mapping ``{component_name: prefix}`` is also accepted when
+    constructing :class:`URDFCfg` and will be normalized internally.
+    """
+
+    name_case: dict[str, str] = field(
+        default_factory=lambda: {
+            "joint": "upper",
+            "link": "lower",
+        }
+    )
+
     def __init__(
         self,
         components: list[dict[str, str | np.ndarray]] | None = None,
@@ -855,6 +883,8 @@ class URDFCfg:
         fpath_prefix: str = EMBODICHAIN_DEFAULT_DATA_ROOT + "/assembled",
         use_signature_check: bool = True,
         base_link_name: str = "base_link",
+        component_prefix: list[tuple[str, str | None]] | None = None,
+        name_case: dict[str, str] | None = None,
     ):
         """
         Initialize URDFCfg with optional list of components and output path settings.
@@ -871,6 +901,9 @@ class URDFCfg:
             fpath_prefix (str): Output directory prefix for the assembled URDF file.
             use_signature_check (bool): Whether to use signature check when merging URDFs.
             base_link_name (str): Name of the base link in the assembled robot.
+            component_prefix (list[tuple[str, str | None]] | None): Optional
+                list of (component_type, prefix) pairs to override default
+                component name prefixes.
         """
         self.components = {}
         self.sensors = sensors or {}
@@ -879,6 +912,36 @@ class URDFCfg:
         self.base_link_name = base_link_name
         self.fname = fname
         self.fpath_prefix = fpath_prefix
+
+        # Initialize component prefixes (patch-style mapping per component type)
+        if component_prefix is None:
+            # Use the same default as the dataclass field
+            self.component_prefix = [
+                ("chassis", None),
+                ("legs", None),
+                ("torso", None),
+                ("head", None),
+                ("left_arm", "left_"),
+                ("right_arm", "right_"),
+                ("left_hand", "left_"),
+                ("right_hand", "right_"),
+                ("arm", None),
+                ("hand", None),
+            ]
+        elif isinstance(component_prefix, dict):
+            # Allow dict-style config: {"left_hand": "l_", ...}
+            self.component_prefix = list(component_prefix.items())
+        else:
+            # Assume caller provided a list of (component_name, prefix) tuples
+            self.component_prefix = component_prefix
+
+        if name_case is None:
+            self.name_case = {
+                "joint": "upper",
+                "link": "lower",
+            }
+        else:
+            self.name_case = name_case
 
         # Auto-add components if provided
         if components:
@@ -1041,6 +1104,27 @@ class URDFCfg:
         # If there are multiple components, merge them into a single URDF file.
         manager = URDFAssemblyManager()
         manager.base_link_name = self.base_link_name
+
+        if self.component_prefix is None:
+            self.component_prefix = [
+                ("left_arm", "left_"),
+                ("right_arm", "right_"),
+                ("left_hand", "left_"),
+                ("right_hand", "right_"),
+            ]
+        if isinstance(self.component_prefix, dict):
+            self.component_prefix = list(self.component_prefix.items())
+        # Forward configured component prefixes to the assembly manager
+        manager.component_prefix = self.component_prefix
+
+        if self.name_case is not None:
+            manager.name_case = self.name_case
+        else:
+            manager.name_case = {
+                "joint": "upper",
+                "link": "lower",
+            }
+
         for comp_type, comp_config in components:
             params = comp_config.get("params", {})
             success = manager.add_component(
@@ -1094,12 +1178,16 @@ class URDFCfg:
         fpath = init_dict.get("fpath", None)
         use_signature_check = init_dict.get("use_signature_check", True)
         base_link_name = init_dict.get("base_link_name", "base_link")
+        component_prefix = init_dict.get("component_prefix", None)
+        name_case = init_dict.get("name_case", None)
         return cls(
             components=components,
             sensors=sensors,
             fpath=fpath,
             use_signature_check=use_signature_check,
             base_link_name=base_link_name,
+            component_prefix=component_prefix,
+            name_case=name_case,
         )
 
 

--- a/embodichain/lab/sim/robots/cobotmagic.py
+++ b/embodichain/lab/sim/robots/cobotmagic.py
@@ -114,14 +114,14 @@ class CobotMagicCfg(RobotCfg):
                     root_link_name="left_arm_base",
                     tcp=np.array(
                         [[-1, 0, 0, 0], [0, -1, 0, 0], [0, 0, 1, 0.143], [0, 0, 0, 1]]
-                    )
+                    ),
                 ),
                 "right_arm": OPWSolverCfg(
                     end_link_name="right_link6",
                     root_link_name="right_arm_base",
                     tcp=np.array(
                         [[-1, 0, 0, 0], [0, -1, 0, 0], [0, 0, 1, 0.143], [0, 0, 0, 1]]
-                    )
+                    ),
                 ),
             },
             "min_position_iters": 8,

--- a/embodichain/toolkits/urdf_assembly/component.py
+++ b/embodichain/toolkits/urdf_assembly/component.py
@@ -25,7 +25,7 @@ from embodichain.toolkits.urdf_assembly.logging_utils import (
     URDFAssemblyLogger,
 )
 from embodichain.toolkits.urdf_assembly.mesh import URDFMeshManager
-
+from embodichain.toolkits.urdf_assembly.name_normalizer import NameNormalizer
 
 __all__ = ["ComponentRegistry", "URDFComponent", "URDFComponentManager"]
 
@@ -83,11 +83,39 @@ class URDFComponent:
 
 
 class URDFComponentManager:
-    """Responsible for loading, renaming, and processing meshes for a single component."""
+    """Responsible for loading, renaming, and processing meshes for a single component.
 
-    def __init__(self, mesh_manager: URDFMeshManager):
+    This manager normalizes link and joint names according to a configurable
+    case policy so that the overall assembly naming scheme can be controlled
+    centrally (e.g. all links lowercase, all joints uppercase).
+    """
+
+    def __init__(
+        self,
+        mesh_manager: URDFMeshManager,
+        name_case: dict[str, str] | None = None,
+    ):
+        """Create a component manager.
+
+        Args:
+            mesh_manager (URDFMeshManager): Mesh manager used for copying and
+                rewriting mesh references.
+            name_case (dict[str, str] | None): Optional mapping controlling
+                how joint and link names are normalized. Supported keys are
+                ``"joint"`` and ``"link"`` with values ``"upper``,
+                ``"lower"`` or ``"none"``. When omitted, joints are
+                uppercased and links are lowercased (the previous default
+                behavior).
+        """
+
         self.mesh_manager = mesh_manager
         self.logger = URDFAssemblyLogger.get_logger("component_manager")
+
+        self.name_normalizer = NameNormalizer(name_case)
+
+    def _apply_case(self, kind: str, name: str | None) -> str | None:
+        """Normalize a name using the NameNormalizer."""
+        return self.name_normalizer.normalize(kind, name)
 
     def process_component(
         self,
@@ -119,12 +147,12 @@ class URDFComponentManager:
 
             # Safe way to get link and joint names, handling None values
             global_link_names = {
-                link.get("name").lower()
+                self._apply_case("link", link.get("name"))
                 for link in links
                 if link.get("name") is not None
             }
             global_joint_names = {
-                joint.get("name").upper()
+                self._apply_case("joint", joint.get("name"))
                 for joint in joints
                 if joint.get("name") is not None
             }
@@ -143,15 +171,19 @@ class URDFComponentManager:
 
                 # Generate unique name
                 if prefix:
-                    new_name = self._generate_unique_name(
-                        orig_name, prefix, global_link_names
-                    ).lower()
+                    new_name = self._apply_case(
+                        "link",
+                        self._generate_unique_name(
+                            orig_name, prefix, global_link_names
+                        ),
+                    )
                 else:
                     # For components without prefix, ensure names are unique
-                    if orig_name.lower() in global_link_names:
-                        new_name = f"{comp}_{orig_name}".lower()
+                    normalized_orig = self._apply_case("link", orig_name)
+                    if normalized_orig in global_link_names:
+                        new_name = self._apply_case("link", f"{comp}_{orig_name}")
                     else:
-                        new_name = orig_name.lower()
+                        new_name = normalized_orig
 
                 global_link_names.add(new_name)
 
@@ -160,7 +192,7 @@ class URDFComponentManager:
                     base_points[comp] = new_name
                     first_link_flag = False
 
-                # Update link name mapping and set link name to lowercase
+                # Update link name mapping and set link name according to policy
                 name_mapping[(comp, orig_name)] = new_name
                 link.set("name", new_name)
                 links.append(link)
@@ -176,9 +208,12 @@ class URDFComponentManager:
                 if orig_joint_name is None:
                     continue
 
-                new_joint_name = self._generate_unique_name(
-                    orig_joint_name, prefix, global_joint_names
-                ).upper()
+                new_joint_name = self._apply_case(
+                    "joint",
+                    self._generate_unique_name(
+                        orig_joint_name, prefix, global_joint_names
+                    ),
+                )
                 global_joint_names.add(new_joint_name)
 
                 # Build the complete mapping table
@@ -192,16 +227,16 @@ class URDFComponentManager:
                 # Set the new joint name
                 joint.set("name", new_joint_name)
 
-                # Update parent and child links to lowercase - with None checks
+                # Update parent and child links with case normalization - with None checks
                 parent_elem = joint.find("parent")
                 child_elem = joint.find("child")
 
                 if parent_elem is not None:
                     parent = parent_elem.get("link")
                     if parent is not None:
-                        new_parent_name = name_mapping.get(
-                            (comp, parent), parent
-                        ).lower()
+                        new_parent_name = self._apply_case(
+                            "link", name_mapping.get((comp, parent), parent)
+                        )
                         parent_elem.set("link", new_parent_name)
                     else:
                         self.logger.warning(
@@ -211,7 +246,9 @@ class URDFComponentManager:
                 if child_elem is not None:
                     child = child_elem.get("link")
                     if child is not None:
-                        new_child_name = name_mapping.get((comp, child), child).lower()
+                        new_child_name = self._apply_case(
+                            "link", name_mapping.get((comp, child), child)
+                        )
                         child_elem.set("link", new_child_name)
                     else:
                         self.logger.warning(
@@ -270,10 +307,14 @@ class URDFComponentManager:
         if orig_name is None:
             orig_name = "unnamed"
 
+        # For uniqueness checks we always operate on a normalized form that is
+        # consistent with the link case policy. This keeps collisions and
+        # generated names aligned with how names are written back to the URDF.
+        base_name = orig_name
         if prefix and not orig_name.lower().startswith(prefix.lower()):
-            new_name = f"{prefix}{orig_name}".lower()
-        else:
-            new_name = orig_name.lower()
+            base_name = f"{prefix}{orig_name}"
+
+        new_name = base_name
 
         # Ensure the new name is unique
         if new_name in existing_names:

--- a/embodichain/toolkits/urdf_assembly/connection.py
+++ b/embodichain/toolkits/urdf_assembly/connection.py
@@ -14,30 +14,259 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
+from __future__ import annotations
+
 import xml.etree.ElementTree as ET
+from typing import Any
 
 from scipy.spatial.transform import Rotation as R
 
-from embodichain.toolkits.urdf_assembly.logging_utils import (
-    URDFAssemblyLogger,
-)
+from embodichain.toolkits.urdf_assembly.logging_utils import URDFAssemblyLogger
+from embodichain.toolkits.urdf_assembly.name_normalizer import NameNormalizer
 
 __all__ = ["URDFConnectionManager"]
 
 
 class URDFConnectionManager:
-    r"""
-    Responsible for managing connection rules between components and sensor attachments.
-    """
+    r"""Responsible for managing connection rules between components and sensor attachments."""
 
-    def __init__(self, base_link_name: str):
-        r"""Initialize the URDFConnectionManager.
+    _DEFAULT_ORIGIN = {"xyz": "0 0 0", "rpy": "0 0 0"}
+
+    def __init__(self, base_link_name: str, name_case: dict[str, str] | None = None):
+        """Initialize the URDFConnectionManager.
 
         Args:
-            base_link_name (str): The name of the base link to which the chassis or other components may be attached.
+            base_link_name: The name of the base link to which the chassis or other
+                components may be attached.
+            name_case: Optional mapping controlling how joint and link names are
+                normalized. Supported keys are ``"joint"`` and ``"link"`` with
+                values ``"upper"``, ``"lower"`` or ``"none"``.
+
+                When omitted, joints are uppercased and links are lowercased (the
+                previous default behavior).
         """
         self.base_link_name = base_link_name
         self.logger = URDFAssemblyLogger.get_logger("connection_manager")
+        self.name_normalizer = NameNormalizer(name_case)
+
+    def _apply_case(self, kind: str, name: str | None) -> str | None:
+        """Normalize a name using the NameNormalizer."""
+        return self.name_normalizer.normalize(kind, name)
+
+    @staticmethod
+    def _get_attr(obj: Any, key: str, default: Any = None) -> Any:
+        """Read attribute from object or key from dict."""
+        if obj is None:
+            return default
+        if isinstance(obj, dict):
+            return obj.get(key, default)
+        return getattr(obj, key, default)
+
+    @staticmethod
+    def _format_scalar(value: Any) -> str:
+        """Format scalar values for URDF attribute strings."""
+        try:
+            f = float(value)
+        except Exception:
+            return "0"
+
+        # Keep strings stable and compact (avoid long repr / numpy scalars).
+        s = f"{f:.6f}".rstrip("0").rstrip(".")
+        return s if s else "0"
+
+    def _format_vec3(self, vec3: Any) -> str:
+        """Format a 3D vector as URDF 'x y z' string."""
+        try:
+            x, y, z = vec3[0], vec3[1], vec3[2]
+        except Exception:
+            return "0 0 0"
+        return f"{self._format_scalar(x)} {self._format_scalar(y)} {self._format_scalar(z)}"
+
+    def _origin_kwargs_from_transform(self, transform: Any | None) -> dict[str, str]:
+        """Convert a 4x4 transform matrix to URDF origin attributes."""
+        if transform is None:
+            return dict(self._DEFAULT_ORIGIN)
+
+        try:
+            xyz = transform[:3, 3]
+            rotation = R.from_matrix(transform[:3, :3])
+            rpy = rotation.as_euler("xyz")
+        except Exception as exc:
+            self.logger.warning(f"Invalid transform, fallback to identity: {exc}")
+            return dict(self._DEFAULT_ORIGIN)
+
+        return {"xyz": self._format_vec3(xyz), "rpy": self._format_vec3(rpy)}
+
+    @staticmethod
+    def _make_unique(base: str, existing: set[str]) -> str:
+        """Make a unique name by appending suffixes when needed."""
+        if base not in existing:
+            return base
+        idx = 1
+        while f"{base}_{idx}" in existing:
+            idx += 1
+        return f"{base}_{idx}"
+
+    def _collect_existing_joint_names(self, joints: list) -> set[str]:
+        names: set[str] = set()
+        for joint in joints:
+            if not hasattr(joint, "get"):
+                continue
+            raw = joint.get("name")
+            if not raw:
+                continue
+            normalized = self._apply_case("joint", raw)
+            if normalized:
+                names.add(normalized)
+        return names
+
+    def _append_fixed_joint(
+        self,
+        joints: list,
+        existing_joint_names: set[str],
+        joint_name: str,
+        parent_link: str,
+        child_link: str,
+        origin_kwargs: dict[str, str] | None = None,
+    ) -> None:
+        """Append a fixed joint if it doesn't already exist."""
+        normalized_joint_name = self._apply_case("joint", joint_name)
+        if not normalized_joint_name:
+            self.logger.error(f"Empty joint name for joint_name={joint_name!r}")
+            return
+
+        if normalized_joint_name in existing_joint_names:
+            self.logger.warning(f"Duplicate joint: {normalized_joint_name}")
+            return
+
+        joint = ET.Element("joint", name=normalized_joint_name, type="fixed")
+        ET.SubElement(joint, "origin", **(origin_kwargs or dict(self._DEFAULT_ORIGIN)))
+        ET.SubElement(joint, "parent", link=parent_link)
+        ET.SubElement(joint, "child", link=child_link)
+
+        joints.append(joint)
+        existing_joint_names.add(normalized_joint_name)
+
+    def _normalize_link_or_none(self, link_name: str | None) -> str | None:
+        if not link_name:
+            return None
+        return self._apply_case("link", link_name)
+
+    def _connect_chassis_to_base(
+        self,
+        joints: list,
+        base_points: dict,
+        existing_joint_names: set[str],
+        chassis_component: str,
+    ) -> bool:
+        if chassis_component not in base_points:
+            return False
+
+        chassis_first_link = self._normalize_link_or_none(
+            base_points.get(chassis_component)
+        )
+        if not chassis_first_link:
+            self.logger.error("Invalid chassis base link (None)")
+            return True
+
+        self._append_fixed_joint(
+            joints=joints,
+            existing_joint_names=existing_joint_names,
+            joint_name=f"BASE_LINK_TO_{chassis_component}_CONNECTOR",
+            parent_link=self.base_link_name,
+            child_link=chassis_first_link,
+        )
+        self.logger.info(
+            f"[{chassis_component.capitalize()}] connected to [base_link] via ({chassis_first_link})"
+        )
+        return True
+
+    def _connect_orphan_components_to_base(
+        self,
+        joints: list,
+        base_points: dict,
+        connection_rules: list,
+        component_transforms: dict,
+        existing_joint_names: set[str],
+    ) -> None:
+        # Find components that don't have parents in connection_rules
+        components_with_parents = {child for parent, child in connection_rules}
+        orphan_components = [
+            comp for comp in base_points.keys() if comp not in components_with_parents
+        ]
+
+        for comp in orphan_components:
+            comp_first_link = self._normalize_link_or_none(base_points.get(comp))
+            if not comp_first_link:
+                self.logger.error(f"Invalid base link for component [{comp}]")
+                continue
+
+            origin_kwargs = self._origin_kwargs_from_transform(
+                component_transforms.get(comp)
+            )
+            if comp in component_transforms:
+                self.logger.info(
+                    f"Applied transform to base connection {comp}: {origin_kwargs}"
+                )
+
+            self._append_fixed_joint(
+                joints=joints,
+                existing_joint_names=existing_joint_names,
+                joint_name=f"BASE_TO_{comp}_CONNECTOR",
+                parent_link=self.base_link_name,
+                child_link=comp_first_link,
+                origin_kwargs=origin_kwargs,
+            )
+
+            self.logger.info(
+                f"[{comp.capitalize()}] connected to [base_link] via ({comp_first_link})"
+            )
+
+    def _connect_component_pair(
+        self,
+        joints: list,
+        base_points: dict,
+        parent_attach_points: dict,
+        parent: str,
+        child: str,
+        component_transforms: dict,
+        existing_joint_names: set[str],
+    ) -> None:
+        if parent not in parent_attach_points or child not in base_points:
+            self.logger.error(f"Invalid connection rule: {parent} -> {child}")
+            return
+
+        parent_connect_link = self._normalize_link_or_none(
+            parent_attach_points.get(parent)
+        )
+        child_connect_link = self._normalize_link_or_none(base_points.get(child))
+
+        if not parent_connect_link or not child_connect_link:
+            self.logger.error(
+                f"Invalid link in connection: {parent} ({parent_connect_link}) -> {child} ({child_connect_link})"
+            )
+            return
+
+        self.logger.info(
+            f"Connecting [{parent}]-({parent_connect_link}) to [{child}]-({child_connect_link})"
+        )
+
+        origin_kwargs = self._origin_kwargs_from_transform(
+            component_transforms.get(child)
+        )
+        if child in component_transforms:
+            self.logger.info(
+                f"Applied transform to connection {parent} -> {child}: {origin_kwargs}"
+            )
+
+        self._append_fixed_joint(
+            joints=joints,
+            existing_joint_names=existing_joint_names,
+            joint_name=self._apply_case("joint", f"{parent}_TO_{child}_CONNECTOR"),
+            parent_link=parent_connect_link,
+            child_link=child_connect_link,
+            origin_kwargs=origin_kwargs,
+        )
 
     def add_connections(
         self,
@@ -45,168 +274,195 @@ class URDFConnectionManager:
         base_points: dict,
         parent_attach_points: dict,
         connection_rules: list,
-        component_transforms: dict = None,
-    ):
+        component_transforms: dict | None = None,
+    ) -> None:
         r"""Add connection joints between robot components according to the specified rules.
 
         Args:
-            joints (list): A list to collect joint elements.
-            base_points (dict): A mapping from component names to their child connection link names.
-            parent_attach_points (dict): A mapping from component names to their parent connection link names.
-            connection_rules (list): A list of (parent, child) tuples specifying connection relationships.
-            component_transforms (dict): Optional mapping from component names to their transform matrices.
+            joints: A list to collect joint elements.
+            base_points: Mapping from component names to their child connection link names.
+            parent_attach_points: Mapping from component names to their parent connection link names.
+            connection_rules: A list of (parent, child) tuples specifying connection relationships.
+            component_transforms: Optional mapping from component names to their 4x4 transform matrices.
         """
         chassis_component = "chassis"
         component_transforms = component_transforms or {}
 
-        existing_joint_names = {
-            joint.get("name") for joint in joints if hasattr(joint, "get")
-        }
+        existing_joint_names = self._collect_existing_joint_names(joints)
 
         # chassis is always attached to base_link (no transform applied to this connection)
-        if chassis_component in base_points:
-            chassis_first_link = base_points[chassis_component]
-            joint_name = f"BASE_LINK_TO_{chassis_component.upper()}_CONNECTOR"
-            if joint_name not in existing_joint_names:
-                joint = ET.Element("joint", name=joint_name, type="fixed")
-                ET.SubElement(joint, "origin", xyz="0 0 0", rpy="0 0 0")
-                ET.SubElement(joint, "parent", link=self.base_link_name)
-                ET.SubElement(joint, "child", link=chassis_first_link)
-                joints.append(joint)
-                existing_joint_names.add(joint_name)
-                self.logger.info(
-                    f"[{chassis_component.capitalize()}] connected to [base_link] via ({chassis_first_link})"
-                )
-        else:
+        if not self._connect_chassis_to_base(
+            joints=joints,
+            base_points=base_points,
+            existing_joint_names=existing_joint_names,
+            chassis_component=chassis_component,
+        ):
             # If no chassis, connect components directly to base_link with their transforms
             self.logger.info(
                 "No chassis found, connecting components directly to base_link"
             )
-
-            # Find components that don't have parents in connection_rules
-            components_with_parents = {child for parent, child in connection_rules}
-            orphan_components = [
-                comp
-                for comp in base_points.keys()
-                if comp not in components_with_parents
-            ]
-
-            for comp in orphan_components:
-                comp_first_link = base_points[comp]
-                joint_name = f"BASE_TO_{comp.upper()}_CONNECTOR"
-
-                if joint_name not in existing_joint_names:
-                    joint = ET.Element("joint", name=joint_name, type="fixed")
-
-                    # Apply transform to this specific connection if the component has one
-                    if comp in component_transforms:
-                        transform = component_transforms[comp]
-                        xyz = transform[:3, 3]  # Extract translation
-                        rotation = R.from_matrix(transform[:3, :3])
-                        rpy = rotation.as_euler("xyz")
-
-                        ET.SubElement(
-                            joint,
-                            "origin",
-                            xyz=f"{xyz[0]} {xyz[1]} {xyz[2]}",
-                            rpy=f"{rpy[0]} {rpy[1]} {rpy[2]}",
-                        )
-                        self.logger.info(
-                            f"Applied transform to base connection {comp}: xyz={xyz}, rpy={rpy}"
-                        )
-                    else:
-                        ET.SubElement(joint, "origin", xyz="0 0 0", rpy="0 0 0")
-
-                    ET.SubElement(joint, "parent", link=self.base_link_name)
-                    ET.SubElement(joint, "child", link=comp_first_link)
-                    joints.append(joint)
-                    existing_joint_names.add(joint_name)
-
-                    self.logger.info(
-                        f"[{comp.capitalize()}] connected to [base_link] via ({comp_first_link})"
-                    )
+            self._connect_orphan_components_to_base(
+                joints=joints,
+                base_points=base_points,
+                connection_rules=connection_rules,
+                component_transforms=component_transforms,
+                existing_joint_names=existing_joint_names,
+            )
 
         # Process other connection relationships
         for parent, child in connection_rules:
-            if parent in parent_attach_points and child in base_points:
-                parent_connect_link = parent_attach_points[parent].lower()
-                child_connect_link = base_points[child].lower()
-
-                self.logger.info(
-                    f"Connecting [{parent}]-({parent_connect_link}) to [{child}]-({child_connect_link})"
-                )
-
-                # Create a unique joint name
-                base_joint_name = f"{parent.upper()}_TO_{child.upper()}_CONNECTOR"
-                if base_joint_name not in existing_joint_names:
-                    joint = ET.Element("joint", name=base_joint_name, type="fixed")
-
-                    # Apply transform to this specific connection if the child component has one
-                    if child in component_transforms:
-                        transform = component_transforms[child]
-                        xyz = transform[:3, 3]  # Extract translation
-                        rotation = R.from_matrix(transform[:3, :3])
-                        rpy = rotation.as_euler("xyz")
-
-                        ET.SubElement(
-                            joint,
-                            "origin",
-                            xyz=f"{xyz[0]} {xyz[1]} {xyz[2]}",
-                            rpy=f"{rpy[0]} {rpy[1]} {rpy[2]}",
-                        )
-                        self.logger.info(
-                            f"Applied transform to connection {parent} -> {child}: xyz={xyz}, rpy={rpy}"
-                        )
-                    else:
-                        ET.SubElement(joint, "origin", xyz="0 0 0", rpy="0 0 0")
-
-                    ET.SubElement(joint, "parent", link=parent_connect_link)
-                    ET.SubElement(joint, "child", link=child_connect_link)
-                    joints.append(joint)
-                    existing_joint_names.add(base_joint_name)
-                else:
-                    self.logger.warning(
-                        f"Duplicate connection rule: {parent} -> {child}"
-                    )
-            else:
-                self.logger.error(f"Invalid connection rule: {parent} -> {child}")
+            self._connect_component_pair(
+                joints=joints,
+                base_points=base_points,
+                parent_attach_points=parent_attach_points,
+                parent=parent,
+                child=child,
+                component_transforms=component_transforms,
+                existing_joint_names=existing_joint_names,
+            )
 
     def add_sensor_attachments(
-        self, joints: list, attach_dict: dict, base_points: dict
-    ):
-        r"""Attach sensors to the robot by creating fixed joints."""
+        self, links: list, joints: list, attach_dict: dict, base_points: dict
+    ) -> None:
+        r"""Attach sensors by adding their URDF links/joints and creating a fixed connector.
+
+        .. attention::
+            This is a legacy helper kept for backward compatibility. Newer code paths
+            use :class:`URDFSensorManager`.
+
+        Args:
+            links: Global list to collect sensor link elements.
+            joints: Global list to collect sensor joint elements.
+            attach_dict: Mapping from sensor names to attachment configs.
+            base_points: Mapping from component names to their base link names.
+        """
+        existing_link_names = {
+            self._apply_case("link", link.get("name"))
+            for link in links
+            if hasattr(link, "get") and link.get("name")
+        }
+        existing_link_names.discard(None)
+
+        existing_joint_names = self._collect_existing_joint_names(joints)
+
         for sensor_name, attach in attach_dict.items():
-            sensor_urdf = ET.parse(attach.sensor_urdf).getroot()
+            sensor_urdf_path = self._get_attr(attach, "sensor_urdf")
+            if not sensor_urdf_path:
+                self.logger.error(f"Sensor [{sensor_name}] has no sensor_urdf")
+                continue
 
-            # Add sensor links and joints to the main lists
+            try:
+                sensor_urdf = ET.parse(sensor_urdf_path).getroot()
+            except Exception as exc:
+                self.logger.error(
+                    f"Failed to parse sensor URDF for [{sensor_name}]: {exc}"
+                )
+                continue
+
+            link_name_map: dict[str, str] = {}
+            processed_link_names: list[str] = []
+
+            # Add sensor links to the links list (ensure lowercase + uniqueness)
             for link in sensor_urdf.findall("link"):
-                # Ensure sensor link names are lowercase
-                link.set("name", link.get("name").lower())
-                joints.append(link)  # This should be added to links list instead
+                raw_name = link.get("name")
+                if not raw_name:
+                    continue
 
+                normalized_raw = self._apply_case("link", raw_name)
+                if not normalized_raw:
+                    continue
+
+                base_name = normalized_raw
+                sensor_suffix = str(sensor_name).lower()
+                if sensor_suffix and sensor_suffix not in base_name:
+                    base_name = f"{base_name}_{sensor_suffix}"
+
+                unique_name = self._make_unique(base_name, existing_link_names)
+                link.set("name", unique_name)
+
+                link_name_map[normalized_raw] = unique_name
+                processed_link_names.append(unique_name)
+                existing_link_names.add(unique_name)
+                links.append(link)
+
+            # Add sensor joints to the joints list (ensure uppercase + update link references)
             for joint in sensor_urdf.findall("joint"):
-                # Ensure sensor joint names are uppercase and link references are lowercase
-                joint.set("name", joint.get("name").upper())
+                raw_joint_name = joint.get("name") or "sensor_joint"
+
+                normalized_joint_name = self._apply_case(
+                    "joint", f"{sensor_name}_{raw_joint_name}"
+                )
+                if not normalized_joint_name:
+                    continue
+
+                normalized_joint_name = self._make_unique(
+                    normalized_joint_name, existing_joint_names
+                )
+                joint.set("name", normalized_joint_name)
+
                 parent_elem = joint.find("parent")
                 child_elem = joint.find("child")
+
                 if parent_elem is not None:
-                    parent_elem.set("link", parent_elem.get("link").lower())
+                    raw_parent = parent_elem.get("link")
+                    normalized_parent = self._apply_case("link", raw_parent)
+                    if normalized_parent and normalized_parent in link_name_map:
+                        parent_elem.set("link", link_name_map[normalized_parent])
+                    elif normalized_parent:
+                        parent_elem.set("link", normalized_parent)
+
                 if child_elem is not None:
-                    child_elem.set("link", child_elem.get("link").lower())
+                    raw_child = child_elem.get("link")
+                    normalized_child = self._apply_case("link", raw_child)
+                    if normalized_child and normalized_child in link_name_map:
+                        child_elem.set("link", link_name_map[normalized_child])
+                    elif normalized_child:
+                        child_elem.set("link", normalized_child)
+
                 joints.append(joint)
+                existing_joint_names.add(normalized_joint_name)
 
-            parent_link = base_points.get(
-                attach.parent_component, attach.parent_component
-            ).lower()  # Ensure lowercase
+            if not processed_link_names:
+                self.logger.error(f"Sensor [{sensor_name}] has no <link> elements")
+                continue
 
-            # Create connection joint with uppercase name
-            joint_name = (
-                f"{attach.parent_component.upper()}_TO_{sensor_name.upper()}_CONNECTOR"
+            # Determine parent link: prefer explicit parent_link if provided.
+            parent_component = self._get_attr(attach, "parent_component")
+            raw_parent_link = self._get_attr(attach, "parent_link")
+            if raw_parent_link:
+                parent_link = self._apply_case("link", raw_parent_link)
+            else:
+                parent_link = self._apply_case(
+                    "link",
+                    base_points.get(parent_component, parent_component),
+                )
+
+            if not parent_link:
+                self.logger.error(
+                    f"Invalid parent link for sensor [{sensor_name}] on component [{parent_component}]"
+                )
+                continue
+
+            # Create connector joint (apply transform if provided by attachment).
+            origin_kwargs = self._origin_kwargs_from_transform(
+                self._get_attr(attach, "transform")
             )
-            joint = ET.Element("joint", name=joint_name, type="fixed")
-            ET.SubElement(joint, "origin", xyz="0 0 0", rpy="0 0 0")
-            ET.SubElement(joint, "parent", link=parent_link)
-            ET.SubElement(
-                joint, "child", link=sensor_urdf.find("link").get("name").lower()
+
+            connector_joint_name = self._make_unique(
+                self._apply_case(
+                    "joint", f"{parent_component}_TO_{sensor_name}_CONNECTOR"
+                )
+                or self._apply_case(
+                    "joint", f"{parent_component}_TO_{sensor_name}_CONNECTOR".upper()
+                ),
+                existing_joint_names,
             )
-            joints.append(joint)
+
+            self._append_fixed_joint(
+                joints=joints,
+                existing_joint_names=existing_joint_names,
+                joint_name=connector_joint_name,
+                parent_link=parent_link,
+                child_link=processed_link_names[0],
+                origin_kwargs=origin_kwargs,
+            )

--- a/embodichain/toolkits/urdf_assembly/file_writer.py
+++ b/embodichain/toolkits/urdf_assembly/file_writer.py
@@ -127,7 +127,7 @@ class URDFFileWriter:
         now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
         # Calculate proper spacing for centered content
-        header_width = 80
+        header_width = 120
         separator_line = "<!--" + "=" * (header_width - 8) + "-->"
 
         def center_comment(text: str) -> str:

--- a/embodichain/toolkits/urdf_assembly/name_normalizer.py
+++ b/embodichain/toolkits/urdf_assembly/name_normalizer.py
@@ -1,0 +1,77 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+
+class NameNormalizer:
+    """Handles name normalization for different entity types."""
+
+    VALID_KEYS = {"joint", "link"}
+    VALID_MODES = {"upper", "lower", "none"}
+
+    def __init__(self, default_case: dict[str, str] | None = None):
+        """Initialize the NameNormalizer with default cases.
+
+        Args:
+            default_case (dict[str, str] | None): Default normalization modes for "joint" and "link".
+        """
+        self._name_case = {
+            "joint": "upper",
+            "link": "lower",
+        }
+        if default_case:
+            for key, mode in default_case.items():
+                if key in self.VALID_KEYS and mode in self.VALID_MODES:
+                    self._name_case[key] = mode
+                else:
+                    raise ValueError(
+                        f"Invalid default_case entry {key}={mode}. "
+                        f"Allowed keys: {self.VALID_KEYS}, allowed modes: {self.VALID_MODES}."
+                    )
+
+    def set_case(self, key: str, mode: str):
+        """Set the normalization mode for a specific key.
+
+        Args:
+            key (str): The entity type ("joint" or "link").
+            mode (str): The normalization mode ("upper", "lower", "none").
+        """
+        if key in self.VALID_KEYS and mode in self.VALID_MODES:
+            self._name_case[key] = mode
+        else:
+            raise ValueError(
+                f"Invalid key or mode: {key}={mode}. "
+                f"Allowed keys: {self.VALID_KEYS}, allowed modes: {self.VALID_MODES}."
+            )
+
+    def normalize(self, kind: str, name: str | None) -> str | None:
+        """Normalize a name according to the configured case policy.
+
+        Args:
+            kind (str): One of "joint" or "link".
+            name (str | None): The original name.
+
+        Returns:
+            str | None: The normalized name, or the original value if kind is unknown or mode is "none".
+        """
+        if name is None:
+            return None
+
+        mode = self._name_case.get(kind, "none")
+        if mode == "lower":
+            return name.lower()
+        if mode == "upper":
+            return name.upper()
+        return name

--- a/embodichain/toolkits/urdf_assembly/signature.py
+++ b/embodichain/toolkits/urdf_assembly/signature.py
@@ -62,6 +62,12 @@ class URDFAssemblySignatureManager:
         signature_data = {
             "output_filename": os.path.basename(output_path),
             "components": {},
+            # Optional metadata that can affect the assembly even if the
+            # component URDF files themselves do not change. For example,
+            # the processing order and name prefixes for each component,
+            # and the global casing policy for links/joints.
+            "component_order_and_prefix": [],
+            "name_case": {},
         }
 
         def to_serializable(obj):
@@ -85,8 +91,20 @@ class URDFAssemblySignatureManager:
             else:
                 return obj
 
-        # Process each component
+        # Process each entry passed in from the assembly manager. Most entries
+        # are components (with URDF files), but some may be metadata such as
+        # the component_order_and_prefix or name_case used during assembly.
         for comp_type, comp_obj in urdf_dict.items():
+            # Special key reserved for component order/prefix metadata
+            if comp_type == "__component_order_and_prefix__":
+                signature_data["component_order_and_prefix"] = to_serializable(comp_obj)
+                continue
+
+            # Special key reserved for global name_case policy (link/joint casing)
+            if comp_type == "__name_case__":
+                signature_data["name_case"] = to_serializable(comp_obj)
+                continue
+
             if comp_obj is None:
                 continue
 

--- a/embodichain/toolkits/urdf_assembly/urdf_assembly_manager.py
+++ b/embodichain/toolkits/urdf_assembly/urdf_assembly_manager.py
@@ -241,8 +241,6 @@ class URDFAssemblyManager:
             raise ValueError("name_case must contain keys 'joint' and 'link'.")
 
         self._name_case = new_name_case
-        self.component_manager.name_case = new_name_case
-        self.sensor_manager.name_case = new_name_case
 
     def _apply_case(self, kind: str, name: str | None) -> str | None:
         """Normalize a name according to the assembly-wide case policy.
@@ -288,15 +286,14 @@ class URDFAssemblyManager:
 
     @component_order_and_prefix.setter
     def component_order_and_prefix(self, new_order):
-        """Patch the internal component prefix configuration.
-
+        """Set the internal component prefix configuration.
         Args:
-            new_order (list[tuple[str, str | None]]): List of
+            new_order: Value assigned directly to the internal
+                ``_component_order_and_prefix`` attribute, typically a list of
                 ``(component_name, prefix)`` tuples.
-
-        Raises:
-            ValueError: If the new order is not a list of tuples or if it
-                contains unknown component names.
+        Note:
+            This setter performs no validation or patch-style merging; it
+            stores ``new_order`` as provided.
         """
         self._component_order_and_prefix = new_order
 
@@ -305,9 +302,15 @@ class URDFAssemblyManager:
         """Configure name prefixes per component type.
 
         This is a user-facing alias over :attr:`component_order_and_prefix`.
-        It accepts a list of ``(component_name, prefix)`` tuples and updates
-        the internal configuration in a patch-style manner, without requiring
-        users to reason about the full processing order.
+
+        Semantics:
+            This setter is **patch-only**: it updates prefixes for components that
+            already exist in the current internal order and does **not** allow
+            introducing new component names.
+
+        Returns:
+            list[tuple[str, str | None]]: The internal list of
+            ``(component_name, prefix)`` pairs.
         """
 
         return self.component_order_and_prefix
@@ -318,13 +321,15 @@ class URDFAssemblyManager:
             isinstance(item, tuple) and len(item) == 2 for item in new_prefixes
         ):
             raise ValueError(
-                "component_order_and_prefix must be a list of (component_name, prefix) tuples."
+                "component_prefix must be a list of (component_name, prefix) tuples."
             )
 
-        # Treat new_order as a patch on top of the existing/default order:
+        # Treat new_prefixes as a patch on top of the existing/default order:
         #  - For components already present in self._component_order_and_prefix, update their prefix.
-        #  - Preserve components that are not mentioned in new_order, keeping their relative order.
-        #  - Append any brand‑new components from new_order at the end.
+        #  - Preserve components that are not mentioned, keeping their relative order.
+        #
+        # Note: New/unknown component names are rejected to keep the assembly order
+        # controlled internally.
 
         # Allowed components are exactly those already present in the default order.
         existing_components = {comp for comp, _ in self._component_order_and_prefix}
@@ -333,12 +338,10 @@ class URDFAssemblyManager:
         override_map = {}
         for comp, prefix in new_prefixes:
             if not isinstance(comp, str):
-                raise ValueError(
-                    "component name in component_order_and_prefix must be a string."
-                )
+                raise ValueError("component name in component_prefix must be a string.")
             if comp not in existing_components:
                 raise ValueError(
-                    f"component_order_and_prefix cannot introduce new component '{comp}'. "
+                    f"component_prefix cannot introduce new component '{comp}'. "
                     f"Allowed components: {sorted(existing_components)}"
                 )
             override_map[comp] = prefix

--- a/embodichain/toolkits/urdf_assembly/urdf_assembly_manager.py
+++ b/embodichain/toolkits/urdf_assembly/urdf_assembly_manager.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
+import copy
 import os
 import time
 import logging
@@ -128,6 +129,15 @@ class URDFAssemblyManager:
     ):
         self.logger = setup_urdf_logging()
 
+        # Global name normalization strategy for this assembly. By default,
+        # this preserves the legacy behavior: link names are lowercase and
+        # joint names are uppercase. The same mapping is passed down to
+        # managers that deal with naming so that the policy stays consistent.
+        self._name_case: dict[str, str] = {
+            "joint": "upper",
+            "link": "lower",
+        }
+
         # Use registries for components and sensors
         self.component_registry = component_registry or ComponentRegistry()
         self.sensor_registry = sensor_registry or SensorRegistry()
@@ -137,13 +147,13 @@ class URDFAssemblyManager:
 
         # Initialize managers for components and sensors
         self.component_manager = component_manager or URDFComponentManager(
-            self.mesh_manager
+            self.mesh_manager, name_case=self._name_case
         )
         self.sensor_manager = sensor_manager or URDFSensorManager(self.mesh_manager)
 
         # Processing order for components with their name prefixes
         # Tuple format: (component_name, prefix)
-        self.component_order = [
+        self._component_order_and_prefix = [
             ("chassis", None),
             ("legs", None),
             ("torso", None),
@@ -204,6 +214,147 @@ class URDFAssemblyManager:
 
         # Initialize signature manager instead of cache manager
         self.signature_manager = URDFAssemblySignatureManager()
+
+    @property
+    def name_case(self):
+        """Get the current name case policy for joints and links.
+
+        Returns:
+            dict[str, str]: A dictionary mapping 'joint' and 'link' to their respective case modes.
+        """
+        return self._name_case
+
+    @name_case.setter
+    def name_case(self, new_name_case: dict[str, str]):
+        """Set a new name case policy for joints and links.
+
+        This method updates the name case policy and propagates it to the component and sensor managers.
+
+        Args:
+            new_name_case (dict[str, str]): A dictionary mapping 'joint' and 'link' to their desired case modes (e.g., 'upper', 'lower', 'none').
+        """
+        if not isinstance(new_name_case, dict):
+            raise ValueError(
+                "name_case must be a dictionary mapping 'joint' and 'link' to case modes."
+            )
+        if "joint" not in new_name_case or "link" not in new_name_case:
+            raise ValueError("name_case must contain keys 'joint' and 'link'.")
+
+        self._name_case = new_name_case
+        self.component_manager.name_case = new_name_case
+        self.sensor_manager.name_case = new_name_case
+
+    def _apply_case(self, kind: str, name: str | None) -> str | None:
+        """Normalize a name according to the assembly-wide case policy.
+
+        This helper mirrors the behavior of the managers' own case helpers so
+        that any name sets computed here (e.g. for sensors) stay consistent
+        with how names are written into the URDF.
+
+        Args:
+            kind (str): One of ``"joint"`` or ``"link"``.
+            name (str | None): The original name.
+
+        Returns:
+            str | None: The normalized name, or the original value if the
+            kind is unknown or its mode is ``"none"``.
+        """
+
+        if name is None:
+            return None
+
+        mode = self._name_case.get(kind, "none")
+        if mode == "lower":
+            return name.lower()
+        if mode == "upper":
+            return name.upper()
+        return name
+
+    @property
+    def component_order_and_prefix(self):
+        """Get the internal component order with their name prefixes.
+
+        Note:
+            This exposes the internal list of ``(component_name, prefix)`` pairs
+            used when assembling URDFs. In most user code it is recommended to
+            use :attr:`component_prefix` instead, which focuses on configuring
+            prefixes rather than ordering.
+
+        Returns:
+            list[tuple[str, str | None]]: A list of tuples specifying component
+            names and their prefixes.
+        """
+        return self._component_order_and_prefix
+
+    @component_order_and_prefix.setter
+    def component_order_and_prefix(self, new_order):
+        """Patch the internal component prefix configuration.
+
+        Args:
+            new_order (list[tuple[str, str | None]]): List of
+                ``(component_name, prefix)`` tuples.
+
+        Raises:
+            ValueError: If the new order is not a list of tuples or if it
+                contains unknown component names.
+        """
+        self._component_order_and_prefix = new_order
+
+    @property
+    def component_prefix(self):
+        """Configure name prefixes per component type.
+
+        This is a user-facing alias over :attr:`component_order_and_prefix`.
+        It accepts a list of ``(component_name, prefix)`` tuples and updates
+        the internal configuration in a patch-style manner, without requiring
+        users to reason about the full processing order.
+        """
+
+        return self.component_order_and_prefix
+
+    @component_prefix.setter
+    def component_prefix(self, new_prefixes):
+        if not isinstance(new_prefixes, list) or not all(
+            isinstance(item, tuple) and len(item) == 2 for item in new_prefixes
+        ):
+            raise ValueError(
+                "component_order_and_prefix must be a list of (component_name, prefix) tuples."
+            )
+
+        # Treat new_order as a patch on top of the existing/default order:
+        #  - For components already present in self._component_order_and_prefix, update their prefix.
+        #  - Preserve components that are not mentioned in new_order, keeping their relative order.
+        #  - Append any brand‑new components from new_order at the end.
+
+        # Allowed components are exactly those already present in the default order.
+        existing_components = {comp for comp, _ in self._component_order_and_prefix}
+
+        # Build override map from the incoming list, but only for existing components.
+        override_map = {}
+        for comp, prefix in new_prefixes:
+            if not isinstance(comp, str):
+                raise ValueError(
+                    "component name in component_order_and_prefix must be a string."
+                )
+            if comp not in existing_components:
+                raise ValueError(
+                    f"component_order_and_prefix cannot introduce new component '{comp}'. "
+                    f"Allowed components: {sorted(existing_components)}"
+                )
+            override_map[comp] = prefix
+
+        merged_order: list[tuple[str, str | None]] = []
+
+        # First, walk the existing order and apply overrides where available.
+        # The relative order of components is kept internal and usually does
+        # not need to be changed by users.
+        for comp, prefix in self._component_order_and_prefix:
+            if comp in override_map:
+                merged_order.append((comp, override_map.pop(comp)))
+            else:
+                merged_order.append((comp, prefix))
+
+        self._component_order_and_prefix = merged_order
 
     def add_component(
         self,
@@ -572,9 +723,21 @@ class URDFAssemblyManager:
                 self.logger.debug(f"    Transform: applied")
 
         if use_signature_check:
-            # Calculate current assembly signature
+            # Calculate current assembly signature. In addition to the component
+            # registry contents, include the current component_order_and_prefix
+            # so that changes to name prefixes also invalidate the cache.
+            component_info = self.component_registry.all().copy()
+            component_info["__component_order_and_prefix__"] = list(
+                self.component_order_and_prefix
+            )
+            # Also include the assembly-wide name_case policy so that
+            # renaming rules (e.g. link/joint casing) participate in the
+            # signature. This ensures that changing naming strategy forces
+            # a rebuild.
+            component_info["__name_case__"] = dict(self._name_case)
+
             assembly_signature = self.signature_manager.calculate_assembly_signature(
-                self.component_registry.all(), output_path
+                component_info, output_path
             )
 
             self.logger.info(f"Current assembly signature: [{assembly_signature}]")
@@ -606,6 +769,26 @@ class URDFAssemblyManager:
         robot_name = os.path.splitext(os.path.basename(output_path))[0]
         merged_urdf = ET.Element("robot", name=robot_name)
 
+        # Collect global URDF material definitions from components/sensors.
+        # Some URDFs reference materials by name in <visual><material name="..."/>
+        # and rely on <robot><material name="...">... definitions. These are not
+        # part of links/joints, so we must explicitly merge them.
+        materials: list[ET.Element] = []
+        material_names: set[str] = set()
+
+        def _add_materials_from_root(root: ET.Element, source: str) -> None:
+            for mat in root.findall("material"):
+                mat_name = mat.get("name")
+                if not mat_name:
+                    continue
+                if mat_name in material_names:
+                    continue
+                materials.append(copy.deepcopy(mat))
+                material_names.add(mat_name)
+                self.logger.debug(
+                    f"Merged URDF material definition: '{mat_name}' from {source}"
+                )
+
         # 2. Create single base link for the entire robot
         base_link = ET.Element("link", name=self.base_link_name)
         # Store links and joints separately for proper ordering
@@ -622,8 +805,12 @@ class URDFAssemblyManager:
         ensure_directory_exists(output_dir, self.logger)
         mesh_manager = URDFMeshManager(output_dir)
         mesh_manager.ensure_dirs()
-        component_manager = URDFComponentManager(mesh_manager)
-        connection_manager = URDFConnectionManager(self.base_link_name)
+        component_manager = URDFComponentManager(
+            mesh_manager, name_case=self._name_case
+        )
+        connection_manager = URDFConnectionManager(
+            self.base_link_name, name_case=self._name_case
+        )
 
         # Initialize sensor manager with mesh_manager
         sensor_manager = URDFSensorManager(mesh_manager)
@@ -647,7 +834,7 @@ class URDFAssemblyManager:
             if comp_obj and comp_obj.transform is not None:
                 component_transforms[comp] = comp_obj.transform
 
-        for comp, prefix in self.component_order:
+        for comp, prefix in self.component_order_and_prefix:
             comp_obj = self.component_registry.get(comp)
             if not comp_obj:
                 continue
@@ -658,6 +845,7 @@ class URDFAssemblyManager:
 
             # Parse component URDF to analyze its structure
             urdf_root = ET.parse(comp_obj.urdf_path).getroot()
+            _add_materials_from_root(urdf_root, str(comp_obj.urdf_path))
 
             # Determine parent component and attachment point for current component
             parent_component = None
@@ -747,16 +935,32 @@ class URDFAssemblyManager:
             component_transforms,
         )
 
-        # Track existing names for sensor processing
+        # Track existing names for sensor processing. Use the same case policy
+        # as the rest of the assembly so that collision checks are consistent
+        # with how names are written.
         existing_link_names = {
-            link.get("name").lower() for link in links if link.get("name")
+            self._apply_case("link", link.get("name"))
+            for link in links
+            if link.get("name")
         }
         existing_joint_names = {
-            joint.get("name").upper() for joint in joints if joint.get("name")
+            self._apply_case("joint", joint.get("name"))
+            for joint in joints
+            if joint.get("name")
         }
 
         # 5. Process sensor attachments using the new sensor manager
         for sensor_name, sensor_attach in self.sensor_registry.all().items():
+            # Merge any global materials defined in the sensor URDF.
+            try:
+                sensor_root = ET.parse(sensor_attach.sensor_urdf).getroot()
+            except Exception as exc:
+                self.logger.debug(
+                    f"Failed to parse sensor URDF for material merge ({sensor_attach.sensor_urdf}): {exc}"
+                )
+            else:
+                _add_materials_from_root(sensor_root, str(sensor_attach.sensor_urdf))
+
             sensor_manager.attach_sensor(
                 sensor_name=sensor_name,
                 sensor_source=sensor_attach.sensor_urdf,
@@ -769,7 +973,49 @@ class URDFAssemblyManager:
             links, joints, base_points, existing_link_names, existing_joint_names
         )
 
-        # 6. Add all links and joints to merged URDF in proper order
+        # 6. Ensure referenced materials exist (avoid simulator warnings).
+        # If a link references <material name="X"/> but X is not defined globally,
+        # inject a conservative fallback only for a small known palette.
+        fallback_palette = {
+            "white": "1 1 1 1",
+            "black": "0 0 0 1",
+            "red": "1 0 0 1",
+            "green": "0 1 0 1",
+            "blue": "0 0 1 1",
+            "gray": "0.5 0.5 0.5 1",
+            "grey": "0.5 0.5 0.5 1",
+        }
+
+        referenced_materials: set[str] = set()
+        for link in links:
+            for mat in link.findall(".//visual/material"):
+                mat_name = mat.get("name")
+                if not mat_name:
+                    continue
+                # A material with children is already defined inline.
+                if list(mat):
+                    continue
+                referenced_materials.add(mat_name)
+
+        for mat_name in sorted(referenced_materials - material_names):
+            key = mat_name.lower()
+            if key in fallback_palette:
+                rgba = fallback_palette[key]
+                fallback_mat = ET.Element("material", name=mat_name)
+                ET.SubElement(fallback_mat, "color", rgba=rgba)
+                materials.append(fallback_mat)
+                material_names.add(mat_name)
+                self.logger.warning(
+                    f"Material '{mat_name}' undefined; injected fallback color rgba='{rgba}'"
+                )
+            else:
+                self.logger.warning(
+                    f"Material '{mat_name}' referenced but not defined in merged URDF"
+                )
+
+        # Add global materials, then links/joints to merged URDF in proper order
+        for mat in materials:
+            merged_urdf.append(mat)
         for link in links:
             merged_urdf.append(link)
         for joint in joints:

--- a/embodichain/toolkits/urdf_assembly/urdf_assembly_manager.py
+++ b/embodichain/toolkits/urdf_assembly/urdf_assembly_manager.py
@@ -687,6 +687,40 @@ class URDFAssemblyManager:
                 break  # No further links found in the chain
         return current_link
 
+    def _log_names_once(
+        self,
+        kind: str,
+        elems: list[ET.Element],
+        *,
+        max_items: int = 300,
+        max_chars: int = 8000,
+    ) -> None:
+        """Log element names in a single line (truncated)."""
+        names: list[str] = []
+        for e in elems:
+            n = e.get("name")
+            if n:
+                names.append(n)
+
+        total = len(names)
+        shown_names = names[:max_items]
+        text = ", ".join(shown_names)
+
+        truncated_items = max(0, total - len(shown_names))
+        truncated_chars = 0
+        if len(text) > max_chars:
+            text = text[:max_chars] + "..."
+            truncated_chars = 1
+
+        suffix_parts: list[str] = []
+        if truncated_items:
+            suffix_parts.append(f"truncated_items={truncated_items}")
+        if truncated_chars:
+            suffix_parts.append("truncated_chars=1")
+        suffix = f" ({', '.join(suffix_parts)})" if suffix_parts else ""
+
+        self.logger.info(f"[merge_urdfs] {kind}: count={total} names=[{text}]{suffix}")
+
     @performance_monitor
     def merge_urdfs(
         self,
@@ -713,6 +747,16 @@ class URDFAssemblyManager:
             if obj is not None
         ]
         self.logger.info(f"🔧 Preparing to merge components: {available_components}")
+
+        order_items = " ".join(
+            f"[{comp}]({prefix})" for comp, prefix in self.component_order_and_prefix
+        )
+        self.logger.info(f"[component_order_and_prefix] {order_items}")
+
+        case_keys = [k for k in ("joint", "link") if k in self.name_case]
+        case_keys += [k for k in sorted(self.name_case) if k not in case_keys]
+        case_items = " ".join(f"[{k}]({self.name_case[k]})" for k in case_keys)
+        self.logger.info(f"[name_case] {case_items}")
 
         for comp in available_components:
             comp_obj = self.component_registry.get(comp)
@@ -769,25 +813,45 @@ class URDFAssemblyManager:
         robot_name = os.path.splitext(os.path.basename(output_path))[0]
         merged_urdf = ET.Element("robot", name=robot_name)
 
-        # Collect global URDF material definitions from components/sensors.
-        # Some URDFs reference materials by name in <visual><material name="..."/>
-        # and rely on <robot><material name="...">... definitions. These are not
-        # part of links/joints, so we must explicitly merge them.
+        # Global <material> definitions live directly under <robot> and are not part
+        # of links/joints. To avoid polluting the merged URDF, we only merge global
+        # materials that are actually referenced by merged links' visuals.
         materials: list[ET.Element] = []
         material_names: set[str] = set()
+        material_sources: list[tuple[ET.Element, str]] = []
 
-        def _add_materials_from_root(root: ET.Element, source: str) -> None:
-            for mat in root.findall("material"):
-                mat_name = mat.get("name")
-                if not mat_name:
-                    continue
-                if mat_name in material_names:
-                    continue
-                materials.append(copy.deepcopy(mat))
-                material_names.add(mat_name)
+        def _register_material_source(root: ET.Element, source: str) -> None:
+            material_sources.append((root, source))
+
+        def _merge_material_if_defined(mat_name: str) -> bool:
+            """Merge a global <material name=...> definition from known sources.
+
+            Only merges if the material is referenced and if a source URDF actually
+            defines it at the <robot> root. This prevents bringing in unused
+            materials from component URDFs.
+            """
+            if not mat_name or mat_name in material_names:
+                return False
+
+            matches: list[tuple[ET.Element, str]] = []
+            for root, source in material_sources:
+                for mat in root.findall("material"):
+                    if mat.get("name") == mat_name:
+                        matches.append((mat, source))
+
+            if not matches:
+                return False
+
+            if len(matches) > 1:
                 self.logger.debug(
-                    f"Merged URDF material definition: '{mat_name}' from {source}"
+                    f"Material '{mat_name}' defined in multiple URDF sources; using the first: {matches[0][1]}"
                 )
+
+            mat, source = matches[0]
+            materials.append(copy.deepcopy(mat))
+            material_names.add(mat_name)
+            self.logger.debug(f"Merged referenced material '{mat_name}' from {source}")
+            return True
 
         # 2. Create single base link for the entire robot
         base_link = ET.Element("link", name=self.base_link_name)
@@ -845,7 +909,7 @@ class URDFAssemblyManager:
 
             # Parse component URDF to analyze its structure
             urdf_root = ET.parse(comp_obj.urdf_path).getroot()
-            _add_materials_from_root(urdf_root, str(comp_obj.urdf_path))
+            _register_material_source(urdf_root, str(comp_obj.urdf_path))
 
             # Determine parent component and attachment point for current component
             parent_component = None
@@ -951,15 +1015,15 @@ class URDFAssemblyManager:
 
         # 5. Process sensor attachments using the new sensor manager
         for sensor_name, sensor_attach in self.sensor_registry.all().items():
-            # Merge any global materials defined in the sensor URDF.
+            # Register sensor URDF as a material source (do not merge materials eagerly).
             try:
                 sensor_root = ET.parse(sensor_attach.sensor_urdf).getroot()
             except Exception as exc:
                 self.logger.debug(
-                    f"Failed to parse sensor URDF for material merge ({sensor_attach.sensor_urdf}): {exc}"
+                    f"Failed to parse sensor URDF for material sourcing ({sensor_attach.sensor_urdf}): {exc}"
                 )
             else:
-                _add_materials_from_root(sensor_root, str(sensor_attach.sensor_urdf))
+                _register_material_source(sensor_root, str(sensor_attach.sensor_urdf))
 
             sensor_manager.attach_sensor(
                 sensor_name=sensor_name,
@@ -973,19 +1037,9 @@ class URDFAssemblyManager:
             links, joints, base_points, existing_link_names, existing_joint_names
         )
 
-        # 6. Ensure referenced materials exist (avoid simulator warnings).
-        # If a link references <material name="X"/> but X is not defined globally,
-        # inject a conservative fallback only for a small known palette.
-        fallback_palette = {
-            "white": "1 1 1 1",
-            "black": "0 0 0 1",
-            "red": "1 0 0 1",
-            "green": "0 1 0 1",
-            "blue": "0 0 1 1",
-            "gray": "0.5 0.5 0.5 1",
-            "grey": "0.5 0.5 0.5 1",
-        }
-
+        # 6. Merge only the global materials that are actually referenced by merged links.
+        # If a link references <material name="X"/> but no source URDF defines a global
+        # <material name="X"> under <robot>, we warn but do not inject guessed fallbacks.
         referenced_materials: set[str] = set()
         for link in links:
             for mat in link.findall(".//visual/material"):
@@ -997,27 +1051,26 @@ class URDFAssemblyManager:
                     continue
                 referenced_materials.add(mat_name)
 
-        for mat_name in sorted(referenced_materials - material_names):
-            key = mat_name.lower()
-            if key in fallback_palette:
-                rgba = fallback_palette[key]
-                fallback_mat = ET.Element("material", name=mat_name)
-                ET.SubElement(fallback_mat, "color", rgba=rgba)
-                materials.append(fallback_mat)
-                material_names.add(mat_name)
-                self.logger.warning(
-                    f"Material '{mat_name}' undefined; injected fallback color rgba='{rgba}'"
-                )
-            else:
-                self.logger.warning(
-                    f"Material '{mat_name}' referenced but not defined in merged URDF"
-                )
+        missing_materials: list[str] = []
+        for mat_name in sorted(referenced_materials):
+            if mat_name in material_names:
+                continue
+            if not _merge_material_if_defined(mat_name):
+                missing_materials.append(mat_name)
+
+        for mat_name in missing_materials:
+            self.logger.warning(
+                f"Material '{mat_name}' referenced but not defined in any source URDF"
+            )
 
         # Add global materials, then links/joints to merged URDF in proper order
         for mat in materials:
             merged_urdf.append(mat)
+
+        self._log_names_once("links", links)
         for link in links:
             merged_urdf.append(link)
+        self._log_names_once("joints", joints)
         for joint in joints:
             merged_urdf.append(joint)
 


### PR DESCRIPTION

**Summary**

This PR refines the URDF assembly pipeline with configurable component name prefixes, a global name casing policy for links and joints, and extended signature semantics so that naming‑related configuration changes correctly invalidate cached assemblies.
<img width="1808" height="1019" alt="img_v3_0210q_eacc1551-3694-4433-b839-6ffb23faa26g" src="https://github.com/user-attachments/assets/5b8d3e9e-6eb7-498c-9fec-14357a09ec16" />

---

**Motivation**

- Make component name prefixes configurable in a predictable, patch‑style way without exposing internal ordering details.
- Centralize and expose the link/joint `lower()/upper()` behavior via a single `name_case` policy instead of hard‑coded transformations scattered across managers.
- Ensure that changes to prefixes and naming policies are reflected in the assembly signature so that cached URDFs are rebuilt when naming semantics change.
- Align `URDFCfg` and documentation with the new configuration surface.

---

**Changes**

1. **URDFAssemblyManager**
   - Add support for per‑component name prefixes via the `component_prefix` property:
     - Internal storage remains `_component_order_and_prefix: list[tuple[str, str | None]]`.
     - `component_prefix` acts as a *patch‑style* interface:
       - Accepts a list of `(component_name, prefix)` tuples.
       - Only existing component names (e.g. `chassis`, `torso`, `left_arm`, …) may be overridden.
       - Components not mentioned keep their original prefix.
       - Unknown component names raise a `ValueError`.
   - Introduce a global **name casing policy** via the optional `name_case` argument:
     - Signature: `URDFAssemblyManager(..., name_case: dict[str, str] | None = None)`.
     - Valid keys: `"joint"`, `"link"`.
     - Valid values: `"upper"`, `"lower"`, `"none"`.
     - Default behavior matches the legacy implementation:
       - joint names → upper case,
       - link names → lower case.
     - Provide a helper `_apply_case(kind: str, name: str | None) -> str | None` and remove scattered hard‑coded `.lower()` / `.upper()` calls in favor of this policy.
   - Propagate `name_case` to internal managers:
     - `URDFComponentManager(mesh_manager, name_case=self._name_case)`
     - `URDFConnectionManager(self.base_link_name, name_case=self._name_case)`
     - (Optional / if implemented) `URDFSensorManager` can also honor the same policy.
   - Extend assembly signature input:
     - When building `component_info` for `URDFAssemblySignatureManager`, inject:
       - `__component_order_and_prefix__ = list(self.component_order_and_prefix)`
       - `__name_case__ = dict(self._name_case)`
     - This ensures that changing prefixes or casing policy invalidates the cached assembly and forces a rebuild.

2. **URDFAssemblySignatureManager**
   - Extend `signature_data` to include:
     - `component_order_and_prefix`
     - `name_case`
   - Handle the special metadata keys when iterating components:
     - `__component_order_and_prefix__` → stored in `signature_data["component_order_and_prefix"]`
     - `__name_case__` → stored in `signature_data["name_case"]`
   - Keep existing component hashing logic unchanged, so previous behavior is preserved aside from the new fields.

3. **URDFCfg integration**
   - Add `component_prefix` support to `URDFCfg`:
     - Field type: `list[tuple[str, str | None]]` with a default matching `URDFAssemblyManager`’s internal order.
     - Initialization logic allows:
       - `None` → uses the default prefix list.
       - `dict[str, str]` → converted to `list(component_prefix.items())` for convenience (e.g. `{"left_hand": "l_", "right_hand": "r_"}`).
       - `list[tuple[str, str | None]]` → used as is.
   - In `assemble_urdf()`, pass `self.component_prefix` directly to `URDFAssemblyManager.component_prefix` so that `URDFCfg` can drive per‑component prefixes from robot configs.
   - (If implemented) Add optional `name_case` to `URDFCfg` and forward it to `URDFAssemblyManager` to allow configuring naming policy from robot configuration.

4. **Component and connection managers (if part of this PR)**
   - **URDFComponentManager**
     - Accept `name_case: dict[str, str] | None = None` and store internally.
     - Add a local `_apply_case(kind, name)` helper mirroring the assembly manager.
     - Replace hard‑coded `.lower()` / `.upper()` on link and joint names with the configured casing policy.
   - **URDFConnectionManager**
     - Accept `name_case: dict[str, str] | None = None`.
     - Use `_apply_case("joint", ...)` for generated joint names.
     - Use `_apply_case("link", ...)` for parent/child link names in connection joints.
   - (Optional) **ComponentRegistry**
     - If included, normalize component keys via a `key_case` policy while keeping logical component names stable in the public API.

5. **Documentation**
   - Update urdf_assembly.md:
     - Add **Component name prefixes (`component_prefix`)** section describing:
       - The default prefix list.
       - Patch‑style semantics and error behavior on unknown components.
       - The fact that prefixes participate in the assembly signature, so changing them forces a rebuild.
     - Add **Name casing policy (`name_case`)** section describing:
       - Configuration via the `URDFAssemblyManager` constructor.
       - Valid keys/values and default behavior.
       - Propagation to internal managers and inclusion in the assembly signature.
       - The impact on cache invalidation.
     - Extend the **Using with URDFCfg** section to mention `URDFCfg.component_prefix` and its identical semantics to `URDFAssemblyManager.component_prefix`.

---

**Backward compatibility**

- Default behavior is preserved:
  - Joint names remain upper‑cased.
  - Link names remain lower‑cased.
  - Default component prefix list and processing order are unchanged.
- Existing code that does not set `component_prefix` or `name_case` should observe identical URDF outputs.
- New configuration is opt‑in and only affects behavior when explicitly set.


## Checklist

- [x] I have run the `black .` command to format the code base.
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Dependencies have been updated, if applicable.

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
