### PR TITLE
docs: add AI coding agent skills and cross-reference throughout documentation

### DIFF
--- a/.claude/skills/add-functor/SKILL.md
+++ b/.claude/skills/add-functor/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: add-functor
+description: Use when adding a new observation, event, reward, action, dataset, or randomization functor to an EmbodiChain environment
+---
+
+# Add Functor
+
+Scaffold a new functor following EmbodiChain's Functor/FunctorCfg pattern.
+
+## When to Use
+
+- User asks to add an observation term, reward function, event handler, action term, dataset functor, or randomizer
+- User says "add a reward", "new observation", "create a randomizer", "add event functor"
+- Any new function needs to be registered in a manager config
+
+## Determine Functor Type
+
+| Functor Type | Config Class | Module File | Manager | Signature |
+|-------------|-------------|-------------|---------|-----------|
+| Observation | `ObservationCfg` (extends `FunctorCfg`) | `managers/observations.py` | `ObservationManager` | `(env, obs, entity_cfg, ...) -> Tensor` |
+| Reward | `RewardCfg` (extends `FunctorCfg`) | `managers/rewards.py` | `RewardManager` | `(env, obs, action, info, ...) -> Tensor` |
+| Event | `EventCfg` (extends `FunctorCfg`) | `managers/events.py` | `EventManager` | `(env, env_ids, ...) -> None` |
+| Action | `ActionTermCfg` (extends `FunctorCfg`) | `managers/actions.py` | `ActionManager` | Varies |
+| Dataset | `DatasetFunctorCfg` (extends `FunctorCfg`) | `managers/datasets.py` | `DatasetManager` | `(env, ...) -> dict` |
+| Randomization | `EventCfg` (randomizations ARE events) | `managers/randomization/<type>.py` | `EventManager` | `(env, env_ids, entity_cfg, ...) -> None` |
+
+## Two Functor Styles
+
+### Function-style (Preferred for Simple Functors)
+
+A plain function with the right signature. Registered via `FunctorCfg(func=my_function, params={...})`.
+
+```python
+def my_reward(
+    env: EmbodiedEnv,
+    obs: dict,
+    action: EnvAction,
+    info: dict,
+    my_param: float = 1.0,       # params become keyword args
+) -> torch.Tensor:
+    """Short one-line summary.
+
+    Longer description if needed.
+
+    Args:
+        env: The environment instance.
+        obs: The observation dictionary.
+        action: The action taken.
+        info: The info dictionary.
+        my_param: Description of this parameter.
+
+    Returns:
+        Reward tensor of shape (num_envs,).
+    """
+    # implementation
+    return result
+```
+
+### Class-style (Required When Functor Has State)
+
+A class inheriting `Functor`, with `__init__(cfg, env)` and `__call__(env, ...)`. Registered via `FunctorCfg(func=MyClass, params={...})`.
+
+```python
+class my_randomizer(Functor):
+    """One-line summary."""
+
+    def __init__(self, cfg: FunctorCfg, env: EmbodiedEnv):
+        super().__init__(cfg, env)
+        # Extract params and initialize state
+        self.entity_cfg: SceneEntityCfg = cfg.params["entity_cfg"]
+
+    def __call__(self, env: EmbodiedEnv, env_ids: torch.Tensor, **kwargs):
+        """Apply the randomization.
+
+        Args:
+            env: The environment instance.
+            env_ids: Target environment IDs.
+        """
+        # implementation
+```
+
+## Steps
+
+### 1. Identify Functor Type and Style
+
+Ask the user:
+1. **Which manager?** (observation / reward / event / action / dataset / randomization)
+2. **Function or class style?** (function for stateless, class for stateful)
+3. **What does it do?** (brief description for naming + docstring)
+
+### 2. Choose the Right Module File
+
+Place the functor in the existing module for its type:
+
+| Type | File |
+|------|------|
+| Observation | `embodichain/lab/gym/envs/managers/observations.py` |
+| Reward | `embodichain/lab/gym/envs/managers/rewards.py` |
+| Event | `embodichain/lab/gym/envs/managers/events.py` |
+| Action | `embodichain/lab/gym/envs/managers/actions.py` |
+| Dataset | `embodichain/lab/gym/envs/managers/datasets.py` |
+| Physics randomization | `embodichain/lab/gym/envs/managers/randomization/physics.py` |
+| Visual randomization | `embodichain/lab/gym/envs/managers/randomization/visual.py` |
+| Spatial randomization | `embodichain/lab/gym/envs/managers/randomization/spatial.py` |
+| Geometry randomization | `embodichain/lab/gym/envs/managers/randomization/geometry.py` |
+
+### 3. Write the Functor
+
+Follow the template for function-style or class-style (see above).
+
+Key rules:
+- First argument is always `env: EmbodiedEnv` (use `TYPE_CHECKING` guard for the import)
+- Use `from __future__ import annotations` at the top
+- Use `SceneEntityCfg` for entity references, not raw strings
+- For observation functors: add `shape` key to `FunctorCfg.extra` dict
+- For randomization functors: second arg is `env_ids: torch.Tensor | list[int]`
+- For reward functors: return shape must be `(num_envs,)`
+
+### 4. Update `__all__`
+
+Add the new functor to the module's `__all__` list. If no `__all__` exists, create one.
+
+### 5. Write a Test
+
+Place at `tests/gym/envs/managers/test_<functor_type>.py` (append to existing file if present).
+
+For functors that don't need a live simulation, use mock objects (`MockEnv`, `MockSim`, etc.) following the pattern in `tests/gym/envs/managers/test_reward_functors.py`.
+
+### 6. Run `black`
+
+```bash
+black embodichain/lab/gym/envs/managers/<module>.py
+black tests/gym/envs/managers/test_<functor_type>.py
+```
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Wrong first argument signature | Observation: `(env, obs, ...)`, Reward: `(env, obs, action, info, ...)`, Event/Randomization: `(env, env_ids, ...)` |
+| Importing `EmbodiedEnv` at module level | Use `TYPE_CHECKING` guard to avoid circular imports |
+| Forgetting `SceneEntityCfg` for entity refs | Always use `SceneEntityCfg(uid="...")` not bare strings |
+| Returning wrong tensor shape | Rewards must return `(num_envs,)`, observations must match declared shape |
+| Missing `from __future__ import annotations` | Required in every file |
+| Class-style functor not calling `super().__init__` | Always call `super().__init__(cfg, env)` |
+| Adding randomizer as standalone | Randomizations ARE events — they go in `randomization/` but use `EventCfg` |
+
+## Quick Reference
+
+| Step | Action |
+|------|--------|
+| 1 | Identify manager type + function vs class style |
+| 2 | Write functor in the correct module file |
+| 3 | Update `__all__` in that module |
+| 4 | Write test with mocks (no sim needed for most) |
+| 5 | Run `black` on changed files |

