### PR TITLE
Fix rigid object init ordering and reset after GPU physics setup

### DIFF
--- a/embodichain/lab/sim/objects/rigid_object.py
+++ b/embodichain/lab/sim/objects/rigid_object.py
@@ -277,13 +277,14 @@ class RigidObject(BatchEntity):
                 first_entity.get_physical_attr().as_dict()
             )
 
-        if device.type == "cuda":
-            self._world.update(0.001)
-
         super().__init__(cfg, entities, device)
 
         # set default collision filter
         self._set_default_collision_filter()
+
+        if device.type == "cuda":
+            self._world.update(0.001)
+            self.reset()
 
         # update default center of mass pose (only for non-static bodies with body data).
         if self.body_data is not None:

--- a/embodichain/lab/sim/sim_manager.py
+++ b/embodichain/lab/sim/sim_manager.py
@@ -479,7 +479,11 @@ class SimulationManager:
         for robot in self._robots.values():
             robot.reallocate_body_data()
 
-        # We do not perform reallocate body data for robot.
+        # Re-establish rigid object positions after articulation resets, ensuring
+        # no articulation kinematics step has inadvertently corrupted the broadphase
+        # state for rigid bodies.
+        for rigid_obj in self._rigid_objects.values():
+            rigid_obj.reset()
 
         self._is_initialized_gpu_physics = True
 


### PR DESCRIPTION
## Description

This PR fixes two related issues with rigid object state during GPU physics initialization.

1. In `RigidObject.__init__`, the `world.update()` warm-up step was happening **before** `super().__init__()`, meaning collision filters and other base initialization had not yet been applied. The call order is corrected so that `world.update()` and a subsequent `reset()` occur **after** the full object initialization.

2. In `SimulationManager`, after robots reallocate body data, articulation kinematics steps can corrupt the broadphase state for rigid bodies. A new loop calls `rigid_obj.reset()` for all registered rigid objects to restore correct positions before marking GPU physics as initialized.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (existing functionality will not work without user modification)
- [ ] Documentation update

## Screenshots

N/A

## Checklist

- [x] I have run the `black .` command to format the code base.
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Dependencies have been updated, if applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)