### PR TITLE
Fix base  solver fk

### DIFF
--- a/embodichain/lab/sim/solvers/base_solver.py
+++ b/embodichain/lab/sim/solvers/base_solver.py
@@ -428,7 +428,8 @@ class BaseSolver(metaclass=ABCMeta):
             self.tcp_xpos, device=self.device, dtype=torch.float32
         )
         qpos = torch.as_tensor(qpos, dtype=torch.float32, device=self.device)
-
+        if qpos.dim() == 1:
+            qpos = qpos.unsqueeze(0)
         if self.pk_serial_chain is None:
             logger.log_error("Kinematic chain is not initialized.")
             return torch.eye(4, device=self.device)


### PR DESCRIPTION
# Description
Fix base solver `get_fk` when input qpos is a 1-D tensor.


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the `black .` command to format the code base.
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Dependencies have been updated, if applicable.