--- a/.claude/skills/add-task-env/SKILL.md
+++ b/.claude/skills/add-task-env/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: add-task-env
+description: Use when creating a new task environment for EmbodiChain, including expert demostraction tasks, RL tasks or any EmbodiedEnv subclass
+---
+
+# Add Task Environment
+
+Scaffold a new task environment following EmbodiChain's conventions and patterns.
+
+## When to Use
+
+- User asks to create a new task or environment
+- User says "add a task", "new env", "create environment for X"
+- A new EmbodiedEnv or BaseEnv subclass is needed
+
+## Steps
+
+### 1. Determine Task Category
+
+Ask the user which category the task belongs to:
+
+| Category | Directory | Base Class | Typical Use |
+|----------|-----------|------------|-------------|
+| `tableware` | `embodichain/lab/gym/envs/tasks/tableware/` | `EmbodiedEnv` | Manipulation tasks (pouring, stacking, rearranging) |
+| `rl` | `embodichain/lab/gym/envs/tasks/rl/` | `EmbodiedEnv` | Reinforcement learning tasks (push, reach, lift) |
+| `special` | `embodichain/lab/gym/envs/tasks/special/` | `EmbodiedEnv` | Simple or demo tasks |
+
+Also ask:
+- Task name (snake_case, e.g. `pick_place`)
+- Gym registration ID (e.g. `PickPlace-v1`)
+- `max_episode_steps` value
+- Whether this is an RL task (needs reward functors) or an agent task (needs action bank / trajectory)
+
+### 2. Create the Task File
+
+Place at `embodichain/lab/gym/envs/tasks/<category>/<name>.py`.
+
+If the task needs multiple files (e.g. action bank), create a subdirectory package:
+`embodichain/lab/gym/envs/tasks/<category>/<name>/__init__.py` + `<name>.py`
+
+Use this template:
+
+```python
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import torch
+from typing import Dict, Any, Tuple
+
+from embodichain.lab.gym.utils.registration import register_env
+from embodichain.lab.gym.envs import EmbodiedEnv, EmbodiedEnvCfg
+from embodichain.lab.sim.types import EnvObs
+
+__all__ = ["<CamelCaseName>Env"]
+
+
+@register_env("<GymId>", max_episode_steps=<N>)
+class <CamelCaseName>Env(EmbodiedEnv):
+    """<One-line description of the task>.
+
+    <Longer description of what the task involves and its reward structure.>
+    """
+
+    def __init__(self, cfg: EmbodiedEnvCfg = None, **kwargs):
+        if cfg is None:
+            cfg = EmbodiedEnvCfg()
+        super().__init__(cfg, **kwargs)
+
+    def compute_task_state(
+        self, **kwargs
+    ) -> Tuple[torch.Tensor, torch.Tensor, Dict[str, Any]]:
+        """Compute success/fail state and metrics for the task.
+
+        Returns:
+            is_success: Boolean tensor of shape (num_envs,).
+            is_fail: Boolean tensor of shape (num_envs,).
+            metrics: Dictionary of metric tensors.
+        """
+        is_success = torch.zeros(self.num_envs, device=self.device, dtype=torch.bool)
+        is_fail = torch.zeros(self.num_envs, device=self.device, dtype=torch.bool)
+        metrics: Dict[str, Any] = {}
+        return is_success, is_fail, metrics
+
+    def check_truncated(self, obs: EnvObs, info: Dict[str, Any]) -> torch.Tensor:
+        """Check if episodes should be truncated early.
+
+        Returns:
+            Boolean tensor of shape (num_envs,).
+        """
+        return torch.zeros(self.num_envs, device=self.device, dtype=torch.bool)
+
+
+if __name__ == "__main__":
+    env = <CamelCaseName>Env()
+```
+
+### 3. Key Methods to Implement
+
+Based on task needs, implement these methods on the `EmbodiedEnv` subclass:
+
+| Method | Required? | Purpose |
+|--------|-----------|---------|
+| `compute_task_state` | **Yes** | Returns `(is_success, is_fail, metrics)` |
+| `check_truncated` | **Yes** | Returns early-truncation boolean tensor |
+| `_setup_scene` | If custom scene | Override to add task-specific objects/lights |
+| `_reset_idx` | If custom reset | Override for per-env reset logic |
+
+For **RL tasks**, also ensure the `EmbodiedEnvCfg` includes:
+- `event_cfg` with any randomization events
+- `observation_cfg` with observation functors
+- `reward_cfg` with reward functors
+
+For **agent tasks** (trajectory-based), consider adding:
+- An action bank at `tasks/<category>/<name>/action_bank.py`
+- A companion `BaseAgentEnv` subclass (see `tableware/base_agent_env.py`)
+
+### 4. Update `__init__.py`
+
+Add the import and `__all__` entry to `embodichain/lab/gym/envs/tasks/__init__.py`:
+
+```python
+from embodichain.lab.gym.envs.tasks.<category>.<name> import <CamelCaseName>Env
+```
+
+And add `"<CamelCaseName>Env"` to the `__all__` list.
+
+If a new category directory was created, also add a new `__init__.py` in that directory.
+
+### 5. Create a Test File
+
+Place at `tests/gym/envs/tasks/test_<name>.py`. For pure-logic tests (no GPU required), use pytest style. For sim-dependent tests, use class style with `setup_method`/`teardown_method`.
+
+### 6. Run `black`
+
+```bash
+black embodichain/lab/gym/envs/tasks/<category>/<name>.py
+black tests/gym/envs/tasks/test_<name>.py
+```
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Forgetting `@register_env` decorator | Every task must be registered with a unique gym ID |
+| Missing `__all__` in the task module | Define `__all__` with the exported class name |
+| Not setting `cfg = EmbodiedEnvCfg()` default | Always provide a default config in `__init__` |
+| Using `self.device` before `super().__init__` | Call `super().__init__` first |
+| Forgetting Apache 2.0 header | Every file must start with the copyright block |
+| Adding task to `__init__.py` but not `__all__` | Both import AND `__all__` entry are required |
+| Missing `from __future__ import annotations` | Required at top of every file (after header) |
+
+## Quick Reference
+
+| Item | Pattern |
+|------|---------|
+| File location | `embodichain/lab/gym/envs/tasks/<category>/<name>.py` |
+| Base class | `EmbodiedEnv` (most cases), `BaseEnv` (rare) |
+| Registration | `@register_env("<GymId>", max_episode_steps=<N>)` |
+| Config class | `EmbodiedEnvCfg` (inherited or as-is) |
+| Required methods | `compute_task_state`, `check_truncated` |
+| Test location | `tests/gym/envs/tasks/test_<name>.py` |

--- a/.claude/skills/add-task-env/SKILL.md
+++ b/.claude/skills/add-task-env/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: add-task-env
-description: Use when creating a new task environment for EmbodiChain, including expert demostraction tasks, RL tasks or any EmbodiedEnv subclass
+description: Use when creating a new task environment for EmbodiChain, including expert demonstration tasks, RL tasks or any EmbodiedEnv subclass
 ---
 
 # Add Task Environment
@@ -11,34 +11,23 @@ Scaffold a new task environment following EmbodiChain's conventions and patterns
 
 - User asks to create a new task or environment
 - User says "add a task", "new env", "create environment for X"
-- A new EmbodiedEnv or BaseEnv subclass is needed
 
 ## Steps
 
 ### 1. Determine Task Category
 
