### PR TITLE
docs: upgrade README badges and add auto-sync to introduction.rst

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,6 +74,7 @@ jobs:
         run: |
           pip install -e . --extra-index-url http://pyp.open3dv.site:2345/simple/ --trusted-host pyp.open3dv.site
           pip install -r docs/requirements.txt
+          python3 docs/scripts/sync_readme.py
           cd ${GITHUB_WORKSPACE}/docs
           pip uninstall pymeshlab -y
           pip install pymeshlab==2023.12.post3

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 ![teaser](assets/imgs/teaser.jpg)
 
-[![License](https://img.shields.io/github/license/DexForce/EmbodiChain)](LICENSE)
-[![Website](https://img.shields.io/badge/website-dexforce.com-yellow?logo=google-chrome&logoColor=white)](https://dexforce.com/embodichain/index.html#/)
-[![GitHub Pages](https://img.shields.io/badge/GitHub%20Pages-docs-blue?logo=github&logoColor=white)](https://dexforce.github.io/EmbodiChain/main/index.html)
-[![Python](https://img.shields.io/badge/python-3.10%20|%203.11-blue.svg)](https://docs.python.org/3/whatsnew/3.10.html)
-[![Version](https://img.shields.io/github/v/release/DexForce/EmbodiChain?label=version)](https://github.com/DexForce/EmbodiChain/releases)
+[![License](https://img.shields.io/github/license/DexForce/EmbodiChain?style=for-the-badge)](LICENSE)
+[![Website](https://img.shields.io/badge/website-dexforce.com-yellow?style=for-the-badge&logo=google-chrome&logoColor=white)](https://dexforce.com/embodichain/index.html#/)
+[![GitHub Pages](https://img.shields.io/badge/GitHub%20Pages-docs-blue?style=for-the-badge&logo=github&logoColor=white)](https://dexforce.github.io/EmbodiChain/main/index.html)
+[![Python](https://img.shields.io/badge/python-3.10%20|%203.11-blue?style=for-the-badge&logo=python&logoColor=white)](https://docs.python.org/3/whatsnew/3.10.html)
+[![Version](https://img.shields.io/github/v/release/DexForce/EmbodiChain?style=for-the-badge&label=version)](https://github.com/DexForce/EmbodiChain/releases)
 ---
 
-EmbodiChain is an end-to-end, GPU-accelerated framework for Embodied AI. It streamlines research and development by unifying high-performance simulation, real-to-sim data pipelines, modular model architectures, and efficient training workflows. This integration enables rapid experimentation, seamless deployment of intelligent agents, and effective Sim2Real transfer for real-world robotic systems.
+EmbodiChain is an end-to-end, GPU-accelerated framework for Embodied AI. It streamlines research and development by unifying high-performance simulation, automated generative data pipelines, modular model architectures, and efficient training workflows. This integration enables rapid experimentation, seamless deployment of intelligent agents, and effective Sim2Real transfer for real-world robotic systems.
 
 > [!NOTE]
 > EmbodiChain is in Alpha and under active development:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -14,15 +14,20 @@ help:
 
 .PHONY: help Makefile
 
+# Sync README.md -> introduction.rst before building
+.PHONY: sync-readme
+sync-readme:
+	@python3 "$(CURDIR)/scripts/sync_readme.py"
+
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
-%: Makefile
+%: Makefile sync-readme
 	@rm -rf "$(BUILDDIR)"
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 # Build current version only (for local development / PR verification)
 .PHONY: current-docs
-current-docs:
+current-docs: sync-readme
 	@rm -rf "$(BUILDDIR)/html"
 	@$(SPHINXBUILD) -W --keep-going "$(SOURCEDIR)" "$(BUILDDIR)/html" $(SPHINXOPTS) $(O)
 	@python3 "$(CURDIR)/scripts/generate_versions_json.py" --build-dir "$(BUILDDIR)/html"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,3 +8,4 @@ sphinx-autosummary-accessors
 sphinxcontrib-bibtex
 sphinx-design
 sphinx_autodoc_typehints
+pypandoc_binary

--- a/docs/scripts/sync_readme.py
+++ b/docs/scripts/sync_readme.py
@@ -1,0 +1,239 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+"""Synchronize README.md to docs/source/introduction.rst.
+
+Uses pypandoc for Markdown-to-RST conversion, then post-processes the output
+to fix Sphinx-specific formatting issues.
+
+Usage:
+    python docs/scripts/sync_readme.py           # Overwrite introduction.rst
+    python docs/scripts/sync_readme.py --check    # Exit 1 if stale
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+__all__ = ["convert_readme_to_rst", "postprocess_rst"]
+
+# Resolve paths relative to this script
+REPO_ROOT = Path(__file__).resolve().parents[2]
+README_PATH = REPO_ROOT / "README.md"
+RST_PATH = REPO_ROOT / "docs" / "source" / "introduction.rst"
+
+# Prefix to make repo-root-relative paths work from docs/source/
+_DOCS_PATH_PREFIX = "../../"
+
+
+def _fix_image_path(path: str) -> str:
+    """Prefix a repo-root-relative image path for use from docs/source/.
+
+    Args:
+        path: Image path from pandoc output (repo-root-relative).
+
+    Returns:
+        Path adjusted for the RST file location in docs/source/.
+    """
+    if path.startswith(("http://", "https://")):
+        return path
+    return _DOCS_PATH_PREFIX + path
+
+
+def convert_readme_to_rst(readme_content: str) -> str:
+    """Convert Markdown content to RST via pypandoc.
+
+    Args:
+        readme_content: Raw Markdown text from README.md.
+
+    Returns:
+        Raw RST string from pandoc (before post-processing).
+    """
+    import pypandoc
+
+    return pypandoc.convert_text(readme_content, "rst", format="md")
+
+
+def postprocess_rst(rst: str, readme_content: str) -> str:
+    """Fix pandoc RST output for Sphinx compatibility.
+
+    Applies these transformations:
+    1. Strip badge substitution references and definitions.
+    2. Convert ``[!NOTE]`` blockquote to ``.. NOTE::`` directive.
+    3. Convert ``.. raw:: html`` centered-image blocks to ``.. image::``.
+    4. Replace ``.. code:: bibtex`` with ``.. code-block:: bibtex``.
+    5. Convert ``.. figure::`` (with caption) to ``.. image::``.
+
+    Args:
+        rst: Raw RST from pandoc.
+        readme_content: Original Markdown (used to extract image paths).
+
+    Returns:
+        Cleaned RST suitable for Sphinx.
+    """
+    # Extract image paths from README <img> tags for centered HTML blocks
+    readme_images = re.findall(r'<img\s+[^>]*src="([^"]+)"[^>]*>', readme_content)
+
+    lines = rst.split("\n")
+    result_lines: list[str] = []
+    i = 0
+
+    while i < len(lines):
+        line = lines[i]
+
+        # --- 1. Strip badge substitution reference lines ---
+        if re.match(r"^\|.*\|", line):
+            i += 1
+            continue
+
+        # --- 1b. Strip badge substitution definitions at the bottom ---
+        if re.match(r"^\.\. \|\w[\w ]*\w\| image::", line):
+            i += 1
+            while i < len(lines) and lines[i].startswith("   "):
+                i += 1
+            continue
+
+        # --- 2. Convert [!NOTE] blockquote to .. NOTE:: ---
+        if re.match(r"^\s+\[!NOTE\]", line):
+            note_match = re.match(r"^\s+\[!NOTE\]\s*(.*)", line)
+            note_text = note_match.group(1) if note_match else ""
+            note_text = note_text.replace("\\*", "*")
+            note_lines: list[str] = []
+            if note_text:
+                note_lines.append(note_text)
+            i += 1
+            while i < len(lines) and lines[i].startswith("   ") and lines[i].strip():
+                cleaned = lines[i].strip().replace("\\*", "*")
+                note_lines.append(cleaned)
+                i += 1
+            result_lines.append(".. NOTE::")
+            for nl in note_lines:
+                result_lines.append(f"   {nl}")
+            continue
+
+        # --- 3. Convert .. raw:: html centered blocks to .. image:: ---
+        if line.strip() == ".. raw:: html":
+            # Look ahead (skipping blank lines) for <p align="center">
+            j = i + 1
+            while j < len(lines) and lines[j].strip() == "":
+                j += 1
+            if j < len(lines) and "<p align" in lines[j]:
+                # Skip from i through the matching </p> raw block
+                i = j + 1  # skip past <p> line
+                while i < len(lines):
+                    if "</p>" in lines[i]:
+                        i += 1
+                        # Skip any trailing .. raw:: html for </p>
+                        while i < len(lines) and (
+                            lines[i].strip() == ""
+                            or lines[i].strip() == ".. raw:: html"
+                            or "</p>" in lines[i]
+                        ):
+                            i += 1
+                        break
+                    i += 1
+                # Insert images from README source
+                for img_src in readme_images:
+                    result_lines.append(f".. image:: {_fix_image_path(img_src)}")
+                    result_lines.append("   :align: center")
+                result_lines.append("")  # blank line after directive
+                continue
+            elif j < len(lines) and "</p>" in lines[j]:
+                i = j + 1
+                continue
+
+        # --- 4. Replace .. code:: bibtex with .. code-block:: bibtex ---
+        if re.match(r"^\.\. code:: bibtex\s*$", line):
+            result_lines.append(".. code-block:: bibtex")
+            i += 1
+            continue
+
+        # --- 5. Convert .. figure:: with caption to .. image:: ---
+        if re.match(r"^\.\. figure::", line):
+            path_match = re.match(r"^\.\. figure:: (.+)", line)
+            if path_match:
+                img_path = path_match.group(1).strip()
+                result_lines.append(f".. image:: {_fix_image_path(img_path)}")
+                i += 1
+                # Skip :alt:, blank line, and caption lines
+                while i < len(lines):
+                    if lines[i].startswith("   :"):
+                        i += 1
+                        continue
+                    if lines[i].strip() == "":
+                        i += 1
+                        continue
+                    if lines[i].startswith("   "):
+                        i += 1
+                        continue
+                    break
+                continue
+
+        result_lines.append(line)
+        i += 1
+
+    # Clean up excessive blank lines
+    text = "\n".join(result_lines)
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.strip() + "\n"
+
+
+def main() -> None:
+    """CLI entry point for syncing README.md to introduction.rst."""
+    parser = argparse.ArgumentParser(
+        description="Sync README.md to docs/source/introduction.rst"
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Check if introduction.rst is up-to-date (exit 1 if stale)",
+    )
+    args = parser.parse_args()
+
+    if not README_PATH.exists():
+        print(f"Error: {README_PATH} not found", file=sys.stderr)
+        sys.exit(1)
+
+    readme_content = README_PATH.read_text(encoding="utf-8")
+    raw_rst = convert_readme_to_rst(readme_content)
+    final_rst = postprocess_rst(raw_rst, readme_content)
+
+    if args.check:
+        if not RST_PATH.exists():
+            print(
+                f"Error: {RST_PATH} does not exist. Run without --check to generate.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        current = RST_PATH.read_text(encoding="utf-8")
+        if current != final_rst:
+            print(
+                f"Error: {RST_PATH} is out of sync with README.md. "
+                "Run 'python docs/scripts/sync_readme.py' to update.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        print(f"OK: {RST_PATH} is up-to-date.")
+    else:
+        RST_PATH.parent.mkdir(parents=True, exist_ok=True)
+        RST_PATH.write_text(final_rst, encoding="utf-8")
+        print(f"Synced: {README_PATH} -> {RST_PATH}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -1,59 +1,73 @@
-.. EmbodiChain documentation master file, created by
-   sphinx-quickstart on Tue Nov 19 11:00:25 2024.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
 EmbodiChain
-======================================
+===========
 
 .. image:: ../../assets/imgs/teaser.jpg
-   :alt: teaser
 
----
-
-EmbodiChain is an end-to-end, GPU-accelerated framework for Embodied AI. It streamlines research and development by unifying high-performance simulation, real-to-sim data pipelines, modular model architectures, and efficient training workflows. This integration enables rapid experimentation, seamless deployment of intelligent agents, and effective Sim2Real transfer for real-world robotic systems.
+EmbodiChain is an end-to-end, GPU-accelerated framework for Embodied AI.
+It streamlines research and development by unifying high-performance
+simulation, automated generative data pipelines, modular model
+architectures, and efficient training workflows. This integration
+enables rapid experimentation, seamless deployment of intelligent
+agents, and effective Sim2Real transfer for real-world robotic systems.
 
 .. NOTE::
-   EmbodiChain is in Alpha and under active development:
-
-   * More features will be continually added in the coming months. You can find more details in the `roadmap <https://dexforce.github.io/EmbodiChain/resources/roadmap.html>`_.
-   * Since this is an early release, we welcome feedback (bug reports, feature requests, etc.) via GitHub Issues.
-
+   EmbodiChain is in Alpha and under active development: * More
+   features will be continually added in the coming months. You can find
+   more details in the
+   `roadmap <https://dexforce.github.io/EmbodiChain/resources/roadmap.html>`__.
+   * Since this is an early release, we welcome feedback (bug reports,
+   feature requests, etc.) via GitHub Issues.
 
 Key Features
 ------------
 
-* 🚀 **High-Fidelity GPU Simulation**: Realistic physics for rigid & deformable objects, advanced ray-traced sensors, all GPU-accelerated for high-throughput batch simulation.
-* 🤖 **Unified Robot Learning Environment**: Standardized interfaces for Imitation Learning, Reinforcement Learning, and more.
-* 📊 **Scalable Data Pipeline**: Automated data collection, efficient processing, and large-scale generation for model training.
-* ⚡ **Efficient Training & Evaluation**: Online data streaming, parallel environment rollouts, and modern training paradigms.
-* 🧩 **Modular & Extensible**: Easily integrate new robots, environments, and learning algorithms.
+- 🚀 **High-Fidelity GPU Simulation**: Realistic physics for rigid &
+  deformable objects, advanced ray-traced sensors, all GPU-accelerated
+  for high-throughput batch simulation.
+- 🤖 **Unified Robot Learning Environment**: Standardized interfaces for
+  Imitation Learning, Reinforcement Learning, and more.
+- 📊 **Scalable Data Pipeline**: Automated data collection, efficient
+  processing, and large-scale generation for model training.
+- ⚡ **Efficient Training & Evaluation**: Online data streaming,
+  parallel environment rollouts, and modern training paradigms.
+- 🧩 **Modular & Extensible**: Easily integrate new robots,
+  environments, and learning algorithms.
 
 The figure below illustrates the overall architecture of EmbodiChain:
 
 .. image:: ../../assets/imgs/frameworks.jpg
-   :alt: frameworks
+   :align: center
 
 Getting Started
 ---------------
 
 To get started with EmbodiChain, follow these steps:
 
-* `Installation Guide <https://dexforce.github.io/EmbodiChain/quick_start/install.html>`_
-* `Quick Start Tutorial <https://dexforce.github.io/EmbodiChain/tutorial/index.html>`_
-* `API Reference <https://dexforce.github.io/EmbodiChain/api_reference/index.html>`_
+- `Installation
+  Guide <https://dexforce.github.io/EmbodiChain/quick_start/install.html>`__
+- `Quick Start
+  Tutorial <https://dexforce.github.io/EmbodiChain/tutorial/index.html>`__
+- `API
+  Reference <https://dexforce.github.io/EmbodiChain/api_reference/index.html>`__
 
+Contribution Guide
+------------------
+
+We welcome contributions! Please see the
+`CONTRIBUTING.md <CONTRIBUTING.md>`__ file in this repository for
+guidelines on how to get started.
 
 Citation
 --------
 
-If you find EmbodiChain helpful for your research, please consider citing our work:
+If you find EmbodiChain helpful for your research, please consider
+citing our work:
 
 .. code-block:: bibtex
 
    @misc{EmbodiChain,
      author = {EmbodiChain Developers},
-     title = {EmbodiChain: An end-to-end, GPU-accelerated, and modular platform for building generalized Embodied Intelligence.},
+     title = {EmbodiChain: An end-to-end, GPU-accelerated, and modular platform for building generalized Embodied Intelligence},
      month = {November},
      year = {2025},
      url = {https://github.com/DexForce/EmbodiChain}
@@ -68,15 +82,14 @@ If you find EmbodiChain helpful for your research, please consider citing our wo
       month = {October},
       year = {2025},
       journal = {TechRxiv}
-   }
+      }
 
 .. code-block:: bibtex
 
    @inproceedings{Sim2RealVLA,
-      title = {Sim2Real {VLA}: Zero-Shot Generalization of Synthesized Skills to Realistic Manipulation},
-      author = {Runyi Zhao, Sheng Xu, Ruixing Jin, Yueci Deng, Yunxin Tai, Kui Jia, Guiliang Liu},
-      booktitle = {The Fourteenth International Conference on Learning Representations, ICLR},
-      year = {2026},
-      url = {https://openreview.net/forum?id=H4SyKHjd4c}
+       title = {Sim2Real {VLA}: Zero-Shot Generalization of Synthesized Skills to Realistic Manipulation},
+       author = {Runyi Zhao, Sheng Xu, Ruixing Jin, Yueci Deng, Yunxin Tai, Kui Jia, Guiliang Liu},
+       booktitle = {The Fourteenth International Conference on Learning Representations, ICLR},
+       year = {2026},
+       url = {https://openreview.net/forum?id=H4SyKHjd4c}
    }
-

--- a/docs/source/resources/roadmap.md
+++ b/docs/source/resources/roadmap.md
@@ -15,15 +15,14 @@ Currently, EmbodiChain is under active development. Our roadmap includes the fol
         - Add more physical sensors (eg, force sensor) with examples.
     - Motion Generation:
         - Add more advanced motion generation methods with examples.
-    - Useful Tools:
-        - We are working on USD support for EmbodiChain to enable better asset management and interoperability.
+        - Atomic actions for motion generation and easier integration with data generation pipeline.
     - Robots Integration:
         - Add support for more robot models (eg: LeRobot, Unitree H1/G1, etc).
 
 - Data Pipeline Coming Soon:
     - We will release a Real2Sim pipeline, which enables automatic data generation and scaling from real-world seeding priors.
     - We will release an agentic skill generation framework for automated expert trajectory generation.
-    - Add assets and scenes generator and the integration with data pipeline.
+    - We will release a sim-ready asset and scene layout generation framework for fast environment prototyping.
 
 - Models & Training Infrastructure Coming Soon:
     - We will release a modular VLA framework for fast prototyping and training of embodied agents.


### PR DESCRIPTION
## Description

This PR upgrades the README badge style and adds automated synchronization between README.md and docs/source/introduction.rst.

**Badge upgrades:**
- All existing badges upgraded to `for-the-badge` style (taller, bolder, more modern look)
- Added Python logo to the Python version badge

**Auto-sync mechanism:**
- New script `docs/scripts/sync_readme.py` converts README.md → introduction.rst using pypandoc
- Post-processes pandoc output to fix Sphinx-specific formatting (badges, NOTE directives, image paths, code blocks)
- Hooked into `docs/Makefile` so docs always build from the latest README.md
- Added sync step to CI workflow (`.github/workflows/main.yml`)
- Supports `--check` mode for CI staleness validation

**Other updates:**
- Updated roadmap content to reflect current priorities

Dependencies: `pypandoc_binary` added to `docs/requirements.txt`

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which improves an existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (existing functionality will not work without user modification)
- [x] Documentation update

## Screenshots

Badges before (default style) → after (`for-the-badge` style):

Before:
![before](https://img.shields.io/github/license/DexForce/EmbodiChain)

After:
![after](https://img.shields.io/github/license/DexForce/EmbodiChain?style=for-the-badge)

## Checklist

- [x] I have run the `black .` command to format the code base.
- [x] I have made corresponding changes to the documentation
- [x] Dependencies have been updated, if applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)