### PR TITLE
Add YAML support for gym and RL training configs

### DIFF
--- a/configs/agents/rl/basic/cart_pole/gym_config.yaml
+++ b/configs/agents/rl/basic/cart_pole/gym_config.yaml
@@ -1,0 +1,66 @@
+id: CartPoleRL
+max_episodes: 5
+max_episode_steps: 500
+env:
+  events: {}
+  observations:
+    robot_qpos:
+      func: normalize_robot_joint_data
+      mode: modify
+      name: robot/qpos
+      params:
+        joint_ids:
+        - 0
+        - 1
+  rewards:
+    velocity_penalty:
+      func: joint_velocity_penalty
+      mode: add
+      weight: 0.005
+      params:
+        robot_uid: Cart
+        part_name: hand
+  actions:
+    delta_qpos:
+      func: DeltaQposTerm
+      params:
+        scale: 0.1
+  extensions: {}
+robot:
+  uid: Cart
+  urdf_cfg:
+    components:
+    - component_type: arm
+      urdf_path: CartPole/cart_pole.urdf
+  init_pos:
+  - 0.0
+  - 0.0
+  - 0.5
+  init_rot:
+  - 0.0
+  - 0.0
+  - 0.0
+  init_qpos:
+  - -0.2
+  - 0.07
+  drive_pros:
+    stiffness:
+      slider_to_cart: 10.0
+      cart_to_pole: 0.01
+    damping:
+      slider_to_cart: 1.0
+      cart_to_pole: 0.001
+    max_effort:
+      slider_to_cart: 100.0
+      cart_to_pole: 0.1
+  control_parts:
+    arm:
+    - slider_to_cart
+    hand:
+    - cart_to_pole
+sensor: []
+light: {}
+background: []
+rigid_object: []
+rigid_object_group: []
+articulation: []

--- a/configs/agents/rl/basic/cart_pole/train_config.yaml
+++ b/configs/agents/rl/basic/cart_pole/train_config.yaml
@@ -1,0 +1,71 @@
+trainer:
+  exp_name: cart_pole_ppo
+  gym_config: configs/agents/rl/basic/cart_pole/gym_config.yaml
+  seed: 42
+  device: cuda:0
+  headless: true
+  num_envs: 64
+  iterations: 1000
+  buffer_size: 1024
+  eval_freq: 200
+  save_freq: 200
+  use_wandb: false
+  wandb_project_name: embodichain-cart_pole
+  events:
+    eval:
+      record_camera:
+        func: record_camera_data_async
+        mode: interval
+        interval_step: 1
+        params:
+          name: main_cam
+          resolution:
+          - 640
+          - 480
+          eye:
+          - -1.4
+          - 1.4
+          - 2.5
+          target:
+          - 0
+          - 0
+          - 0.7
+          up:
+          - 0
+          - 0
+          - 1
+          intrinsics:
+          - 600
+          - 600
+          - 320
+          - 240
+          save_path: ./outputs/videos/eval
+  renderer: fast-rt
+policy:
+  name: actor_critic
+  actor:
+    type: mlp
+    network_cfg:
+      hidden_sizes:
+      - 256
+      - 256
+      activation: relu
+  critic:
+    type: mlp
+    network_cfg:
+      hidden_sizes:
+      - 256
+      - 256
+      activation: relu
+algorithm:
+  name: ppo
+  cfg:
+    learning_rate: 0.0001
+    n_epochs: 10
+    batch_size: 8192
+    gamma: 0.99
+    gae_lambda: 0.95
+    clip_coef: 0.2
+    ent_coef: 0.01
+    vf_coef: 0.5
+    max_grad_norm: 0.5

--- a/configs/agents/rl/basic/cart_pole/train_config_grpo.yaml
+++ b/configs/agents/rl/basic/cart_pole/train_config_grpo.yaml
@@ -1,0 +1,68 @@
+trainer:
+  exp_name: cart_pole_grpo
+  gym_config: configs/agents/rl/basic/cart_pole/gym_config.yaml
+  seed: 42
+  device: cuda:0
+  headless: true
+  num_envs: 64
+  iterations: 1000
+  buffer_size: 1024
+  eval_freq: 200
+  save_freq: 200
+  use_wandb: true
+  enable_eval: true
+  wandb_project_name: embodichain-cart_pole
+  events:
+    eval:
+      record_camera:
+        func: record_camera_data_async
+        mode: interval
+        interval_step: 1
+        params:
+          name: main_cam
+          resolution:
+          - 640
+          - 480
+          eye:
+          - -1.4
+          - 1.4
+          - 2.5
+          target:
+          - 0
+          - 0
+          - 0.7
+          up:
+          - 0
+          - 0
+          - 1
+          intrinsics:
+          - 600
+          - 600
+          - 320
+          - 240
+          save_path: ./outputs/videos/eval
+  renderer: hybrid
+policy:
+  name: actor_only
+  actor:
+    type: mlp
+    network_cfg:
+      hidden_sizes:
+      - 256
+      - 256
+      activation: relu
+algorithm:
+  name: grpo
+  cfg:
+    learning_rate: 0.0001
+    n_epochs: 10
+    batch_size: 8192
+    gamma: 0.99
+    clip_coef: 0.2
+    ent_coef: 0.01
+    kl_coef: 0.0
+    group_size: 4
+    eps: 1.0e-08
+    reset_every_rollout: true
+    max_grad_norm: 0.5
+    truncate_at_first_done: true

--- a/configs/gym/cobotmagic.yaml
+++ b/configs/gym/cobotmagic.yaml
@@ -1,0 +1,153 @@
+id: EmbodiedEnv-v1
+max_episodes: 10
+env:
+  events:
+    random_light:
+      func: randomize_light
+      mode: interval
+      interval_step: 10
+      params:
+        entity_cfg:
+          uid: light_1
+        position_range:
+        - - -0.5
+          - -0.5
+          - 2
+        - - 0.5
+          - 0.5
+          - 2
+        color_range:
+        - - 0.6
+          - 0.6
+          - 0.6
+        - - 1
+          - 1
+          - 1
+        intensity_range:
+        - 50.0
+        - 100.0
+    random_material:
+      func: randomize_visual_material
+      mode: interval
+      interval_step: 2
+      params:
+        entity_cfg:
+          uid: table
+        random_texture_prob: 0.5
+        texture_path: CocoBackground/coco
+        base_color_range:
+        - - 0.2
+          - 0.2
+          - 0.2
+        - - 1.0
+          - 1.0
+          - 1.0
+    random_robot:
+      func: randomize_visual_material
+      mode: interval
+      interval_step: 5
+      params:
+        entity_cfg:
+          uid: CobotMagic
+          link_names:
+          - .*
+        random_texture_prob: 0.5
+        texture_path: CocoBackground/coco
+        base_color_range:
+        - - 0.2
+          - 0.2
+          - 0.2
+        - - 1.0
+          - 1.0
+          - 1.0
+    record_camera:
+      func: record_camera_data
+      mode: interval
+      interval_step: 1
+      params:
+        name: cam1
+        resolution:
+        - 320
+        - 240
+        eye:
+        - 2
+        - 0
+        - 2
+        target:
+        - 0.5
+        - 0
+        - 1
+    replace_fork:
+      func: replace_assets_from_group
+      mode: reset
+      params:
+        entity_cfg:
+          uid: fork
+        folder_path: TableWare/tableware/fork/
+sensor:
+- uid: camera_1
+  sensor_type: Camera
+  width: 640
+  height: 480
+  enable_mask: true
+  enable_depth: true
+  extrinsics:
+    eye:
+    - 0.0
+    - 0.0
+    - 1.0
+    target:
+    - 0.0
+    - 0.0
+    - 0.0
+robot:
+  robot_type: CobotMagic
+  init_pos:
+  - 0.0
+  - 0.3
+  - 1.2
+light:
+  direct:
+  - uid: light_1
+    light_type: point
+    color:
+    - 1.0
+    - 1.0
+    - 1.0
+    intensity: 50.0
+    init_pos:
+    - 0
+    - 0
+    - 2
+    radius: 10.0
+background:
+- uid: table
+  shape:
+    shape_type: Mesh
+    fpath: ShopTableSimple/shop_table_simple.ply
+  attrs:
+    mass: 10.0
+  body_scale:
+  - 2
+  - 1.6
+  - 1
+  body_type: kinematic
+rigid_object:
+- uid: fork
+  shape:
+    shape_type: Mesh
+    fpath: TableWare/tableware/fork/standard_fork_scale.ply
+  body_scale:
+  - 0.75
+  - 0.75
+  - 1.0
+  init_pos:
+  - 0.0
+  - 0.0
+  - 1.0
+articulation:
+- fpath: SlidingBoxDrawer/SlidingBoxDrawer.urdf
+  init_pos:
+  - 0.5
+  - 0.0
+  - 0.85