-Ask the user which category the task belongs to:
+Ask the user:
 
-| Category | Directory | Base Class | Typical Use |
-|----------|-----------|------------|-------------|
-| `tableware` | `embodichain/lab/gym/envs/tasks/tableware/` | `EmbodiedEnv` | Manipulation tasks (pouring, stacking, rearranging) |
-| `rl` | `embodichain/lab/gym/envs/tasks/rl/` | `EmbodiedEnv` | Reinforcement learning tasks (push, reach, lift) |
-| `special` | `embodichain/lab/gym/envs/tasks/special/` | `EmbodiedEnv` | Simple or demo tasks |
-
-Also ask:
-- Task name (snake_case, e.g. `pick_place`)
-- Gym registration ID (e.g. `PickPlace-v1`)
-- `max_episode_steps` value
-- Whether this is an RL task (needs reward functors) or an agent task (needs action bank / trajectory)
+- **Category**: `tableware`, `rl`, or `special` (maps to `embodichain/lab/gym/envs/tasks/<category>/`)
+- **Task name** (snake_case, e.g. `pick_place`)
+- **Gym ID** (e.g. `PickPlace-v1`)
+- **Task type**: RL task (needs reward functors) or expert demonstration task (needs `create_demo_action_list`)
 
 ### 2. Create the Task File
 
 Place at `embodichain/lab/gym/envs/tasks/<category>/<name>.py`.
 
-If the task needs multiple files (e.g. action bank), create a subdirectory package:
-`embodichain/lab/gym/envs/tasks/<category>/<name>/__init__.py` + `<name>.py`
-
-Use this template:
+Template:
 
 ```python
 # ----------------------------------------------------------------------------
@@ -69,7 +58,7 @@ from embodichain.lab.sim.types import EnvObs
 __all__ = ["<CamelCaseName>Env"]
 
 
-@register_env("<GymId>", max_episode_steps=<N>)
+@register_env("<GymId>")
 class <CamelCaseName>Env(EmbodiedEnv):
     """<One-line description of the task>.
 
@@ -81,96 +70,38 @@ class <CamelCaseName>Env(EmbodiedEnv):
             cfg = EmbodiedEnvCfg()
         super().__init__(cfg, **kwargs)
 
-    def compute_task_state(
-        self, **kwargs
-    ) -> Tuple[torch.Tensor, torch.Tensor, Dict[str, Any]]:
-        """Compute success/fail state and metrics for the task.
-
-        Returns:
-            is_success: Boolean tensor of shape (num_envs,).
-            is_fail: Boolean tensor of shape (num_envs,).
-            metrics: Dictionary of metric tensors.
-        """
-        is_success = torch.zeros(self.num_envs, device=self.device, dtype=torch.bool)
-        is_fail = torch.zeros(self.num_envs, device=self.device, dtype=torch.bool)
-        metrics: Dict[str, Any] = {}
-        return is_success, is_fail, metrics
-
-    def check_truncated(self, obs: EnvObs, info: Dict[str, Any]) -> torch.Tensor:
-        """Check if episodes should be truncated early.
-
-        Returns:
-            Boolean tensor of shape (num_envs,).
-        """
-        return torch.zeros(self.num_envs, device=self.device, dtype=torch.bool)
-
-
-if __name__ == "__main__":
-    env = <CamelCaseName>Env()
+    # Expert demo tasks: implement `create_demo_action_list`.
+    # RL tasks: implement `check_truncated`, `get_reward`, `compute_task_state`.
 ```
 
-### 3. Key Methods to Implement
+### 3. Update Exports
 
-Based on task needs, implement these methods on the `EmbodiedEnv` subclass:
-
-| Method | Required? | Purpose |
-|--------|-----------|---------|
-| `compute_task_state` | **Yes** | Returns `(is_success, is_fail, metrics)` |
-| `check_truncated` | **Yes** | Returns early-truncation boolean tensor |
-| `_setup_scene` | If custom scene | Override to add task-specific objects/lights |
-| `_reset_idx` | If custom reset | Override for per-env reset logic |
-
-For **RL tasks**, also ensure the `EmbodiedEnvCfg` includes:
-- `event_cfg` with any randomization events
-- `observation_cfg` with observation functors
-- `reward_cfg` with reward functors
-
-For **agent tasks** (trajectory-based), consider adding:
-- An action bank at `tasks/<category>/<name>/action_bank.py`
-- A companion `BaseAgentEnv` subclass (see `tableware/base_agent_env.py`)
-
-### 4. Update `__init__.py`
-
-Add the import and `__all__` entry to `embodichain/lab/gym/envs/tasks/__init__.py`:
+Add to `embodichain/lab/gym/envs/tasks/__init__.py`:
 
 ```python
 from embodichain.lab.gym.envs.tasks.<category>.<name> import <CamelCaseName>Env
 ```
 
-And add `"<CamelCaseName>Env"` to the `__all__` list.
+Add `"<CamelCaseName>Env"` to the `__all__` list.
 
-If a new category directory was created, also add a new `__init__.py` in that directory.
+### 4. Create Test Stub
 
-### 5. Create a Test File
+Place at `tests/gym/envs/tasks/test_<name>.py`.
 
-Place at `tests/gym/envs/tasks/test_<name>.py`. For pure-logic tests (no GPU required), use pytest style. For sim-dependent tests, use class style with `setup_method`/`teardown_method`.
-
-### 6. Run `black`
+### 5. Format
 
 ```bash
 black embodichain/lab/gym/envs/tasks/<category>/<name>.py
 black tests/gym/envs/tasks/test_<name>.py
 ```
 
-## Common Mistakes
+## Checklist
 
-| Mistake | Fix |
-|---------|-----|
-| Forgetting `@register_env` decorator | Every task must be registered with a unique gym ID |
-| Missing `__all__` in the task module | Define `__all__` with the exported class name |
-| Not setting `cfg = EmbodiedEnvCfg()` default | Always provide a default config in `__init__` |
-| Using `self.device` before `super().__init__` | Call `super().__init__` first |
-| Forgetting Apache 2.0 header | Every file must start with the copyright block |
-| Adding task to `__init__.py` but not `__all__` | Both import AND `__all__` entry are required |
-| Missing `from __future__ import annotations` | Required at top of every file (after header) |
-
-## Quick Reference
-
-| Item | Pattern |
-|------|---------|
-| File location | `embodichain/lab/gym/envs/tasks/<category>/<name>.py` |
-| Base class | `EmbodiedEnv` (most cases), `BaseEnv` (rare) |
-| Registration | `@register_env("<GymId>", max_episode_steps=<N>)` |
-| Config class | `EmbodiedEnvCfg` (inherited or as-is) |
-| Required methods | `compute_task_state`, `check_truncated` |
-| Test location | `tests/gym/envs/tasks/test_<name>.py` |
+- [ ] File has Apache 2.0 header
+- [ ] Uses `from __future__ import annotations`
+- [ ] `@register_env` decorator with unique gym ID
+- [ ] `__all__` defined in the task module
+- [ ] Default `cfg = EmbodiedEnvCfg()` in `__init__`
+- [ ] Import and `__all__` added to `tasks/__init__.py`
+- [ ] Test stub created
+- [ ] `black` run on both files

