### PR TITLE
refactor: optimize forward kinematics compilation in BaseSolver

### DIFF
--- a/embodichain/lab/sim/solvers/base_solver.py
+++ b/embodichain/lab/sim/solvers/base_solver.py
@@ -172,9 +172,13 @@ class BaseSolver(metaclass=ABCMeta):
                 device=self.device,
             )
 
+            def _fk_end_matrix(th):
+                return self.pk_serial_chain.forward_kinematics(
+                    th, end_only=True
+                ).get_matrix()
+
             self.compiled_fk = torch.compile(
-                self.pk_serial_chain.forward_kinematics_tensor,
-                fullgraph=True,
+                _fk_end_matrix,
                 dynamic=True,
             )
 
@@ -433,7 +437,7 @@ class BaseSolver(metaclass=ABCMeta):
             logger.log_error("Kinematic chain is not initialized.")
             return torch.eye(4, device=self.device)
         # Compute forward kinematics
-        ee_link_xpos = self.compiled_fk(qpos)[-1, :, :, :]
+        ee_link_xpos = self.compiled_fk(qpos)
 
         # Ensure batch format for TCP
         batch_size = qpos.shape[0]


### PR DESCRIPTION
This pull request updates the forward kinematics (FK) computation in the base solver to improve efficiency and correctness. The main changes involve how the FK function is compiled and how its output is handled in the `get_fk` method.

**Forward Kinematics Improvements:**

* Refactored the compiled FK function to use a new helper (`_fk_end_matrix`) that returns only the end-effector transformation matrix, streamlining FK computation.
* Updated the `get_fk` method to use the new FK output directly, removing the unnecessary indexing step since the compiled function now returns only the end-effector pose.