--- a/configs/gym/dexforce_w1.yaml
+++ b/configs/gym/dexforce_w1.yaml
@@ -1,0 +1,134 @@
+id: EmbodiedEnv-v1
+max_episodes: 10
+env:
+  events:
+    random_light:
+      func: randomize_light
+      mode: interval
+      interval_step: 10
+      params:
+        entity_cfg:
+          uid: light_1
+        position_range:
+        - - -0.5
+          - -0.5
+          - 2
+        - - 0.5
+          - 0.5
+          - 2
+        color_range:
+        - - 0.6
+          - 0.6
+          - 0.6
+        - - 1
+          - 1
+          - 1
+        intensity_range:
+        - 50.0
+        - 100.0
+    random_material:
+      func: randomize_visual_material
+      mode: interval
+      interval_step: 2
+      params:
+        entity_cfg:
+          uid: table
+        random_texture_prob: 0.5
+        texture_path: CocoBackground/coco
+        base_color_range:
+        - - 0.2
+          - 0.2
+          - 0.2
+        - - 1.0
+          - 1.0
+          - 1.0
+    record_camera:
+      func: record_camera_data
+      mode: interval
+      interval_step: 1
+      params:
+        name: cam1
+        resolution:
+        - 320
+        - 240
+        eye:
+        - 2
+        - 0
+        - 2
+        target:
+        - 0.5
+        - 0
+        - 1
+    replace_fork:
+      func: replace_assets_from_group
+      mode: reset
+      params:
+        entity_cfg:
+          uid: fork
+        folder_path: TableWare/tableware/fork/
+sensor:
+- sensor_type: Camera
+  width: 640
+  height: 480
+  enable_mask: true
+  enable_depth: true
+  extrinsics:
+    eye:
+    - 0.0
+    - 0.0
+    - 1.0
+    target:
+    - 0.0
+    - 0.0
+    - 0.0
+robot:
+  robot_type: DexforceW1
+  init_pos:
+  - 0.0
+  - 1.0
+  - 0
+light:
+  direct:
+  - uid: light_1
+    light_type: point
+    color:
+    - 1.0
+    - 1.0
+    - 1.0
+    intensity: 50.0
+    init_pos:
+    - 0
+    - 0
+    - 2
+    radius: 10.0
+background:
+- uid: table
+  shape:
+    shape_type: Mesh
+    fpath: ShopTableSimple/shop_table_simple.ply
+  attrs:
+    mass: 10.0
+  body_scale:
+  - 2
+  - 1.6
+  - 1
+  body_type: kinematic
+rigid_object:
+- uid: fork
+  shape:
+    shape_type: Mesh
+    fpath: TableWare/tableware/fork/standard_fork_scale.ply
+  body_scale:
+  - 0.75
+  - 0.75
+  - 1.0
+  init_pos:
+  - 0.0
+  - 0.0
+  - 1.0
+articulation:
+- fpath: SlidingBoxDrawer/SlidingBoxDrawer.urdf
+  init_pos:
+  - 0.5
+  - 0.0
+  - 0.85

--- a/docs/source/api_reference/embodichain/embodichain.agents.rl.train.rst
+++ b/docs/source/api_reference/embodichain/embodichain.agents.rl.train.rst
@@ -13,7 +13,7 @@ Training entry points and command-line helpers for launching RL experiments.
 
    .. autosummary::
    
-      main
+      cli
       parse_args
       train_from_config
 

--- a/docs/source/features/generative_sim/agents.md
+++ b/docs/source/features/generative_sim/agents.md
@@ -76,14 +76,14 @@ Run the agent system with the following command:
 ```bash
 python embodichain/lab/scripts/run_agent.py \
     --task_name YourTask \
-    --gym_config configs/gym/your_task/gym_config.json \
+    --gym_config configs/gym/your_task/gym_config.yaml \
     --agent_config configs/gym/agent/your_agent/agent_config.json \
     --regenerate False
 ```
 
 **Parameters:**
 - `--task_name`: Name identifier for the task
-- `--gym_config`: Path to the gym environment configuration file
+- `--gym_config`: Path to the gym environment configuration file (``.json``, ``.yaml``, or ``.yml``)
 - `--agent_config`: Path to the agent configuration file (defines prompts and agent behavior)
 - `--regenerate`: If `True`, forces regeneration of plans/code even if cached
 

--- a/docs/source/features/online_data.md
+++ b/docs/source/features/online_data.md
@@ -34,7 +34,7 @@ from embodichain.agents.engine.data import OnlineDataEngine, OnlineDataEngineCfg
 cfg = OnlineDataEngineCfg(
     buffer_size=2,           # number of trajectories kept in the ring buffer
     state_dim=6,             # example state dimension
-    gym_config=your_gym_cfg, # parsed JSON config for the task
+    gym_config=your_gym_cfg, # parsed gym config for the task (JSON or YAML)
 )
 engine = OnlineDataEngine(cfg)
 engine.start()

--- a/docs/source/guides/cli.md
+++ b/docs/source/guides/cli.md
@@ -115,28 +115,28 @@ Launch a Gymnasium environment for data generation or interactive preview.
 
 ```bash
 # Run an environment with a gym config file
-python -m embodichain run-env --gym_config path/to/config.json
+python -m embodichain run-env --gym_config path/to/config.yaml
 
 # Run with multiple environments on GPU
 python -m embodichain run-env \
-    --gym_config config.json \
+    --gym_config config.yaml \
     --num_envs 4 \
     --device cuda \
     --gpu_id 0
 
 # Preview mode for interactive development
-python -m embodichain run-env --gym_config config.json --preview
+python -m embodichain run-env --gym_config config.yaml --preview
 
 # Headless execution
-python -m embodichain run-env --gym_config config.json --headless
+python -m embodichain run-env --gym_config config.yaml --headless
 ```
 
 ### Arguments
 
 | Argument | Default | Description |
 |---|---|---|
