### PR TITLE
docs: add workspace analyzer visualization import

### DIFF
--- a/docs/source/features/workspace_analyzer/workspace_analyzer.md
+++ b/docs/source/features/workspace_analyzer/workspace_analyzer.md
@@ -22,6 +22,7 @@ from embodichain.lab.sim.utility.workspace_analyzer import (
     WorkspaceAnalyzerConfig,
     AnalysisMode
 )
+from embodichain.lab.sim.utility.workspace_analyzer.configs import VisualizationConfig
 
 # Setup simulation
 sim = SimulationManager(SimulationManagerCfg(headless=False, sim_device="cpu"))


### PR DESCRIPTION
## Summary
- Add the missing VisualizationConfig import in the Workspace Analyzer documentation quick start example.

## Validation
- Ran git diff --check.
- Confirmed VisualizationConfig is exported from workspace_analyzer.configs.