--- a/.claude/skills/add-test/SKILL.md
+++ b/.claude/skills/add-test/SKILL.md
@@ -1,0 +1,246 @@
+---
+name: add-test
+description: Use when writing tests for EmbodiChain modules, including observation functors, reward functors, solvers, sensors, environments, or any Python module
+---
+
+# Add Test
+
+Write tests following EmbodiChain's conventions and patterns.
+
+## When to Use
+
+- User asks to "add a test", "write tests for X", "test this module"
+- A new public module or function needs test coverage
+- PR checklist requires tests
+
+## Test File Location
+
+Tests mirror the source tree under `tests/`:
+
+```
+embodichain/lab/sim/solvers/pytorch_solver.py  →  tests/sim/solvers/test_pytorch_solver.py
+embodichain/lab/gym/envs/managers/rewards.py    →  tests/gym/envs/managers/test_reward_functors.py
+embodichain/toolkits/graspkit/pg_grasp/foo.py   →  tests/toolkits/test_pg_grasp.py
+embodichain/lab/gym/envs/tasks/rl/push_cube.py  →  tests/gym/envs/tasks/test_push_cube.py
+```
+
+Rules:
+- File name: `test_<module>.py`
+- Directory path mirrors `embodichain/` structure under `tests/`
+- Create `__init__.py` files in new `tests/` subdirectories if needed
+
+## Two Test Styles
+
+### pytest Style — For Pure-Python Logic (No Sim)
+
+Use when: testing functors, utility functions, pure math, config validation — anything that doesn't need a `SimulationManager`.
+
+```python
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# ...
+# ----------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from embodichain.my_module import my_function
+
+
+def test_expected_output():
+    result = my_function(input_value)
+    assert result == expected_value
+
+
+def test_edge_case():
+    result = my_function(edge_input)
+    assert result is not None
+```
+
+### Class Style — For Sim-Dependent or Ordered Tests
+
+Use when: tests need `SimulationManager`, GPU setup, or must run in a specific order. Share state via `setup_method`/`teardown_method`.
+
+```python
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# ...
+# ----------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from embodichain.lab.sim import SimulationManager, SimulationManagerCfg
+
+
+class TestMySimComponent:
+    def setup_method(self):
+        config = SimulationManagerCfg(headless=True, sim_device="cpu")
+        self.sim = SimulationManager(config)
+        # ... setup ...
+
+    def teardown_method(self):
+        self.sim.destroy()
+
+    def test_basic_behavior(self):
+        result = self.sim.do_something()
+        assert result == expected_result
+
+    def test_raises_on_bad_input(self):
+        with pytest.raises(ValueError):
+            self.sim.do_something(bad_input)
+```
+
+## Mocking Patterns for Functor Tests
+
+Most functor tests don't need a live simulation. Use mock objects following the pattern in `tests/gym/envs/managers/test_reward_functors.py`:
+
+```python
+from unittest.mock import MagicMock, Mock
+
+
+class MockSim:
+    """Mock simulation for functor tests."""
+
+    def __init__(self, num_envs: int = 4):
+        self.num_envs = num_envs
+        self.device = torch.device("cpu")
+        self._rigid_objects: dict = {}
+
+    def get_rigid_object(self, uid: str):
+        return self._rigid_objects.get(uid)
+
+    def add_rigid_object(self, obj):
+        self._rigid_objects[obj.uid] = obj
+
+
+class MockEnv:
+    """Mock environment for functor tests."""
+
+    def __init__(self, num_envs: int = 4):
+        self.num_envs = num_envs
+        self.device = torch.device("cpu")
+        self.sim = MockSim(num_envs)
+```
+
+Key points for mock objects:
+- Set `num_envs` and `device` attributes (functors use these)
+- Mock only the sim methods the functor actually calls
+- Use `MagicMock(uid="...")` for `SceneEntityCfg` parameters
+
+## Steps
+
+### 1. Identify What to Test
+
+Ask the user:
+1. **Which module/function?** — determines file path
+2. **Does it need a live simulation?** — determines test style
+3. **Key behaviors to verify** — happy path, edge cases, error cases
+
+### 2. Determine Test File Path
+
+Map the source path to test path:
+
+```
+embodichain/<subpath>/<module>.py  →  tests/<subpath>/test_<module>.py
+```
+
+Check if the test file already exists — append new test classes/functions if so.
+
+### 3. Choose Test Style
+
+```dot
+digraph test_style {
+    rankdir=LR;
+    "Needs SimulationManager?" -> "Class style" [label="yes"];
+    "Needs SimulationManager?" -> "pytest style" [label="no"];
+    "Tests share state/order?" -> "Class style" [label="yes"];
+    "Tests share state/order?" -> "pytest style" [label="no"];
+}
+```
+
+### 4. Write the Test
+
+Use the appropriate template (pytest or class style above).
+
+Rules:
+- **Apache 2.0 header** — required on every test file
+- **`from __future__ import annotations`** — after header, before imports
+- **No magic numbers** — define expected values as named constants or comment their origin
+- **Test function names** — `test_<scenario>` (descriptive, not just `test_foo`)
+- **One assertion concept per test** — don't bundle unrelated checks
+
+### 5. Add `if __name__ == "__main__"` Block
+
+Include this for tests that support optional visual/interactive debugging:
+
+```python
+if __name__ == "__main__":
+    # For visual debugging: set is_visual=True when calling env methods
+    test_obj = TestMyComponent()
+    test_obj.setup_method()
+    # ... manually run test logic ...
+```
+
+### 6. Run the Test
+
+```bash
+# Single file
+pytest tests/<subpath>/test_<module>.py -v
+
+# Single test function
+pytest tests/<subpath>/test_<module>.py::test_expected_output -v
+
+# Single test class method
+pytest tests/<subpath>/test_<module>.py::TestMyClass::test_basic_behavior -v
+```
+
+### 7. Run `black`
+
+```bash
+black tests/<subpath>/test_<module>.py
+```
+
+## Conventions Summary
+
+| Convention | Rule |
+|-----------|------|
+| File header | Apache 2.0 copyright block (same 15 lines as source) |
+| File naming | `test_<module>.py` |
+| Function naming | `test_<scenario>` |
+| `from __future__` | Required after header |
+| Magic numbers | Define as named constants with explanatory comments |
+| Simulation tests | Initialize/teardown in `setup_method`/`teardown_method` |
+| Pure-logic tests | Use mock objects, no real sim |
+| `SceneEntityCfg` | Use `MagicMock(uid="...")` in tests |
+| Assertions | `assert`, `pytest.approx`, `torch.allclose`, `pytest.raises` |
+| Entry block | `if __name__ == "__main__"` for visual debugging support |
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Missing Apache header on test file | Copy the 15-line copyright block |
+| Using real `SimulationManager` for functor tests | Use `MockEnv`/`MockSim` — much faster, no GPU needed |
+| Hardcoded numbers without explanation | Define as `EXPECTED_DISTANCE = 0.5  # cube at origin, target at (0.5, 0, 0)` |
+| Testing multiple concepts in one function | Split into separate `test_<scenario>` functions |
+| Forgetting `teardown_method` | Always call `self.sim.destroy()` in teardown |
+| Not running `black` on test file | CI checks all files including tests |
+
+## Quick Reference
+
+| Action | Command |
+|--------|---------|
+| Run all tests | `pytest tests/` |
+| Run single file | `pytest tests/<path>/test_<name>.py -v` |
+| Run single test | `pytest tests/<path>::test_<name> -v` |
+| Run with print output | `pytest -s tests/<path>/test_<name>.py` |
+| Format | `black tests/<path>/test_<name>.py` |