-| ``--gym_config`` | *(required)* | Path to gym config file |
-| ``--action_config`` | ``None`` | Path to action config file |
+| ``--gym_config`` | *(required)* | Path to gym config file (``.json``, ``.yaml``, or ``.yml``) |
+| ``--action_config`` | ``None`` | Path to action config file (``.json``, ``.yaml``, or ``.yml``) |
 | ``--num_envs`` | ``1`` | Number of parallel environments |
 | ``--device`` | ``cpu`` | Device (``cpu`` or ``cuda``) |
 | ``--headless`` | ``False`` | Run in headless mode |
@@ -153,3 +153,37 @@ When ``--preview`` is enabled, an interactive REPL is available:
 
 - **``p``** — enter an IPython embed session with ``env`` in scope
 - **``q``** — quit
+
+---
+
+## Train RL
+
+Launch reinforcement learning training from a JSON or YAML config file.
+
+```bash
+# Train with a config file (JSON or YAML)
+python -m embodichain train-rl --config configs/agents/rl/basic/cart_pole/train_config.yaml
+
+# JSON configs remain supported
+python -m embodichain train-rl --config configs/agents/rl/push_cube/train_config.json
+
+# Multi-GPU distributed training
+torchrun --nproc_per_node=2 -m embodichain train-rl \
+    --config configs/agents/rl/push_cube/train_config.yaml \
+    --distributed
+```
+
+The direct module entry point remains available:
+
+```bash
+python -m embodichain.agents.rl.train --config configs/agents/rl/basic/cart_pole/train_config.yaml
+```
+
+### Arguments
+
+| Argument | Default | Description |
+|---|---|---|
+| ``--config`` | *(required)* | Path to the RL training config file (``.json``, ``.yaml``, or ``.yml``) |
+| ``--distributed`` | ``None`` | Enable multi-GPU distributed training. If omitted, uses ``trainer.distributed`` from the config. Use ``--no-distributed`` to force single-process training. |
+
+Outputs are written to ``./outputs/<exp_name>_<timestamp>/`` (TensorBoard logs and checkpoints). See the :doc:`../tutorial/rl` tutorial for config structure and training workflow.

--- a/docs/source/guides/configuration.md
+++ b/docs/source/guides/configuration.md
@@ -1,6 +1,6 @@
 # Configuration Guide
 
-EmbodiChain uses a declarative configuration system built on Python dataclasses. This guide explains the key patterns: `@configclass`, `FunctorCfg`, and JSON configuration files.
+EmbodiChain uses a declarative configuration system built on Python dataclasses. This guide explains the key patterns: `@configclass`, `FunctorCfg`, and JSON/YAML configuration files.
 
 ---
 
@@ -122,11 +122,22 @@ class MyEventCfg:
 
 ---
 
-## JSON Configuration
+## JSON and YAML Configuration
 
-For RL training and data generation, EmbodiChain uses JSON config files. The JSON config mirrors the Python config structure but uses string names instead of direct function references.
+For RL training and data generation, EmbodiChain uses file-based configs (`.json`, `.yaml`, or `.yml`). The file format mirrors the Python config structure but uses string names instead of direct function references.
 
-### Environment Config (`gym_config.json`)
+Configs are loaded with `embodichain.utils.utility.load_config`, which selects the parser from the file extension. Both formats produce the same in-memory dictionary and are passed to `config_to_cfg()` for environment setup.
+
+Example paths in the repository:
+
+| Use case | JSON example | YAML example |
+|---|---|---|
+| Gym environment | `configs/gym/cobotmagic.json` | `configs/gym/cobotmagic.yaml` |
+| RL training | `configs/agents/rl/basic/cart_pole/train_config.json` | `configs/agents/rl/basic/cart_pole/train_config.yaml` |
+
+When a training config references a gym config (via `trainer.gym_config`), the nested path may also use any supported extension.
+
+### Environment Config (`gym_config.json` / `gym_config.yaml`)
 
 ```json
 {
@@ -201,7 +212,7 @@ For RL training and data generation, EmbodiChain uses JSON config files. The JSO
 }
 ```
 
-### RL Training Config (`train_config.json`)
+### RL Training Config (`train_config.json` / `train_config.yaml`)
 
 ```json
 {
@@ -249,11 +260,36 @@ For RL training and data generation, EmbodiChain uses JSON config files. The JSO
 }
 ```
 
+The same structure in YAML:
+
+```yaml
+trainer:
+  exp_name: push_cube
+  seed: 42
+  device: cuda:0
+  iterations: 500
+  buffer_size: 1024
+  gym_config: configs/agents/rl/basic/cart_pole/gym_config.yaml
+policy:
+  name: actor_critic
+  actor:
+    type: mlp
+    network_cfg:
+      hidden_sizes: [256, 256]
+      activation: relu
+algorithm:
+  name: ppo
+  cfg:
+    learning_rate: 0.0001
+    batch_size: 64
+    gamma: 0.99
+```
+
 ---
 
 ## String-Based Function Resolution
 
-In JSON configs, functor functions are specified by name (string). EmbodiChain resolves these strings at runtime by searching registered modules. For example:
+In JSON and YAML configs, functor functions are specified by name (string). EmbodiChain resolves these strings at runtime by searching registered modules. For example:
 
 - `"distance_between_objects"` resolves to `embodichain.lab.gym.envs.managers.rewards.distance_between_objects`
 - `"DeltaQposTerm"` resolves to `embodichain.lab.gym.envs.managers.actions.DeltaQposTerm`
@@ -263,9 +299,9 @@ When writing custom functors, make sure they are imported in the module's `__ini
 
 ---
 
-## `SceneEntityCfg` in JSON
+## `SceneEntityCfg` in Config Files
 
-When referencing scene entities in JSON, use a dictionary with a `uid` key:
+When referencing scene entities in JSON or YAML, use a dictionary with a `uid` key:
 
 ```json
 {"uid": "my_cube"}
@@ -277,11 +313,11 @@ This is automatically converted to a `SceneEntityCfg` object at runtime.
 
 ## Tips
 
-1. **Start from an existing config.** Copy a config file from `configs/gym/` and modify it for your task.
+1. **Start from an existing config.** Copy a config file from `configs/gym/` or `configs/agents/rl/` and modify it for your task.
 2. **Use Python configs for development.** They provide IDE auto-completion and type checking.
-3. **Use JSON configs for experiments.** They are easier to version, diff, and share.
+3. **Use JSON or YAML configs for experiments.** YAML is often easier to read for nested structures; JSON remains fully supported.
 4. **Validate configs early.** Run your environment with a short episode count to catch config errors before long training runs.
-5. **Keep config pairs together.** For action-bank tasks, version `gym_config.json` and `action_config.json` together.
+5. **Keep config pairs together.** For action-bank tasks, version `gym_config` and `action_config` together (either format).
 
 ---
 

--- a/docs/source/guides/custom_functors.md
+++ b/docs/source/guides/custom_functors.md
@@ -270,7 +270,7 @@ class DeltaQposTerm(ActionTerm):
         return action * self._scale + self._env.robot.get_qpos()
 ```
 
