### PR TITLE
docs: add academic publications page

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ To get started with EmbodiChain, follow these steps:
 
 We welcome contributions! Please see the [CONTRIBUTING.md](CONTRIBUTING.md) file in this repository for guidelines on how to get started.
 
+## Publications
+
+See [Academic Publications](docs/source/resources/publications/README.md) for a complete list of academic papers related to EmbodiChain.
+
 ## Citation
 
 If you find EmbodiChain helpful for your research, please consider citing our work:
@@ -67,14 +71,4 @@ If you find EmbodiChain helpful for your research, please consider citing our wo
    year = {2025},
    journal = {TechRxiv}
    }
-```
-
-```bibtex
-@inproceedings{Sim2RealVLA,
-    title = {Sim2Real {VLA}: Zero-Shot Generalization of Synthesized Skills to Realistic Manipulation},
-    author = {Runyi Zhao, Sheng Xu, Ruixing Jin, Yueci Deng, Yunxin Tai, Kui Jia, Guiliang Liu},
-    booktitle = {The Fourteenth International Conference on Learning Representations, ICLR},
-    year = {2026},
-    url = {https://openreview.net/forum?id=H4SyKHjd4c}
-}
 ```

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -54,6 +54,7 @@ Table of Contents
    resources/robot/index*
    resources/task/index*
    resources/roadmap.md
+   resources/publications/README.md
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/resources/publications/README.md
+++ b/docs/source/resources/publications/README.md
@@ -1,0 +1,79 @@
+# Academic Publications
+
+[![DOI](https://img.shields.io/badge/DOI-available-success?style=for-the-badge)](#)
+[![Year](https://img.shields.io/badge/year-2025--2026-blue?style=for-the-badge)](#)
+---
+
+This page contains bibliographic information for academic papers related to EmbodiChain. Papers are ordered by year (newest first).
+
+## Publications
+
+### 2026
+
+#### From Reaction to Anticipation: Proactive Failure Recovery through Agentic Task Graph for Robotic Manipulation
+
+**Authors:** Sheng Xu, Ruixing Jin, Huayi Zhou, Bo Yue, Guanren Qiao, Yueci Deng, Yunxin Tai, Kui Jia, Guiliang Liu
+
+**Venue:** Robotics: Science and Systems (RSS), 2026
+
+```bibtex
+@inproceedings{xu2026agentchord,
+  title = {From Reaction to Anticipation: Proactive Failure Recovery through Agentic Task Graph for Robotic Manipulation},
+  author = {Xu, Sheng and Jin, Ruixing and Zhou, Huayi and Yue, Bo and Qiao, Guanren and Deng, Yueci and Tai, Yunxin and Jia, Kui and Liu, Guiliang},
+  booktitle = {Robotics: Science and Systems (RSS)},
+  year = {2026}
+}
+```
+
+---
+
+#### Sim2Real VLA: Zero-Shot Generalization of Synthesized Skills to Realistic Manipulation
+
+**Authors:** Runyi Zhao, Sheng Xu, Ruixing Jin, Yueci Deng, Yunxin Tai, Kui Jia, Guiliang Liu
+
+**Venue:** The Fourteenth International Conference on Learning Representations (ICLR), 2026
+
+```bibtex
+@inproceedings{zhao2026sim2real,
+  title={Sim2real vla: Zero-shot generalization of synthesized skills to realistic manipulation},
+  author={Zhao, Runyi and Xu, Sheng and Jin, Ruixing and Deng, Yueci and Tai, Yunxin and Jia, Kui and Liu, Guiliang},
+  booktitle={The Fourteenth International Conference on Learning Representations},
+  year={2026}
+}
+```
+
+---
+
+### 2025
+
+#### DexScale: Automating Data Scaling for Sim2Real Generalizable Robot Control
+
+**Authors:** Guiliang Liu, Yueci Deng, Runyi Zhao, Huayi Zhou, Jian Chen, Jietao Chen, Ruiyan Xu, Yunxin Tai, Kui Jia
+
+**Venue:** Forty-Second International Conference on Machine Learning (ICML), 2025
+
+```bibtex
+@inproceedings{liu2025dexscale,
+  title={DexScale: automating data scaling for sim2real generalizable robot control},
+  author={Liu, Guiliang and Deng, Yueci and Zhao, Runyi and Zhou, Huayi and Chen, Jian and Chen, Jietao and Xu, Ruiyan and Tai, Yunxin and Jia, Kui},
+  booktitle={Forty-second international conference on machine learning},
+  year={2025}
+}
+```
+
+---
+
+## Adding a New Paper
+
+To add a new publication:
+
+1. Add a new section under the appropriate year heading
+2. Include the paper title, authors, venue, and BibTeX entry
+3. Keep entries ordered by year (newest first)
+
+## Core Framework Citations
+
+The following citations are kept in the main [README.md](https://github.com/DexForce/EmbodiChain) as they are considered core framework references:
+
+- **EmbodiChain** - The framework itself
+- **GS-World** - The underlying generative simulation paradigm


### PR DESCRIPTION
## Description

This PR adds a dedicated publications page to document all academic papers related to EmbodiChain. The new page provides a centralized location for maintaining and viewing publication information.

## Changes

- Created `docs/source/resources/publications/README.md` with:
  - Papers organized by year (newest first)
  - Each paper includes title, authors, venue, and BibTeX entry
  - Clear badges and consistent styling matching main README
  - Instructions for adding new publications

- Updated `README.md`:
  - Added Publications section with link to the new page
  - Kept core framework citations (EmbodiChain, GS-World) in main README for visibility

- Updated `docs/source/index.rst`:
  - Added publications page to documentation table of contents

## Type of change

- [x] Documentation update

## Checklist

- [x] I have run the `black .` command to format the code base.
- [x] I have made corresponding changes to the documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)