--- a/.claude/skills/pre-commit-check/SKILL.md
+++ b/.claude/skills/pre-commit-check/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: pre-commit-check
+description: Use before committing or creating a PR for EmbodiChain to verify code style, headers, annotations, exports, and docstrings pass CI checks
+---
+
+# Pre-Commit Check
+
+Run all local checks that the CI pipeline enforces, catching issues before pushing.
+
+## When to Use
+
+- Before creating a commit or PR
+- User says "check my changes", "pre-commit", "verify before commit", "ready to push"
+- After making any code changes to `.py` files
+
+## Steps
+
+### 1. Identify Changed Files
+
+```bash
+git diff --name-only HEAD
+git diff --name-only --cached
+git status --short
+```
+
+Collect all changed/added `.py` files.
+
+### 2. Run Black Formatting Check
+
+This is the **first CI gate** and will cause immediate failure:
+
+```bash
+black --check --diff --color ./
+```
+
+If it fails, run `black .` and review the formatting changes.
+
+### 3. Check Apache 2.0 Copyright Header
+
+Every `.py` file must begin with the 15-line copyright block. For each changed/new `.py` file, verify the first line is:
+
+```
+# ----------------------------------------------------------------------------
+```
+
+The full header template:
+
+```python
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+```
+
+### 4. Check `from __future__ import annotations`
+
+Every `.py` file must have this import (after the header, before other imports). This enables `A | B` syntax and forward references.
+
+### 5. Check `__all__` in Public Modules
+
+For any new or modified module under `embodichain/`, verify it defines `__all__` listing all public symbols. Example:
+
+```python
+__all__ = ["MyClass", "my_function"]
+```
+
+Skip this check for `__init__.py` files that only re-export via `from . import *`.
+
+### 6. Check Docstrings on Public APIs
+
+For any new public function, class, or method:
+- Must have a Google-style docstring
+- Must include `Args:` section if it takes parameters
+- Must include `Returns:` section if it returns a value
+- Use `.. attention::` or `.. tip::` directives for non-obvious behavior
+
+### 7. Check Type Annotations
+
+For any new public API:
+- All parameters must have type hints
+- Return type must be annotated
+- Use `A | B` over `Union[A, B]`
+- Use `TYPE_CHECKING` guard for imports that would cause circular dependencies
+
+### 8. Check `@configclass` Usage
+
+For any new configuration class:
+- Must use `@configclass` decorator (not bare `@dataclass`)
+- Must use `from dataclasses import MISSING` for required fields
+- Import from `embodichain.utils import configclass`
+
+### 9. Check Test Coverage
+
+For any new public module or function:
+- A corresponding test must exist at `tests/<subpackage>/test_<module>.py`
+- Test file must also have the Apache 2.0 header
+- Report if tests are missing
+
+### 10. Summary Report
+
+Output a pass/fail summary:
+
+```
+Pre-Commit Check Results
+========================
+[PASS] Black formatting
+[PASS] Apache 2.0 headers (5/5 files)
+[FAIL] from __future__ import annotations — missing in: foo.py
+[PASS] __all__ exports
+[PASS] Docstrings on public APIs
+[PASS] Type annotations
+[PASS] @configclass usage
+[WARN] Missing tests for: bar.py
+
+Fix the above issues before committing.
+```
+
+## What CI Checks
+
+The project's CI pipeline (`.github/workflows/main.yml`) runs:
+
+1. **lint** job: `black --check --diff --color ./`
+2. **test** job: `pytest tests`
+3. **build** job: Sphinx docs build
+
+This skill covers items 1 and 2 locally. Docs build is heavier and typically only needed for documentation changes.
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Running `black` on only one file | Run `black .` on the whole project — CI checks everything |
+| Forgetting test Apache header | Test files also need the 15-line copyright block |
+| Using `Union[A, B]` | Use `A \| B` (with `from __future__ import annotations`) |
+| Using bare `@dataclass` | Use `@configclass` from `embodichain.utils` |
+| Missing `__all__` in new module | Add `__all__` with all public symbols |
+
+## Quick Reference
+
+| Check | Command/Method |
+|-------|---------------|
+| Black formatting | `black --check --diff --color ./` |
+| Auto-fix formatting | `black .` |
+| Header check | Verify first line is `# ---...---` |
+| `__future__` import | Grep for `from __future__ import annotations` |
+| `__all__` export | Grep for `__all__` in module |
+| Run tests | `pytest tests/<path>` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,7 @@ EmbodiChain/
   ```bash
   black .
   ```
+- Use the `/pre-commit-check` skill before committing to catch all CI violations locally.
 
 ### File Headers
 
@@ -108,22 +109,14 @@ class MyManagerCfg:
 
 ### Functor / Manager Pattern
 
-Managers (observation, event, reward, randomization) use a `Functor`/`FunctorCfg` pattern:
+Managers (observation, event, reward, randomization) use a `Functor`/`FunctorCfg` pattern with two styles:
 
 - **Function-style**: a plain function with signature `(env, env_ids, ...) -> None`.
 - **Class-style**: a class inheriting `Functor`, with `__init__(cfg, env)` and `__call__(env, env_ids, ...)`.
-- Registered in a manager config via `FunctorCfg(func=..., params={...})`.
 
-```python
-from embodichain.lab.gym.envs.managers import Functor, FunctorCfg
+Registered in a manager config via `FunctorCfg(func=..., params={...})`.
 
-class my_randomizer(Functor):
-    def __init__(self, cfg: FunctorCfg, env):
-        super().__init__(cfg, env)
-
-    def __call__(self, env, env_ids, my_param: float = 0.5):
-        ...
-```
+Use the `/add-functor` skill to scaffold new functors with the correct signature and module placement.
 
 ### Docstrings
 
@@ -203,17 +196,7 @@ Include:
 3. **Format** the code with `black==24.3.0` before submitting.
 4. **Update documentation** for any public API changes.
 5. **Add tests** that prove your fix or feature works.
-6. **Submit** using the PR template (`.github/PULL_REQUEST_TEMPLATE.md`):
-   - Summarize changes and link the related issue (`Fixes #123`).
-   - Specify the type of change (bug fix / enhancement / new feature / breaking change / docs).
-   - Attach before/after screenshots for visual changes.
-   - Complete the checklist:
-     - [ ] `black .` has been run
-     - [ ] Documentation updated
-     - [ ] Tests added
-     - [ ] Dependencies updated (if applicable)
-
-> It is recommended to open an issue and discuss the design before opening a large PR.
+6. Use the `/pr` skill to create PRs following the project's template and label conventions.
 
 ### Adding a New Robot
 