-Register it in JSON config:
+Register it in your gym config file (JSON or YAML):
 
 ```json
 "actions": {

--- a/docs/source/overview/gym/env.md
+++ b/docs/source/overview/gym/env.md
@@ -215,7 +215,7 @@ actions = MyRLActionCfg()
 extensions = {"success_threshold": 0.1}  # Task-specific parameters
 ```
 
-In JSON config, use the ``actions`` section:
+In a gym config file, use the ``actions`` section:
 
 ```json
 "actions": {

--- a/docs/source/overview/rl/algorithm.md
+++ b/docs/source/overview/rl/algorithm.md
@@ -33,7 +33,7 @@ This module contains the core implementations of reinforcement learning algorith
 
 ### Config Classes
 - `AlgorithmCfg`, `PPOCfg`, `GRPOCfg`: Centralized management of learning rate, batch size, clip_coef, ent_coef, vf_coef, and other parameters.
-- Supports automatic loading from JSON config files for batch experiments and parameter tuning.
+- Supports automatic loading from JSON or YAML config files for batch experiments and parameter tuning.
 - Can be extended via inheritance for multiple algorithms and tasks.
 
 ## Code Example
@@ -48,7 +48,7 @@ class PPO(BaseAlgorithm):
 ```
 
 ## Usage Recommendations
-- It is recommended to manage all algorithm parameters via config classes and JSON config files for reproducibility and tuning.
+- It is recommended to manage all algorithm parameters via config classes and JSON or YAML config files for reproducibility and tuning.
 - Supports multi-environment parallel collection to improve sampling efficiency.
 - Custom algorithm classes can be implemented to extend new RL methods.
 - **GRPO**: Use `actor_only` policy (no Critic). Set `kl_coef=0` for from-scratch training (CartPole, dense reward); set `kl_coef=0.02` for VLA/LLM fine-tuning.

--- a/docs/source/overview/rl/config.md
+++ b/docs/source/overview/rl/config.md
@@ -16,7 +16,7 @@ This module defines configuration classes for RL algorithms, centralizing the ma
 - Supports inheritance and extension (e.g., PPOCfg adds clip_coef, ent_coef, vf_coef; GRPOCfg adds group_size, kl_coef, truncate_at_first_done).
 
 ### Automatic Loading
-- Supports automatic parsing of JSON config files; the main training script injects parameters automatically.
+- Supports automatic parsing of JSON and YAML config files; the main training script injects parameters automatically.
 - Decouples config from code, making batch experiments and parameter tuning easier.
 
 ## Usage Example
@@ -76,7 +76,7 @@ GRPO example (for Embodied AI / from-scratch training):
 - Supports parameter validation, default values, and type hints.
 
 ## Practical Tips
-- It is recommended to manage all experiment parameters via JSON config files for reproducibility and tuning.
+- It is recommended to manage all experiment parameters via JSON or YAML config files for reproducibility and tuning.
 - Supports multi-algorithm config for easy comparison and automation.
 
 ---

--- a/docs/source/overview/rl/index.rst
+++ b/docs/source/overview/rl/index.rst
@@ -52,7 +52,7 @@ Extension and Customization
 
 Common Issues and Best Practices
 -------------------------------
-- Config files are recommended to use JSON for easy management and reproducibility.
+- Config files may use JSON or YAML for easy management and reproducibility.
 - Parallel environment sampling can significantly improve training efficiency.
 - The event-driven mechanism allows flexible insertion of custom logic (such as evaluation, saving, callbacks).
 - It is recommended to use WandB/TensorBoard for training process visualization.
@@ -62,7 +62,7 @@ Example
 
 .. code-block:: bash
 
-    python train.py --config configs/agents/rl/push_cube/train_config.json
+    python -m embodichain train-rl --config configs/agents/rl/basic/cart_pole/train_config.yaml
 
 For more details, please refer to the source code and API documentation of each submodule.
 

--- a/docs/source/overview/rl/multi_gpu.md
+++ b/docs/source/overview/rl/multi_gpu.md
@@ -15,13 +15,13 @@ EmbodiChain supports distributed RL training across multiple GPUs using PyTorch 
 Use `torchrun` with `--nproc_per_node` equal to the number of GPUs, and add `--distributed`:
 
 ```bash
-torchrun --nproc_per_node=2 -m embodichain.agents.rl.train --config <config_path> --distributed
+torchrun --nproc_per_node=2 -m embodichain train-rl --config <config_path> --distributed
 ```
 
 Example:
 
 ```bash
-torchrun --nproc_per_node=2 -m embodichain.agents.rl.train --config configs/agents/rl/push_cube/train_config.json --distributed
+torchrun --nproc_per_node=2 -m embodichain train-rl --config configs/agents/rl/push_cube/train_config.yaml --distributed
 ```
 
 No config file changes needed; `device` and `gpu_id` are overridden automatically per rank.
@@ -32,7 +32,7 @@ Use `CUDA_VISIBLE_DEVICES` to select which GPUs to use. The processes will see o
 
 ```bash
 # Use GPU 0 and 1
-CUDA_VISIBLE_DEVICES=0,1 torchrun --nproc_per_node=2 -m embodichain.agents.rl.train --config <config_path> --distributed
+CUDA_VISIBLE_DEVICES=0,1 torchrun --nproc_per_node=2 -m embodichain train-rl --config <config_path> --distributed
 ```
 
 `--nproc_per_node` must equal the number of GPUs in `CUDA_VISIBLE_DEVICES`.

--- a/docs/source/overview/rl/train_script.md
+++ b/docs/source/overview/rl/train_script.md
@@ -5,7 +5,7 @@ This module provides the RL training entry script, responsible for parsing confi
 ## Main Structure and Flow
 
 ### train.py
-- Main training script, supports command-line arguments (such as --config), automatically loads JSON config.
+- Main training script, supports command-line arguments (such as --config), automatically loads JSON or YAML config.
 - Initializes device, random seed, output directory, and logging (TensorBoard/WandB).
 - Loads environment config, supports multi-environment parallelism and evaluation environments.
 - Builds policy (e.g., actor-critic), algorithm (e.g., PPO), and Trainer.
@@ -14,7 +14,7 @@ This module provides the RL training entry script, responsible for parsing confi
 
 ## Argument Parsing
 - Supports command-line arguments:
-    - `--config`: Specify the path to the config file (JSON only).
+    - `--config`: Specify the path to the config file (``.json``, ``.yaml``, or ``.yml``).
     - `--distributed`: Enable multi-GPU distributed training.
 - The config file includes parameters for trainer, policy, algorithm, events, and other modules.
 - See [Multi-GPU Training](multi_gpu.md) for distributed training.
@@ -26,7 +26,7 @@ This module provides the RL training entry script, responsible for parsing confi
 - Supports TensorBoard/WandB logging, automatically records the training process.
 
 ## Training Flow
-1. Load the JSON config file and parse parameters for each module.
+1. Load the config file and parse parameters for each module.
 2. Initialize environment, policy, algorithm, and Trainer.
 3. Enter the main training loop: collect data, update policy, record logs.
 4. Periodically evaluate and save the model.
