### PR TITLE
docs: Remove AI coding agent skills references

### DIFF
--- a/docs/source/quick_start/install.md
+++ b/docs/source/quick_start/install.md
@@ -65,19 +65,3 @@ If the installation is successful, you will see a simulation window with a rende
 ```bash
 python scripts/tutorials/sim/create_scene.py --headless
 ```
-
-## Using an AI Coding Agent
-
-EmbodiChain ships with built-in skills for AI coding agents (Claude Code, Copilot CLI, etc.) that automate common development tasks:
-
-| Skill | Command | Purpose |
-|-------|---------|---------|
-| Add Task Env | `/add-task-env` | Scaffold a new `EmbodiedEnv` task |
-| Add Functor | `/add-functor` | Scaffold observation/reward/event/action/dataset/randomization functors |
-| Add Test | `/add-test` | Write tests following project conventions |
-| Pre-Commit Check | `/pre-commit-check` | Run all local CI checks before committing |
-| Create PR | `/pr` | Create a PR following the project template |
-| Benchmark | `/benchmark` | Write benchmark scripts for EmbodiChain modules |
-
-Run `/pre-commit-check` before every commit to catch formatting, header, annotation, and export issues locally — the same checks the CI pipeline enforces.
-```

--- a/docs/source/tutorial/modular_env.rst
+++ b/docs/source/tutorial/modular_env.rst
@@ -241,5 +241,3 @@ This tutorial demonstrates the full power of EmbodiChain's modular environment s
 
    - **/add-task-env** — Scaffold a new task environment with the correct file structure, ``@register_env`` decorator, base class methods, ``__init__.py`` update, and test stub.
    - **/add-functor** — Add observation, reward, event, or randomization functors with the correct signature and module placement.
-   - **/add-test** — Write tests following project conventions (pytest or class style, mock patterns, correct file placement).
-   - **/pre-commit-check** — Run all local CI checks (black, headers, ``__all__``, type annotations) before committing.


### PR DESCRIPTION
## Description

This PR removes references to AI coding agent skills from the documentation to simplify the user-facing content.

The following changes are made:
- Removed the "Using an AI Coding Agent" section from `docs/source/quick_start/install.md`
- Reduced the skills table in `docs/source/tutorial/modular_env.rst` to only include `/add-task-env` and `/add-functor`

## Type of change

- [x] Documentation update

## Screenshots

N/A

## Checklist

- [x] I have run the `black .` command to format the code base. (N/A - documentation only)
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Dependencies have been updated, if applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)