### PR TITLE
Fix pytorch solver qpos mapping

### DIFF
--- a/embodichain/lab/sim/solvers/pytorch_solver.py
+++ b/embodichain/lab/sim/solvers/pytorch_solver.py
@@ -303,6 +303,19 @@ class PytorchSolver(BaseSolver):
         is_within_limits = (qpos_mapped >= self.lower_qpos_limits) & (
             qpos_mapped <= self.upper_qpos_limits
         )
+
+        # if qpos_mapped is valid near zero, use it
+        k_zero = torch.ceil(
+            (-torch.pi - qpos) / two_pi
+        )  # [-pi, pi] is the valid range near zero
+        qpos_mapped_near_zero = qpos + k_zero * two_pi
+        is_within_limits_near_zero = (
+            qpos_mapped_near_zero >= self.lower_qpos_limits
+        ) & (qpos_mapped_near_zero <= self.upper_qpos_limits)
+        qpos_mapped[is_within_limits_near_zero] = qpos_mapped_near_zero[
+            is_within_limits_near_zero
+        ]
+
         return is_within_limits.all(dim=1), qpos_mapped
 
     @ensure_pose_shape


### PR DESCRIPTION
# Description

Now pytorch solver tend to map joint position near zero value. Advoid mapping joint position near lower joint limits.


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the `black .` command to format the code base.
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Dependencies have been updated, if applicable.