@@ -34,7 +34,7 @@ This module provides the RL training entry script, responsible for parsing confi
 
 ## Usage Example
 ```bash
-python train.py --config configs/agents/rl/push_cube/train_config.json
+python -m embodichain train-rl --config configs/agents/rl/basic/cart_pole/train_config.yaml
 ```
 
 ## Extension and Customization
@@ -43,7 +43,7 @@ python train.py --config configs/agents/rl/push_cube/train_config.json
 - Config-driven management for batch experiments and parameter tuning.
 
 ## Practical Tips
-- It is recommended to manage all experiment parameters via JSON config files for reproducibility and tuning.
+- It is recommended to manage all experiment parameters via JSON or YAML config files for reproducibility and tuning.
 - Supports multi-environment and event extension to improve training flexibility.
 - Logging and checkpoint management help with experiment tracking and recovery.
 

--- a/docs/source/tutorial/data_generation.rst
+++ b/docs/source/tutorial/data_generation.rst
@@ -5,7 +5,7 @@ Data Generation
 
 .. currentmodule:: embodichain.lab.gym
 
-This tutorial shows how to generate synthetic expert demonstration datasets using EmbodiChain's built-in environment rollout and dataset manager. You will learn how to configure LeRobot recording in ``gym_config.json``, how ``run_env.py`` builds an environment from configuration files, and how completed episodes are automatically saved to disk.
+This tutorial shows how to generate synthetic expert demonstration datasets using EmbodiChain's built-in environment rollout and dataset manager. You will learn how to configure LeRobot recording in a gym config file (``.json``, ``.yaml``, or ``.yml``), how ``run_env.py`` builds an environment from configuration files, and how completed episodes are automatically saved to disk.
 
 Overview
 ~~~~~~~~
@@ -24,8 +24,8 @@ What This Tutorial Records
 
 This page documents the full path from task configuration to saved dataset:
 
-1. Prepare a task ``gym_config.json``.
-2. Prepare an ``action_config.json`` if the task uses the action bank.
+1. Prepare a task gym config (e.g. ``gym_config.json`` or ``gym_config.yaml``).
+2. Prepare an action config if the task uses the action bank (same supported extensions).
 3. Launch the environment rollout with ``run-env``.
 4. Let the dataset manager automatically save completed episodes.
 
@@ -34,7 +34,7 @@ Example Task
 
 As a concrete example, this tutorial uses a real action-bank task shipped in the repository:
 
-- ``configs/gym/pour_water/gym_config.json`` defines the simulation scene and dataset recording behavior.
+- ``configs/gym/pour_water/gym_config.json`` defines the simulation scene and dataset recording behavior (YAML equivalents such as ``configs/gym/cobotmagic.yaml`` are also supported).
 - ``configs/gym/pour_water/action_config.json`` defines the action-bank graph used to solve the task.
 
 The Code
@@ -58,7 +58,7 @@ The rollout script builds the environment from configuration, generates expert t
 Step 1: Prepare the Task Configuration
 --------------------------------------
 
-The first input to the pipeline is the task ``gym_config.json``. In the example below, the same file contains rollout settings, scene randomization, observations, dataset recording, and robot or sensor definitions.
+The first input to the pipeline is the task gym config file. In the example below, the same file contains rollout settings, scene randomization, observations, dataset recording, and robot or sensor definitions.
 
 The rollout settings include the episode count:
 
@@ -129,7 +129,7 @@ Note: Action bank is not the only way to generate demonstrations. Depending on t
 Step 3: Launch the Environment Rollout
 --------------------------------------
 
-The rollout script parses command-line arguments, loads ``gym_config.json`` and ``action_config.json``, converts them into environment configuration objects, creates the environment instance, and then runs offline rollout for ``max_episodes`` episodes:
+The rollout script parses command-line arguments, loads the gym and action config files, converts them into environment configuration objects, creates the environment instance, and then runs offline rollout for ``max_episodes`` episodes:
 
 .. literalinclude:: ../../../embodichain/lab/scripts/run_env.py
    :language: python
@@ -153,8 +153,8 @@ When ``--preview`` is enabled, the script opens the environment in an interactiv
 
 Useful CLI arguments:
 
-- **--gym_config**: Path to the task JSON configuration.
-- **--action_config**: Path to the action-bank configuration.
+- **--gym_config**: Path to the task config file (``.json``, ``.yaml``, or ``.yml``).
+- **--action_config**: Path to the action-bank config file (``.json``, ``.yaml``, or ``.yml``).
 - **--num_envs**: Number of environments to run in parallel.
 - **--device**: Simulation device, such as ``cpu`` or ``cuda``.
 - **--headless**: Run without GUI for faster generation.
@@ -182,7 +182,7 @@ In a practical workflow, the output of this stage is the synthesized dataset its
 Best Practices
 ~~~~~~~~~~~~~~
 
-- **Keep the config pair together**: Version ``gym_config.json`` and ``action_config.json`` together for action-bank tasks.
+- **Keep the config pair together**: Version gym and action configs together for action-bank tasks (either JSON or YAML).
 - **Use valid scripted policies**: Make sure ``create_demo_action_list()`` returns executable trajectories for the current scene.
 - **Use ``--headless`` for throughput**: Disable the GUI when generating large datasets.
 - **Use ``--preview`` and ``--filter_dataset_saving`` for debugging**: Inspect task logic without writing datasets.

--- a/docs/source/tutorial/rl.rst
+++ b/docs/source/tutorial/rl.rst
@@ -5,7 +5,7 @@ Reinforcement Learning Training
 
 .. currentmodule:: embodichain.agents.rl
 
-This tutorial shows you how to train reinforcement learning agents using EmbodiChain's RL framework. You'll learn how to configure training via JSON, set up environments, policies, and algorithms, and launch training sessions.
+This tutorial shows you how to train reinforcement learning agents using EmbodiChain's RL framework. You'll learn how to configure training via JSON or YAML, set up environments, policies, and algorithms, and launch training sessions.
 
 Overview
 ~~~~~~~~
@@ -16,7 +16,7 @@ The RL framework provides a modular, extensible stack for robotics tasks:
 - **Algorithm**: Controls data collection process (interacts with environment, fills buffer, computes advantages/returns) and updates the policy (e.g., PPO)
 - **Policy**: Neural network models implementing a unified interface (get_action/get_value/evaluate_actions)
 - **Buffer**: On-policy rollout storage and minibatch iterator (managed by algorithm)
-- **Env Factory**: Build environments from a JSON config via registry
+- **Env Factory**: Build environments from a JSON or YAML config via registry
 
 Architecture
 ~~~~~~~~~~~~
@@ -27,28 +27,35 @@ The framework follows a clean separation of concerns:
 - **Algorithm**: Controls data collection process (interacts with environment, fills buffer, computes advantages/returns) and updates the policy (e.g., PPO)
 - **Policy**: Neural network models implementing a unified interface
 - **Buffer**: On-policy rollout storage and minibatch iterator (managed by algorithm)
-- **Env Factory**: Build environments from a JSON config via registry
+- **Env Factory**: Build environments from a JSON or YAML config via registry
 
 The core components and their relationships:
 
 - Trainer → Policy, Env, Algorithm (via callbacks for statistics)
 - Algorithm → Policy, RolloutBuffer (algorithm manages its own buffer)
 
