### PR TITLE
ci: fix multiversion docs deployment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,6 +45,7 @@ jobs:
       NVIDIA_DRIVER_CAPABILITIES: all
       NVIDIA_VISIBLE_DEVICES: all
       NVIDIA_DISABLE_REQUIRE: 1
+      DOCS_MAX_VERSIONS: 5
     container: *container_template
     steps:
       - uses: actions/checkout@v4
@@ -89,7 +90,7 @@ jobs:
 
             # Prune old release versions beyond the window
             mapfile -t TAG_DIRS < <(ls -d v*/ 2>/dev/null | sort -V)
-            while [[ ${#TAG_DIRS[@]} -gt ${DOCS_MAX_VERSIONS} ]]; do
+            while [[ ${#TAG_DIRS[@]} -gt ${DOCS_MAX_VERSIONS:-5} ]]; do
               echo "Pruning old version: ${TAG_DIRS[0]}"
               rm -rf "${TAG_DIRS[0]}"
               TAG_DIRS=("${TAG_DIRS[@]:1}")
@@ -145,7 +146,7 @@ jobs:
   publish:
     if: github.event_name == 'push'
     needs: build
-    runs-on: Linux
+    runs-on: ubuntu-latest
     permissions:
       pages: write
       id-token: write


### PR DESCRIPTION
## Description

This PR fixes three bugs that prevented the multiversion docs from deploying correctly to GitHub Pages.

**Bug 1 — `DOCS_MAX_VERSIONS` undefined (tag builds crashed):**
The bash prune loop at line 92 referenced `${DOCS_MAX_VERSIONS}` but the variable was never set in the build job environment. On every release tag push, bash hit `[[ N -gt ]]` → syntax error, failing the build step. Fixed by adding `DOCS_MAX_VERSIONS: 5` to the build job env and a `${DOCS_MAX_VERSIONS:-5}` bash fallback.

**Bug 2 — `publish` job on self-hosted runner (OIDC unavailable):**
`actions/deploy-pages@v4` requires OIDC token generation to authenticate with the GitHub Pages API. This is only guaranteed on GitHub-hosted runners (`ubuntu-latest`). The self-hosted `Linux` runner does not support OIDC, causing the deploy step to fail. Fixed by changing `publish.runs-on` to `ubuntu-latest`. The heavy build job still correctly uses the GPU container.

**Bug 3 — Main pushes overwriting release docs (already addressed in prior PRs):**
The cache-based approach from #263 and #266 is sound — this PR preserves it as-is. Main pushes restore the full cached site, rebuild only `main/`, and save back. Release docs are never touched by main pushes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (existing functionality will not work without user modification)
- [ ] Documentation update

## Checklist

- [x] I have run the `black .` command to format the code base.
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Dependencies have been updated, if applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)