@@ -231,107 +214,25 @@ Also add robot documentation in `docs/source/resources/robot/` (see existing exa
 
 ### Adding a New Task Environment
 
-Refer to `embodichain/lab/gym/envs/tasks/` for existing examples. Tasks subclass `EmbodiedEnv` or `BaseAgentEnv` and implement `_setup_scene`, `_reset_idx`, and evaluation logic.
+Use the `/add-task-env` skill to scaffold a new task with the correct file structure, `@register_env` decorator, base class, and test stub.
+
+### Adding Functors
+
+Use the `/add-functor` skill to scaffold observation, reward, event, action, dataset, or randomization functors with the correct signature, style, and module placement.
+
+### Writing Tests
+
+Use the `/add-test` skill to scaffold tests with the correct file placement, style (pytest vs class), mock patterns, and project conventions.
 
 ---
 
-## Unit Tests
+## Skills Quick Reference
 
-### Structure
-
-Tests live in `tests/` and mirror the source tree:
-
-```text
-tests/
-├── toolkits/
-│   └── test_pg_grasp.py
-├── gym/
-│   └── action_bank/
-│       └── test_configurable_action.py
-└── sim/
-    ├── objects/
-    │   ├── test_light.py
-    │   └── test_rigid_object_group.py
-    ├── sensors/
-    │   ├── test_camera.py
-    │   └── test_stereo.py
-    └── planners/
-        └── test_motion_generator.py
-```
-
-Place new test files at `tests/<subpackage>/test_<module>.py`, matching the layout of `embodichain/`.
-
-### Two accepted styles
-
-**pytest style** — for pure-Python logic with no test ordering dependency:
-
-```python
-# ----------------------------------------------------------------------------
-# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
-# Licensed under the Apache License, Version 2.0 (the "License");
-# ...
-# ----------------------------------------------------------------------------
-
-from embodichain.my_module import my_function
-
-
-def test_expected_output():
-    result = my_function(input_value)
-    assert result == expected_value
-
-
-def test_edge_case():
-    result = my_function(edge_input)
-    assert result is not None
-```
-
-**`Class` style** — when tests must run in a specific order or share `setup_method`/`teardown_method` state:
-
-```python
-# ----------------------------------------------------------------------------
-# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
-# Licensed under the Apache License, Version 2.0 (the "License");
-# ...
-# ----------------------------------------------------------------------------
-
-from embodichain.my_module import MyClass
-
-
-class TestMyClass():
-    def setup_method(self):
-        self.obj = MyClass(param=1.0)
-
-    def teardown_method(self):
-        pass
-
-    def test_basic_behavior(self):
-        result = self.obj.run()
-        assert result == expected_result
-
-    def test_raises_on_bad_input(self):
-        with pytest.raises(ValueError):
-            self.obj.run(bad_input)
-
-### Conventions
-
-- **File header**: include the standard Apache 2.0 copyright block (same as all source files).
-- **Naming**: test files are `test_<module>.py`; test functions/methods are `test_<scenario>`.
-- **Simulation-dependent tests**: tests that require a running `SimulationManager` (GPU, sensors, robots) must initialize and teardown the sim inside `setUp`/`tearDown` or a pytest fixture. Keep them isolated from pure-logic tests.
-- **No magic numbers**: define expected values as named constants or comments explaining their origin.
-- **`if __name__ == "__main__"`**: include this block for tests that support optional visual/interactive output (pass `is_visual=True` manually when debugging).
-
-### Running tests
-
-```bash
-# Run all tests
-pytest tests/
-
-# Run a specific file
-pytest tests/toolkits/test_pg_grasp.py
-
-# Run a specific test function
-pytest tests/toolkits/test_pg_grasp.py::test_antipodal_score_selector
-
-# Run with verbose output
-pytest -v tests/
-```
+| Skill | Command | Purpose |
+|-------|---------|---------|
+| Add Task Env | `/add-task-env` | Scaffold a new `EmbodiedEnv` task |
+| Add Functor | `/add-functor` | Scaffold observation/reward/event/action/dataset/randomization functors |
+| Add Test | `/add-test` | Scaffold tests following project conventions |
+| Pre-Commit Check | `/pre-commit-check` | Run all local CI checks before committing |
+| Create PR | `/pr` | Create a PR following the project template |
+| Benchmark | `/benchmark` | Write benchmark scripts for EmbodiChain modules |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,23 @@ We welcome pull requests for bug fixes, new features, and documentation improvem
     *   Include a summary of the changes and link to any relevant issues (e.g., `Fixes #123`).
     *   Ensure all checks pass.
 
+
+## Contribute specific robots
+
+To contribute a new robot, please check the documentation on [Adding a New Robot](https://dexforce.github.io/EmbodiChain/guides/add_robot.html).
+
+## Contribute specific environments
+
+To contribute a new environment, please check the documentation on [Embodied Environments](https://dexforce.github.io/EmbodiChain/overview/gym/env.html) and see the tutorial below:
+- [Creating a Basic Environment](https://dexforce.github.io/EmbodiChain/tutorial/basic_env.html) 
+- [Creating a Modular Environment](https://dexforce.github.io/EmbodiChain/tutorial/modular_env.html)
+
+If you want to implement your tasks in a new repo and with some customized functors and utilities, you can also use the [Task Template Repo](https://github.com/DexForce/embodichain_task_template).
+
 ## Using Claude Code for Contributions
+
+<details>
+<summary>Setup, skills, and tips for using Claude Code</summary>
 
 [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) is an AI-powered CLI that can assist you throughout the contribution workflow — from understanding the codebase to writing, reviewing, and debugging code.
 
@@ -50,6 +66,33 @@ claude
 ```
 
 A `CLAUDE.md` file is present at the root of this repository. Claude Code reads it automatically at startup to load project conventions, structure, and style rules, so it is context-aware from the first prompt.
+
+### Skills
+
+Claude Code skills are built-in slash commands that automate common development tasks. They scaffold code, run checks, and enforce project conventions so you can focus on your logic instead of boilerplate. Invoke any skill by typing its command in the Claude Code prompt.
+
+| Skill | Command | Purpose |
+|-------|---------|---------|
+| Add Functor | `/add-functor` | Scaffold a new observation, reward, event, action, dataset, or randomization functor with the correct signature, style, and module placement |
+| Add Task Env | `/add-task-env` | Scaffold a new task environment with the correct file structure, `@register_env` decorator, base class, and test stub |
+| Add Test | `/add-test` | Scaffold tests with the correct file placement, style (pytest vs class), mock patterns, and project conventions |
+| Pre-Commit Check | `/pre-commit-check` | Run all local CI checks — code style, headers, annotations, exports, and docstrings — before committing |
+| Create PR | `/pr` | Create a pull request following the project template and label conventions |
+| Benchmark | `/benchmark` | Write benchmark scripts for measuring performance of solvers, samplers, and other computationally intensive components |
+
+#### When to use each skill
+
+**`/add-functor`** — Use when adding a new observation, event, reward, action, dataset, or randomization functor to an EmbodiChain environment. The skill will ask for the functor type and name, then generate the function- or class-style implementation with proper docstrings, type hints, and `__all__` exports.
+
+**`/add-task-env`** — Use when creating a new task environment, including expert demonstration tasks, RL tasks, or any `EmbodiedEnv` subclass. The skill scaffolds the task file with `_setup_scene`, `_reset_idx`, and evaluation logic, plus a test stub.
+
+**`/add-test`** — Use when writing tests for any EmbodiChain module — functors, solvers, sensors, environments, or utilities. The skill determines the correct test file location, style (pytest function vs class), and generates tests with the standard Apache 2.0 header and named constants.
+
+**`/pre-commit-check`** — Run this before committing or creating a PR. It verifies code formatting (`black`), file headers, type annotations, `__all__` exports, and docstring completeness — the same checks the CI pipeline enforces.
+
+**`/pr`** — Use after committing your changes to create a pull request. The skill checks git state, determines the PR type, drafts a description following the project template, runs formatting, creates a feature branch, and opens the PR via `gh` CLI with the correct labels.
+
+**`/benchmark`** — Use when you need to measure the performance of a module (IK solvers, grasp samplers, metrics, etc.). The skill generates a well-structured benchmark script following project conventions.
 
 ### Suggested workflows
 
@@ -66,7 +109,7 @@ A `CLAUDE.md` file is present at the root of this repository. Claude Code reads 
 ```
 > I want to add a new observation functor that returns the end-effector velocity.
   Which existing functor should I model it after?
-> Generate the functor following the project style, with a proper docstring and type hints.
+> /add-functor
 ```
 
 **Validate style and formatting before submitting**
@@ -74,13 +117,13 @@ A `CLAUDE.md` file is present at the root of this repository. Claude Code reads 
 ```
 > Review my changes in embodichain/lab/gym/envs/managers/randomization/visual.py
   for style issues, missing type hints, and docstring completeness.
+> /pre-commit-check
 ```
 
 **Write or update tests**
 
 ```
-> Write a pytest test for the randomize_emission_light function in
-  embodichain/lab/gym/envs/managers/randomization/visual.py.
+> /add-test
 ```
 
 **Understand a bug**
@@ -92,38 +135,17 @@ A `CLAUDE.md` file is present at the root of this repository. Claude Code reads 
 
 **Create a pull request**
 
-After you've made your changes and committed them, use the `/pr` command to create a pull request:
+After you've made your changes and committed them:
 
 ```
 > /pr
 ```
 
-This will guide you through:
-1. Checking the current git state and changes
-2. Determining the PR type (bug fix, enhancement, new feature, etc.)
-3. Drafting a proper PR description following the project template
-4. Running code formatting with `black .`
-5. Creating a properly named feature branch
-6. Committing changes with a conventional commit message
-7. Pushing to remote and creating the PR via `gh` CLI
-
-The `/pr` skill ensures your PR follows the EmbodiChain contribution guidelines and populates the required checklist items.
+The `/pr` skill will guide you through checking git state, determining the PR type, drafting a description, running formatting, and creating the PR with proper labels.
 
 ### Tips
 
-*   Always run `black .` after Claude Code generates or edits Python files — Claude Code can do this for you if you ask.
+*   Always run `/pre-commit-check` after making changes — it catches the same issues the CI pipeline checks.
 *   Claude Code respects the `CLAUDE.md` conventions. If you notice it deviating (wrong docstring style, missing `__all__`, etc.), point it out and it will correct the output.
-*   For large features, break the work into small, focused tasks and handle them one at a time.
-*   Claude Code can help draft your PR description and populate the PR checklist once your changes are ready.
-
-## Contribute specific robots
-
-To contribute a new robot, please check the documentation on [Adding a New Robot](https://dexforce.github.io/EmbodiChain/guides/add_robot.html).
-
-## Contribute specific environments
-
-To contribute a new environment, please check the documentation on [Embodied Environments](https://dexforce.github.io/EmbodiChain/overview/gym/env.html) and see the tutorial below:
-- [Creating a Basic Environment](https://dexforce.github.io/EmbodiChain/tutorial/basic_env.html) 
-- [Creating a Modular Environment](https://dexforce.github.io/EmbodiChain/tutorial/modular_env.html)
-
-If you want to implement your tasks in a new repo and with some customized functors and utilities, you can also use the [Task Template Repo](https://github.com/DexForce/embodichain_task_template).
+*   For large features, break the work into small, focused tasks and handle them one at a time using the appropriate skill for each step.
+*   If you add a new skill to `.claude/skills/`, make sure to also add it to the Skills table and "When to use each skill" list in this document so contributors can discover it.

--- a/docs/source/guides/add_robot.rst
+++ b/docs/source/guides/add_robot.rst
@@ -561,3 +561,11 @@ After adding your robot:
 - Configure sensors (cameras, force sensors)
 - Implement custom IK solvers if needed
 - Add motion planning support
+
+.. tip::
+   **Using an AI coding agent?** These skills can help when extending your robot:
+
+   - **/add-task-env** — Scaffold a task environment that uses your new robot.
+   - **/add-functor** — Add observation, reward, or randomization functors for robot-specific tasks.
+   - **/add-test** — Write tests for your robot config or task environment.
+   - **/pre-commit-check** — Verify all code passes CI checks before committing.

--- a/docs/source/overview/gym/action_functors.md
+++ b/docs/source/overview/gym/action_functors.md
@@ -5,6 +5,10 @@
 
 This page lists all available action terms that can be used with the Action Manager. Action terms are configured using {class}`~cfg.ActionTermCfg` and are responsible for processing raw actions from the policy and converting them to the format expected by the robot (e.g., qpos, qvel, qf).
 
+````{tip}
+**Using an AI coding agent?** Use the **`/add-functor`** skill to scaffold a new action term with the correct class structure, `ActionTermCfg` registration, and module placement in `actions.py`.
+````
+
 ## Joint Position Control
 
 ```{list-table} Joint Position Action Terms

--- a/docs/source/overview/gym/dataset_functors.md
+++ b/docs/source/overview/gym/dataset_functors.md
@@ -5,6 +5,10 @@
 
 This page lists all available dataset functors that can be used with the Dataset Manager. Dataset functors are configured using {class}`~cfg.DatasetFunctorCfg` and are responsible for collecting and saving episode data during environment interaction.
 
+````{tip}
+**Using an AI coding agent?** Use the **`/add-functor`** skill to scaffold a new dataset functor with the correct signature, `DatasetFunctorCfg` registration, and module placement in `datasets.py`.
+````
+
 ## Recording Functors
 
 ```{list-table} Dataset Recording Functors

--- a/docs/source/overview/gym/env.md
+++ b/docs/source/overview/gym/env.md
@@ -229,6 +229,16 @@ In JSON config, use the ``actions`` section:
 
 ## Creating a Custom Task
 
+````{tip}
+**Using an AI coding agent?** The following skills can scaffold boilerplate for you:
+
+- **`/add-task-env`** — Generate a new task environment with the correct file structure, `@register_env` decorator, base class methods, `__init__.py` update, and test stub.
+- **`/add-functor`** — Add observation, reward, event, or randomization functors with the correct signature and module placement.
+- **`/add-test`** — Write tests following project conventions (pytest or class style, mock patterns, correct file placement).
+- **`/pre-commit-check`** — Run all local CI checks (black, headers, `__all__`, type annotations) before committing.
+
+````
+
 ### For Reinforcement Learning Tasks
 
 Inherit from {class}`~envs.EmbodiedEnv` and implement the task-specific logic. Configure the Action Manager via ``actions`` in your config:

--- a/docs/source/overview/gym/event_functors.md
+++ b/docs/source/overview/gym/event_functors.md
@@ -5,6 +5,10 @@
 
 This page lists all available event functors that can be used with the Event Manager. Event functors are configured using {class}`~cfg.EventCfg` and can be triggered at different stages: ``startup``, ``reset``, or ``interval``.
 
+````{tip}
+**Using an AI coding agent?** Use the **`/add-functor`** skill to scaffold a new event or randomization functor with the correct signature (`env, env_ids, ...`), function or class style, and module placement. Use **`/add-test`** to generate mock-based tests.
+````
+
 ## Physics Randomization
 
 ```{list-table} Physics Randomization Functors

--- a/docs/source/overview/gym/observation_functors.md
+++ b/docs/source/overview/gym/observation_functors.md
@@ -5,6 +5,10 @@
 
 This page lists all available observation functors that can be used with the Observation Manager. Observation functors are configured using {class}`~cfg.ObservationCfg` and can operate in two modes: ``modify`` (update existing observations) or ``add`` (add new observations).
 
+````{tip}
+**Using an AI coding agent?** Use the **`/add-functor`** skill to scaffold a new observation functor with the correct signature (`env, obs, entity_cfg, ...`), module placement in `observations.py`, and `__all__` export. Use **`/add-test`** to generate mock-based tests.
+````
+
 ## Pose Computations
 
 ```{list-table} Pose Computation Functors

--- a/docs/source/overview/gym/reward_functors.md
+++ b/docs/source/overview/gym/reward_functors.md
@@ -5,6 +5,10 @@
 
 This page lists all available reward functors that can be used with the Reward Manager. Reward functors are configured using {class}`~cfg.RewardCfg` and return scalar reward tensors that are weighted and summed to form the total environment reward.
 
+````{tip}
+**Using an AI coding agent?** Use the **`/add-functor`** skill to scaffold a new reward functor with the correct signature (`env, obs, action, info, ...`), module placement in `rewards.py`, and `__all__` export. Use **`/add-test`** to generate mock-based tests.
+````
+
 ## Distance-Based Rewards
 
 ```{list-table} Distance-Based Reward Functors

--- a/docs/source/quick_start/install.md
+++ b/docs/source/quick_start/install.md
@@ -65,3 +65,19 @@ If the installation is successful, you will see a simulation window with a rende
 ```bash
 python scripts/tutorials/sim/create_scene.py --headless
 ```
+
+## Using an AI Coding Agent
+
+EmbodiChain ships with built-in skills for AI coding agents (Claude Code, Copilot CLI, etc.) that automate common development tasks:
+
+| Skill | Command | Purpose |
+|-------|---------|---------|
+| Add Task Env | `/add-task-env` | Scaffold a new `EmbodiedEnv` task |
+| Add Functor | `/add-functor` | Scaffold observation/reward/event/action/dataset/randomization functors |
+| Add Test | `/add-test` | Write tests following project conventions |
+| Pre-Commit Check | `/pre-commit-check` | Run all local CI checks before committing |
+| Create PR | `/pr` | Create a PR following the project template |
+| Benchmark | `/benchmark` | Write benchmark scripts for EmbodiChain modules |
+
+Run `/pre-commit-check` before every commit to catch formatting, header, annotation, and export issues locally — the same checks the CI pipeline enforces.
+```

--- a/docs/source/tutorial/basic_env.rst
+++ b/docs/source/tutorial/basic_env.rst
@@ -182,3 +182,6 @@ This tutorial showcases several important features of EmbodiChain environments:
 4. **Custom Objects**: Adding and manipulating scene objects
 5. **Flexible Actions**: Customizable action spaces and execution methods
 6. **Extensible Observations**: Adding task-specific observation data
+
+.. tip::
+   **Using an AI coding agent?** Once you're ready to create your own task environment, use the **/add-task-env** skill to scaffold the file with the correct structure, ``@register_env`` decorator, base class methods, and test stub. Use **/add-test** to write tests and **/pre-commit-check** to verify everything passes CI before committing.

--- a/docs/source/tutorial/modular_env.rst
+++ b/docs/source/tutorial/modular_env.rst
@@ -235,3 +235,11 @@ This tutorial showcases the most advanced features of EmbodiChain environments:
 
 
 This tutorial demonstrates the full power of EmbodiChain's modular environment system, providing the foundation for creating sophisticated robotic learning scenarios.
+
+.. tip::
+   **Using an AI coding agent?** These skills can help you build on this tutorial:
+
+   - **/add-task-env** — Scaffold a new task environment with the correct file structure, ``@register_env`` decorator, base class methods, ``__init__.py`` update, and test stub.
+   - **/add-functor** — Add observation, reward, event, or randomization functors with the correct signature and module placement.
+   - **/add-test** — Write tests following project conventions (pytest or class style, mock patterns, correct file placement).
+   - **/pre-commit-check** — Run all local CI checks (black, headers, ``__all__``, type annotations) before committing.


### PR DESCRIPTION
## Description

This PR adds built-in AI coding agent skills (Claude Code / Copilot CLI) for common EmbodiChain development tasks and replaces verbose boilerplate examples in `AGENTS.md` with concise skill references.

### Changes

- **New skill files** (`.claude/skills/`): `add-functor`, `add-task-env`, `add-test`, `pre-commit-check`, `pr`, `benchmark`
- **AGENTS.md**: Replaced inline code examples for functor scaffolding, test writing, and PR submission with references to the corresponding skills. Added a Skills Quick Reference table.
- **Documentation cross-references**: Added contextual tip boxes in 10 doc pages (guides, tutorials, reference pages) pointing developers to relevant skills for their current task.

### Skill summary

| Skill | Command | Purpose |
|-------|---------|---------|
| Add Task Env | `/add-task-env` | Scaffold a new `EmbodiedEnv` task |
| Add Functor | `/add-functor` | Scaffold observation/reward/event/action/dataset/randomization functors |
| Add Test | `/add-test` | Write tests following project conventions |
| Pre-Commit Check | `/pre-commit-check` | Run all local CI checks before committing |
| Create PR | `/pr` | Create a PR following the project template |
| Benchmark | `/benchmark` | Write benchmark scripts for EmbodiChain modules |

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which improves an existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (existing functionality will not work without user modification)
- [ ] Documentation update

## Checklist

- [x] I have run the `black .` command to format the code base.
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Dependencies have been updated, if applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)