-Configuration via JSON
-~~~~~~~~~~~~~~~~~~~~~~
+Configuration via JSON or YAML
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Training is configured via a JSON file that defines runtime settings, environment, policy, and algorithm parameters.
+Training is configured via a JSON or YAML file that defines runtime settings, environment, policy, and algorithm parameters. EmbodiChain loads either format with ``load_config()``; the nested ``trainer.gym_config`` path supports the same extensions.
 
 Example Configuration
 ---------------------   
 
-The configuration file (e.g., ``train_config.json``) is located in ``configs/agents/rl/push_cube``:
+The configuration file (e.g., ``train_config.json`` or ``train_config.yaml``) is located in ``configs/agents/rl/push_cube`` or ``configs/agents/rl/basic/cart_pole``:
 
 .. dropdown:: Example: train_config.json
    :icon: code
 
    .. literalinclude:: ../../../configs/agents/rl/push_cube/train_config.json
       :language: json
+      :linenos:
+
+.. dropdown:: Example: train_config.yaml (CartPole)
+   :icon: code
+
+   .. literalinclude:: ../../../configs/agents/rl/basic/cart_pole/train_config.yaml
+      :language: yaml
       :linenos:
 
 Configuration Sections
@@ -67,7 +74,7 @@ The ``trainer`` section controls experiment setup:
 - **buffer_size**: Steps collected per rollout (e.g., 1024)
 - **eval_freq**: Frequency of evaluation (in steps)
 - **save_freq**: Frequency of checkpoint saving (in steps)
-- **use_wandb**: Whether to enable Weights & Biases logging (set in JSON config)
+- **use_wandb**: Whether to enable Weights & Biases logging (set in the config file)
 - **wandb_project_name**: Weights & Biases project name
 
 Environment Configuration
@@ -203,7 +210,7 @@ The Script Explained
 
 The training script performs the following steps:
 
-1. **Parse Configuration**: Loads JSON config and extracts runtime/env/policy/algorithm blocks
+1. **Parse Configuration**: Loads the config file (``.json``, ``.yaml``, or ``.yml``) and extracts runtime/env/policy/algorithm blocks
 2. **Setup**: Initializes device, seeds, output directories, TensorBoard, and Weights & Biases
 3. **Build Components**:
    - Environment via ``build_env()`` factory
@@ -219,7 +226,13 @@ To start training, run:
 
 .. code-block:: bash
 
-   python -m embodichain.agents.rl.train --config configs/agents/rl/push_cube/train_config.json
+   python -m embodichain train-rl --config configs/agents/rl/basic/cart_pole/train_config.yaml
+
+JSON configs are also supported:
+
+.. code-block:: bash
+
+   python -m embodichain train-rl --config configs/agents/rl/push_cube/train_config.json
 
 Outputs
 -------
@@ -276,7 +289,7 @@ All policies must inherit from the ``Policy`` abstract base class:
 Available Policies
 ------------------
 
-- **ActorCritic**: MLP-based Gaussian policy with learnable log_std. Requires external ``actor`` and ``critic`` modules to be provided (defined in JSON config). Used with PPO.
+- **ActorCritic**: MLP-based Gaussian policy with learnable log_std. Requires external ``actor`` and ``critic`` modules to be provided (defined in the training config file). Used with PPO.
 - **ActorOnly**: Actor-only policy without Critic. Used with GRPO (group-relative advantage estimation).
 - **VLAPlaceholderPolicy**: Placeholder for Vision-Language-Action policies
 
@@ -372,7 +385,7 @@ To add a new RL environment:
            return is_success, is_fail, metrics
 
 
-2. Configure the environment in your JSON config with ``actions`` and ``extensions``:
+2. Configure the environment in your config file with ``actions`` and ``extensions``:
 
 .. code-block:: json
 
@@ -402,7 +415,7 @@ Best Practices
 
 - **Use EmbodiedEnv with Action Manager for RL Tasks**: Inherit from ``EmbodiedEnv`` and configure ``actions`` in your config. The Action Manager handles action preprocessing (delta_qpos, qpos, qvel, qf, eef_pose) in a modular way.
 
-- **Action Configuration**: Use the ``actions`` field in your JSON config. Example: ``"delta_qpos": {"func": "DeltaQposTerm", "params": {"scale": 0.1}}``.
+- **Action Configuration**: Use the ``actions`` field in your config file. Example: ``"delta_qpos": {"func": "DeltaQposTerm", "params": {"scale": 0.1}}``.
 
 - **Device Management**: Device is single-sourced from ``runtime.cuda``. All components (trainer/algorithm/policy/env) share the same device.
 

--- a/embodichain/__main__.py
+++ b/embodichain/__main__.py
@@ -20,6 +20,7 @@ Usage examples::
 
     python -m embodichain preview-asset --asset_path /path/to/asset.usda --preview
     python -m embodichain run-env --env_name my_env
+    python -m embodichain train-rl --config configs/agents/rl/push_cube/train_config.json
     python -m embodichain annotate-grasp --mesh_path /path/to/object.ply
 """
 
@@ -74,6 +75,15 @@ def main() -> None:
     )
 
     annotate_grasp_parser.set_defaults(func=annotate_grasp_cli)
+
+    # -- train-rl ------------------------------------------------------------
+    train_rl_parser = subparsers.add_parser(
+        "train-rl",
+        help="Train an RL agent from a config file (.json, .yaml, or .yml).",
+    )
+    from embodichain.agents.rl.train import cli as train_rl_cli
+
+    train_rl_parser.set_defaults(func=train_rl_cli)
 
     # -- Parse ---------------------------------------------------------------
     # If no sub-command is given, print help and exit.

--- a/embodichain/agents/rl/train.py
+++ b/embodichain/agents/rl/train.py
@@ -22,7 +22,6 @@ from pathlib import Path
 import numpy as np
 import torch
 import wandb
-import json
 from torch.utils.tensorboard import SummaryWriter
 from copy import deepcopy
 
@@ -34,7 +33,7 @@ from embodichain.agents.rl.utils.trainer import Trainer
 from embodichain.utils import logger
 from embodichain.lab.gym.envs.tasks.rl import build_env
 from embodichain.lab.gym.utils.gym_utils import config_to_cfg, DEFAULT_MANAGER_MODULES
-from embodichain.utils.utility import load_json
+from embodichain.utils.utility import load_config
 from embodichain.utils.module_utils import find_function_from_modules
 from embodichain.lab.sim import SimulationManagerCfg
 from embodichain.lab.sim.cfg import RenderCfg
@@ -44,7 +43,12 @@ from embodichain.lab.gym.envs.managers.cfg import EventCfg
 def parse_args():
     """Parse command line arguments."""
     parser = argparse.ArgumentParser()
-    parser.add_argument("--config", type=str, required=True, help="Path to JSON config")
+    parser.add_argument(
+        "--config",
+        type=str,
+        required=True,
+        help="Path to training config file (.json, .yaml, or .yml).",
+    )
     parser.add_argument(
         "--distributed",
         action=argparse.BooleanOptionalAction,
@@ -58,16 +62,15 @@ def train_from_config(config_path: str, distributed: bool | None = None):
     """Run training from a config file path.
 
     Args:
-        config_path: Path to the JSON config file
+        config_path: Path to the training config file (.json, .yaml, or .yml).
         distributed: If True, run multi-GPU distributed training.
             If None, use trainer.distributed from config.
     """
-    with open(config_path, "r") as f:
-        cfg_json = json.load(f)
+    cfg_data = load_config(config_path)
 
-    trainer_cfg = cfg_json["trainer"]
-    policy_block = cfg_json["policy"]
-    algo_block = cfg_json["algorithm"]
+    trainer_cfg = cfg_data["trainer"]
+    policy_block = cfg_data["policy"]
+    algo_block = cfg_data["algorithm"]
 
     # Resolve distributed flag
     if distributed is None:
@@ -180,13 +183,13 @@ def train_from_config(config_path: str, distributed: bool | None = None):
     # Initialize Weights & Biases (optional)
     use_wandb = trainer_cfg.get("use_wandb", False)
     if use_wandb and rank == 0:
-        wandb.init(project=wandb_project_name, name=exp_name, config=cfg_json)
+        wandb.init(project=wandb_project_name, name=exp_name, config=cfg_data)
 
     gym_config_path = Path(trainer_cfg["gym_config"])
     if rank == 0:
         logger.log_info(f"Current working directory: {Path.cwd()}")
 
-    gym_config_data = load_json(str(gym_config_path))
+    gym_config_data = load_config(str(gym_config_path))
     gym_env_cfg = config_to_cfg(
         gym_config_data, manager_modules=DEFAULT_MANAGER_MODULES
     )
@@ -208,7 +211,6 @@ def train_from_config(config_path: str, distributed: bool | None = None):
     gym_env_cfg.sim_cfg.headless = headless
     gym_env_cfg.sim_cfg.render_cfg = RenderCfg(renderer=renderer)
     gym_env_cfg.sim_cfg.gpu_id = gpu_id
-
     logger.log_info(
         f"Loaded gym_config from {gym_config_path} (env_id={gym_config_data['id']}, num_envs={gym_env_cfg.num_envs}, headless={gym_env_cfg.sim_cfg.headless}, renderer={gym_env_cfg.sim_cfg.render_cfg.renderer}, sim_device={gym_env_cfg.sim_cfg.sim_device})"
     )
@@ -410,11 +412,14 @@ def train_from_config(config_path: str, distributed: bool | None = None):
             logger.log_info("Training finished")
 
 
-def main():
-    """Main entry point for command-line training."""
+def cli() -> None:
+    """Command-line interface for RL training.
+
+    Parses CLI arguments and launches training from a config file.
+    """
     args = parse_args()
     train_from_config(args.config, distributed=args.distributed)
 
 
 if __name__ == "__main__":
-    main()
+    cli()

--- a/embodichain/lab/gym/utils/gym_utils.py
+++ b/embodichain/lab/gym/utils/gym_utils.py
@@ -791,12 +791,15 @@ def add_env_launcher_args_to_parser(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--gym_config",
         type=str,
-        help="Path to gym config file.",
+        help="Path to gym config file (.json, .yaml, or .yml).",
         default="",
         required=False,
     )
     parser.add_argument(
-        "--action_config", type=str, help="Path to action config file.", default=None
+        "--action_config",
+        type=str,
+        help="Path to action config file (.json, .yaml, or .yml).",
+        default=None,
     )
     parser.add_argument(
         "--preview",
@@ -852,12 +855,12 @@ def build_env_cfg_from_args(
         tuple[EmbodiedEnvCfg, dict, dict]: A tuple containing the environment configuration object,
             the original gym configuration dictionary, and the action configuration dictionary.
     """
-    from embodichain.utils.utility import load_json
+    from embodichain.utils.utility import load_config
     from embodichain.lab.gym.envs import EmbodiedEnvCfg
     from embodichain.lab.sim import SimulationManagerCfg
     from embodichain.lab.sim.cfg import RenderCfg
 
