### PR TITLE
docs: add NVIDIA driver guide and mesh loading tutorial

### DIFF
--- a/docs/source/quick_start/install.md
+++ b/docs/source/quick_start/install.md
@@ -6,7 +6,7 @@
 |-----------|------------|
 | **OS** | Linux (x86_64): Ubuntu 20.04+ |
 | **GPU** | NVIDIA with compute capability 7.0+ |
-| **NVIDIA Driver** | 535 or higher (recommended 570) |
+| **NVIDIA Driver** | 535 - 570 (580+ is untested and may be unstable) |
 | **Python** | 3.10 or 3.11 |
 
 > [!NOTE]

--- a/scripts/tutorials/sim/create_scene.py
+++ b/scripts/tutorials/sim/create_scene.py
@@ -26,7 +26,7 @@ from embodichain.lab.sim import SimulationManager, SimulationManagerCfg
 from embodichain.lab.sim.cfg import RigidBodyAttributesCfg
 from embodichain.lab.sim.shapes import CubeCfg, MeshCfg
 from embodichain.lab.sim.objects import RigidObject, RigidObjectCfg
-from dexsim.utility.path import get_resources_data_path
+from embodichain.data import get_data_path
 
 
 def main():
@@ -71,7 +71,7 @@ def main():
     # Create the simulation instance
     sim = SimulationManager(sim_cfg)
 
-    # Add objects to the scene
+    # Add cube object to the scene
     cube: RigidObject = sim.add_rigid_object(
         cfg=RigidObjectCfg(
             uid="cube",
@@ -83,7 +83,25 @@ def main():
                 static_friction=0.5,
                 restitution=0.1,
             ),
-            init_pos=[0.0, 0.0, 1.0],
+            init_pos=[0.5, 0.0, 1.0],
+        )
+    )
+
+    # Add toy_duck object to the scene
+    toy_duck_path = get_data_path("ToyDuck/toy_duck.glb")
+    toy_duck: RigidObject = sim.add_rigid_object(
+        cfg=RigidObjectCfg(
+            uid="toy_duck",
+            shape=MeshCfg(fpath=toy_duck_path),
+            body_type="dynamic",
+            attrs=RigidBodyAttributesCfg(
+                mass=1.0,
+                dynamic_friction=0.5,
+                static_friction=0.5,
+                restitution=0.1,
+            ),
+            init_pos=[0.0, 0.0, 0.2],
+            init_rot=[0.0, 0.0, 0.0],
         )
     )
 


### PR DESCRIPTION
# Description
Add the NVIDIA driver version guide and add an example of loading mesh in tutorial.

## Fixes # (issue)
Clarify NVIDIA driver version requirements.
Add an example of loading mesh in create_scene tutorial.

## Type of change

- New feature (non-breaking change which adds functionality)
- Documentation update

## Checklist

- [x] I have run the `black .` command to format the code base.
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Dependencies have been updated, if applicable.
