### PR TITLE
Fix PyPI release workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -157,40 +157,60 @@ jobs:
         uses: actions/deploy-pages@v4
 
 
-  # release:
-  #   if: startsWith(github.ref, 'refs/tags/v')
-  #   runs-on: Linux
-  #   permissions:
-  #     contents: write
-  #     id-token: write   # PyPI Trusted Publishing
+  release-build:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: lint
+    runs-on: Linux
 
-  #   container: *container_template
+    container: *container_template
 
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #       with:
-  #         fetch-depth: 0
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-  #     - name: (Release) Install build tools
-  #       run: |
-  #         python -m pip install --upgrade pip
-  #         pip install build
+      - name: (Release) Install build tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
 
-  #     - name: (Release) Build sdist and wheel
-  #       run: |
-  #         python -m build --wheel
+      - name: (Release) Build sdist and wheel
+        run: |
+          python -m build
 
-  #     # - name: (Release) Create GitHub Release (draft)
-  #     #   uses: softprops/action-gh-release@v2
-  #     #   with:
-  #     #     draft: true
-  #     #     generate_release_notes: true
-  #     #     files: |
-  #     #       dist/*
-  #     #   env:
-  #     #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # - name: (Release) Create GitHub Release (draft)
+      #   uses: softprops/action-gh-release@v2
+      #   with:
+      #     draft: true
+      #     generate_release_notes: true
+      #     files: |
+      #       dist/*
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  #     - name: (Release) Publish to PyPI
-  #       uses: pypa/gh-action-pypi-publish@release/v1
-  #       with:
-  #         password: ${{ secrets.PYPI_API_TOKEN }}
+      - name: (Release) Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-distributions
+          path: dist/
+
+  release-publish:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: release-build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/embodichain
+    permissions:
+      contents: read
+      id-token: write   # PyPI Trusted Publishing
+
+    steps:
+      - name: (Release) Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: python-distributions
+          path: dist/
+
+      - name: (Release) Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
# Description

Fix the tag release workflow so Python distributions are built in the existing container runner, uploaded as workflow artifacts, and published to PyPI from a dedicated GitHub-hosted job using Trusted Publishing.

Fixes #

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Not applicable.

## Checklist

- [ ] I have run the `black .` command to format the code base.
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Dependencies have been updated, if applicable.

## Validation

- Parsed `.github/workflows/main.yml` successfully as YAML.
- Did not run `black .`; this change only updates GitHub Actions YAML.
- Did not run package build locally because `python -m build` is not installed in the current environment.