-    gym_config = load_json(args.gym_config)
+    gym_config = load_config(args.gym_config)
     gym_config = merge_args_with_gym_config(args, gym_config)
 
     cfg: EmbodiedEnvCfg = config_to_cfg(
@@ -872,7 +875,7 @@ def build_env_cfg_from_args(
 
     action_config = {}
     if args.action_config is not None:
-        action_config = load_json(args.action_config)
+        action_config = load_config(args.action_config)
         action_config["action_config"] = action_config
 
     cfg.sim_cfg = SimulationManagerCfg(

--- a/embodichain/lab/scripts/run_agent.py
+++ b/embodichain/lab/scripts/run_agent.py
@@ -19,7 +19,7 @@ import numpy as np
 import argparse
 import torch
 
-from embodichain.utils.utility import load_json
+from embodichain.utils.utility import load_config
 from embodichain.lab.gym.utils.gym_utils import (
     add_env_launcher_args_to_parser,
     build_env_cfg_from_args,
@@ -61,7 +61,7 @@ if __name__ == "__main__":
 
     # Load configurations
     env_cfg, gym_config, action_config = build_env_cfg_from_args(args)
-    agent_config = load_json(args.agent_config)
+    agent_config = load_config(args.agent_config)
 
     # Create environment
     env = gymnasium.make(

--- a/embodichain/utils/utility.py
+++ b/embodichain/utils/utility.py
@@ -27,7 +27,8 @@ import numpy as np
 from tqdm import tqdm
 from PIL import Image
 from functools import wraps
-from typing import Dict, List, Tuple, Callable, Any
+from pathlib import Path
+from typing import Any, Dict, List, Tuple, Callable
 
 from embodichain.utils.string import callable_to_string
 
@@ -358,6 +359,74 @@ def load_json(path: str) -> Dict:
     with open(path) as f:
         config = json.load(f)
     return config
+
+
+def _config_format_from_path(path: str | Path) -> str:
+    """Return the config format inferred from a file suffix."""
+    suffix = Path(path).suffix.lower()
+    if suffix == ".json":
+        return "json"
+    if suffix in {".yaml", ".yml"}:
+        return "yaml"
+    raise ValueError(
+        f"Unsupported config file format for '{path}'. "
+        "Supported extensions: .json, .yaml, .yml"
+    )
+
+
+def load_config(path: str | Path) -> Dict[str, Any]:
+    """Load a gym or agent config file into a dictionary.
+
+    Supports JSON (``.json``) and YAML (``.yaml`` / ``.yml``) formats.
+
+    Args:
+        path: Path to the config file.
+
+    Returns:
+        The parsed config dictionary.
+
+    Raises:
+        ValueError: If the file extension is not supported.
+        TypeError: If the parsed YAML root is not a mapping.
+    """
+    path = Path(path)
+    config_format = _config_format_from_path(path)
+
+    if config_format == "json":
+        return load_json(str(path))
+
+    import yaml
+
+    with path.open("r", encoding="utf-8") as file:
+        config = yaml.safe_load(file) or {}
+
+    if not isinstance(config, dict):
+        raise TypeError(
+            f"Expected mapping in config file '{path}', got {type(config)!r}."
+        )
+    return config
+
+
+def save_config(path: str | Path, data: Dict[str, Any]) -> None:
+    """Save a config dictionary to a JSON or YAML file.
+
+    The output format is inferred from the file extension.
+
+    Args:
+        path: Destination file path.
+        data: Config dictionary to serialize.
+    """
+    path = Path(path)
+    config_format = _config_format_from_path(path)
+
+    if config_format == "json":
+        save_json(str(path), data)
+        return
+
+    import yaml
+
+    with path.open("w", encoding="utf-8") as file:
+        yaml.safe_dump(data, file, sort_keys=False, default_flow_style=False)
 
 
 def load_txt(path: str) -> str:

--- a/examples/agents/datasets/online_dataset_demo.py
+++ b/examples/agents/datasets/online_dataset_demo.py
@@ -71,9 +71,9 @@ def _build_engine(args: argparse.Namespace) -> OnlineDataEngine:
             "Provide a valid path via --config."
         )
 
-    from embodichain.utils.utility import load_json
+    from embodichain.utils.utility import load_config
 
-    gym_config = load_json(config_path)
+    gym_config = load_config(config_path)
 
     gym_config["headless"] = True
     gym_config.setdefault("renderer", True)

--- a/scripts/benchmark/rl/runtime.py
+++ b/scripts/benchmark/rl/runtime.py
@@ -36,7 +36,7 @@ from embodichain.lab.gym.envs.tasks.rl import build_env
 from embodichain.lab.gym.utils.gym_utils import DEFAULT_MANAGER_MODULES, config_to_cfg
 from embodichain.lab.sim import SimulationManagerCfg
 from embodichain.utils.module_utils import find_function_from_modules
-from embodichain.utils.utility import load_json
+from embodichain.utils.utility import load_config
 
 EVENT_MODULES = [
     "embodichain.lab.gym.envs.managers.randomization",
@@ -95,7 +95,7 @@ def _build_env_cfg(
     device: torch.device,
     gpu_id: int,
 ):
-    gym_config_data = load_json(gym_config_path)
+    gym_config_data = load_config(gym_config_path)
     gym_env_cfg = config_to_cfg(
         gym_config_data, manager_modules=DEFAULT_MANAGER_MODULES
     )

--- a/tests/gym/utils/test_gym_utils.py
+++ b/tests/gym/utils/test_gym_utils.py
@@ -22,7 +22,12 @@ import torch
 
 from tensordict import TensorDict
 
-from embodichain.lab.gym.utils.gym_utils import init_rollout_buffer_from_config
+from embodichain.lab.gym.utils.gym_utils import (
+    config_to_cfg,
+    DEFAULT_MANAGER_MODULES,
+    init_rollout_buffer_from_config,
+)
+from embodichain.utils.utility import load_config, save_config
 
 
 class TestInitRolloutBufferFromConfig:
@@ -333,6 +338,42 @@ class TestInitRolloutBufferFromConfig:
         )
 
         assert buffer["obs"]["extra_data"].shape == (4, 200, 2)
+
+
+class TestConfigToCfgFromYaml:
+    def test_yaml_gym_config_parses_to_cfg(self, tmp_path):
+        config = {
+            "id": "EmbodiedEnv-v1",
+            "max_episode_steps": 100,
+            "env": {
+                "events": {},
+                "observations": {},
+                "rewards": {},
+            },
+            "robot": {
+                "uid": "TestRobot",
+                "urdf_cfg": {
+                    "components": [
+                        {
+                            "component_type": "arm",
+                            "urdf_path": "UniversalRobots/UR5/UR5.urdf",
+                        }
+                    ]
+                },
+                "init_pos": [0.0, 0.0, 0.0],
+                "init_rot": [0.0, 0.0, 0.0],
+                "init_qpos": [0.0] * 6,
+            },
+        }
+
+        config_path = tmp_path / "gym_config.yaml"
+        save_config(config_path, config)
+
+        loaded = load_config(config_path)
+        cfg = config_to_cfg(loaded, manager_modules=DEFAULT_MANAGER_MODULES)
+
+        assert cfg.max_episode_steps == 100
+        assert cfg.robot.uid == "TestRobot"
 
 
 if __name__ == "__main__":

--- a/tests/utils/test_utility.py
+++ b/tests/utils/test_utility.py
@@ -1,0 +1,83 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from embodichain.utils.utility import load_config, save_config
+
+
+@pytest.fixture
+def sample_config() -> dict:
+    return {
+        "id": "TestEnv-v1",
+        "num_envs": 2,
+        "env": {"events": {}},
+        "robot": {"uid": "robot_1"},
+    }
+
+
+class TestLoadConfig:
+    def test_load_json(self, tmp_path, sample_config):
+        path = tmp_path / "config.json"
+        path.write_text(json.dumps(sample_config), encoding="utf-8")
+
+        loaded = load_config(path)
+
+        assert loaded == sample_config
+
+    def test_load_yaml(self, tmp_path, sample_config):
+        path = tmp_path / "config.yaml"
+        save_config(path, sample_config)
+
+        loaded = load_config(path)
+
+        assert loaded == sample_config
+
+    def test_load_yml_extension(self, tmp_path, sample_config):
+        path = tmp_path / "config.yml"
+        save_config(path, sample_config)
+
+        loaded = load_config(path)
+
+        assert loaded == sample_config
+
+    def test_unsupported_extension(self, tmp_path):
+        path = tmp_path / "config.toml"
+        path.write_text("id = 'TestEnv-v1'", encoding="utf-8")
+
+        with pytest.raises(ValueError, match="Unsupported config file format"):
+            load_config(path)
+
+    def test_yaml_root_must_be_mapping(self, tmp_path):
+        path = tmp_path / "config.yaml"
+        path.write_text("- item\n", encoding="utf-8")
+
+        with pytest.raises(TypeError, match="Expected mapping"):
+            load_config(path)
+
+    def test_round_trip_yaml(self, tmp_path, sample_config):
+        path = tmp_path / "config.yaml"
+        save_config(path, sample_config)
+
+        assert load_config(path) == sample_config
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Description

This PR adds YAML configuration support alongside the existing JSON config system for gym environments and RL training.

### Changes

- Add `load_config()` and `save_config()` in `embodichain.utils.utility` (supports `.json`, `.yaml`, `.yml`)
- Wire `load_config()` through `build_env_cfg_from_args`, `train_from_config`, `run_agent`, benchmark runtime, and related entry points
- Register `train-rl` subcommand in `python -m embodichain` CLI with updated help text
- Add example YAML configs:
  - `configs/gym/cobotmagic.yaml`, `configs/gym/dexforce_w1.yaml`
  - `configs/agents/rl/basic/cart_pole/gym_config.yaml`, `train_config.yaml`, `train_config_grpo.yaml`
- Add unit tests for config loading and YAML → `config_to_cfg` parsing
- Update documentation (configuration guide, CLI reference, RL tutorial, data generation, RL overview)

### Usage

```bash
python -m embodichain run-env --gym_config configs/gym/cobotmagic.yaml
python -m embodichain train-rl --config configs/agents/rl/basic/cart_pole/train_config.yaml
```

JSON configs remain fully supported with no breaking changes.

Fixes #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (existing functionality will not work without user modification)
- [x] Documentation update

## Screenshots

N/A

## Checklist

- [x] I have run the `black .` command to format the code base.
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Dependencies have been updated, if applicable. (PyYAML already listed in `pyproject.toml`)


Made with [Cursor](https://cursor.com)