### PR TITLE
feat: add agent context routing system for EmbodiChain

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,29 @@
 # EmbodiChain — Developer Reference
 
+## Project Agent Context Routing
+
+EmbodiChain keeps agent-facing context in a structured topic registry:
+
+- `agent_context/` — agent-readable Markdown context, indexed by `agent_context/MAP.yaml`
+- `docs/source/` — human-facing Sphinx documentation
+- `skills/project-dev-context/` — the skill that routes "reference project context" requests
+
+When a request says things like:
+
+- `reference project development docs`
+- `reference project context`
+
+the agent should:
+
+1. Read `agent_context/MAP.yaml` first
+2. Resolve the topic by `id`, `aliases`, then `keywords`
+3. Load only the matched Markdown files under `agent_context/`
+4. Avoid reading `docs/source/` unless the user explicitly asks for the Sphinx documentation
+
+Available topics: `env-framework`, `manager-functor`, `ik-solvers`, `robot-system`, `sensor-system`, `motion-planning`, `rl-training`, `configclass-pattern`, `randomization`.
+
+---
+
 ## Package Name
 
 **IMPORTANT**: The Python package name is `embodichain` (all lowercase, one word).

--- a/agent_context/MAP.yaml
+++ b/agent_context/MAP.yaml
@@ -1,0 +1,324 @@
+version: 1
+defaults:
+  contexts:
+    - conventions/writing-style.md
+    - conventions/naming.md
+    - conventions/topic-lifecycle.md
+topics:
+  - id: env-framework
+    title: Environment Framework
+    aliases:
+      - env framework
+      - environment framework
+      - base env
+      - embodied env
+      - task environment
+      - gym environment
+      - register env
+      - task registration
+      - 环境框架
+      - 任务环境
+    keywords:
+      - env
+      - environment
+      - base_env
+      - embodied_env
+      - EmbodiedEnv
+      - BaseEnv
+      - register_env
+      - gym
+      - task
+      - step
+      - reset
+      - wrapper
+    paths:
+      - topics/env-framework/env-framework.md
+    source_of_truth:
+      - embodichain/lab/gym/envs/base_env.py
+      - embodichain/lab/gym/envs/embodied_env.py
+      - embodichain/lab/gym/envs/tasks/
+      - embodichain/lab/gym/utils/
+    related_topics:
+      - manager-functor
+    status: active
+
+  - id: manager-functor
+    title: Manager & Functor Pattern
+    aliases:
+      - manager functor
+      - functor pattern
+      - manager pattern
+      - observation manager
+      - reward manager
+      - event manager
+      - action manager
+      - dataset manager
+      - functor cfg
+    keywords:
+      - manager
+      - functor
+      - FunctorCfg
+      - ObservationManager
+      - RewardManager
+      - EventManager
+      - ActionManager
+      - DatasetManager
+      - observation
+      - reward
+      - event
+      - action
+      - dataset
+    paths:
+      - topics/manager-functor/manager-functor.md
+    source_of_truth:
+      - embodichain/lab/gym/envs/managers/manager_base.py
+      - embodichain/lab/gym/envs/managers/cfg.py
+      - embodichain/lab/gym/envs/managers/observation_manager.py
+      - embodichain/lab/gym/envs/managers/reward_manager.py
+      - embodichain/lab/gym/envs/managers/event_manager.py
+    related_topics:
+      - env-framework
+      - randomization
+    status: active
+
+  - id: ik-solvers
+    title: IK Solver System
+    aliases:
+      - ik solver
+      - inverse kinematics
+      - solver system
+      - srs solver
+      - opw solver
+      - pink solver
+      - pinocchio solver
+      - pytorch solver
+      - differential solver
+      - 逆运动学
+      - IK求解器
+    keywords:
+      - ik
+      - solver
+      - inverse kinematics
+      - SRS
+      - OPW
+      - pink
+      - pinocchio
+      - pytorch
+      - differential
+      - kinematics
+      - joint
+      - tcp
+      - end effector
+    paths:
+      - topics/ik-solvers/ik-solvers.md
+    source_of_truth:
+      - embodichain/lab/sim/solvers/base_solver.py
+      - embodichain/lab/sim/solvers/srs_solver.py
+      - embodichain/lab/sim/solvers/opw_solver.py
+      - embodichain/lab/sim/solvers/pink_solver.py
+      - embodichain/lab/sim/solvers/pinocchio_solver.py
+      - embodichain/lab/sim/solvers/pytorch_solver.py
+      - embodichain/lab/sim/solvers/differential_solver.py
+    related_topics:
+      - robot-system
+      - motion-planning
+    status: active
+
+  - id: robot-system
+    title: Robot System
+    aliases:
+      - robot
+      - robot config
+      - robot cfg
+      - robot system
+      - dexforce w1
+      - cobotmagic
+      - control parts
+      - drive properties
+      - 机器人系统
+      - 机器人配置
+    keywords:
+      - robot
+      - RobotCfg
+      - Robot
+      - control
+      - drive
+      - joint
+      - urdf
+      - cobotmagic
+      - dexforce_w1
+      - gripper
+      - arm
+    paths:
+      - topics/robot-system/robot-system.md
+    source_of_truth:
+      - embodichain/lab/sim/objects/robot.py
+      - embodichain/lab/sim/robots/
+      - embodichain/lab/sim/cfg.py
+    related_topics:
+      - ik-solvers
+      - motion-planning
+      - sensor-system
+    status: active
+
+  - id: sensor-system
+    title: Sensor System
+    aliases:
+      - sensor
+      - camera
+      - stereo camera
+      - contact sensor
+      - sensor system
+      - 传感器
+      - 相机
+    keywords:
+      - sensor
+      - camera
+      - stereo
+      - contact
+      - BaseSensor
+      - Camera
+      - StereoCamera
+      - ContactSensor
+      - rgb
+      - depth
+      - pointcloud
+    paths:
+      - topics/sensor-system/sensor-system.md
+    source_of_truth:
+      - embodichain/lab/sim/sensors/base_sensor.py
+      - embodichain/lab/sim/sensors/camera.py
+      - embodichain/lab/sim/sensors/stereo.py
+      - embodichain/lab/sim/sensors/contact_sensor.py
+    related_topics:
+      - robot-system
+      - env-framework
+    status: active
+
+  - id: motion-planning
+    title: Motion Planning
+    aliases:
+      - motion planning
+      - motion planner
+      - toppra
+      - motion generator
+      - trajectory planning
+      - 运动生成
+      - 运动规划
+      - 轨迹规划
+    keywords:
+      - planner
+      - planning
+      - trajectory
+      - toppra
+      - motion generator
+      - path
+      - waypoint
+      - velocity
+      - acceleration
+    paths:
+      - topics/motion-planning/motion-planning.md
+    source_of_truth:
+      - embodichain/lab/sim/planners/base_planner.py
+      - embodichain/lab/sim/planners/toppra_planner.py
+      - embodichain/lab/sim/planners/motion_generator.py
+    related_topics:
+      - robot-system
+      - ik-solvers
+    status: active
+
+  - id: rl-training
+    title: RL Training Pipeline
+    aliases:
+      - rl training
+      - reinforcement learning
+      - ppo
+      - rl agent
+      - actor critic
+      - rollout buffer
+      - 强化学习
+      - RL训练
+    keywords:
+      - rl
+      - reinforcement
+      - ppo
+      - actor
+      - critic
+      - buffer
+      - rollout
+      - training
+      - collector
+      - policy
+      - reward
+    paths:
+      - topics/rl-training/rl-training.md
+    source_of_truth:
+      - embodichain/agents/rl/train.py
+      - embodichain/agents/rl/algo/
+      - embodichain/agents/rl/buffer/
+      - embodichain/agents/rl/models/
+      - embodichain/agents/rl/collector/
+    related_topics:
+      - env-framework
+      - manager-functor
+    status: active
+
+  - id: configclass-pattern
+    title: Configclass Pattern
+    aliases:
+      - configclass
+      - config class
+      - configuration pattern
+      - MISSING sentinel
+      - 配置类
+      - 配置模式
+    keywords:
+      - configclass
+      - config
+      - configuration
+      - MISSING
+      - dataclass
+      - decorator
+      - cfg
+      - nested
+    paths:
+      - topics/configclass-pattern/configclass-pattern.md
+    source_of_truth:
+      - embodichain/utils/configclass.py
+    related_topics:
+      - env-framework
+      - manager-functor
+      - robot-system
+    status: active
+
+  - id: randomization
+    title: Domain Randomization
+    aliases:
+      - randomization
+      - domain randomization
+      - physics randomization
+      - visual randomization
+      - spatial randomization
+      - geometry randomization
+      - 域随机化
+      - 随机化
+    keywords:
+      - randomization
+      - randomize
+      - physics
+      - visual
+      - spatial
+      - geometry
+      - domain
+      - EventCfg
+      - startup
+      - reset
+    paths:
+      - topics/randomization/randomization.md
+    source_of_truth:
+      - embodichain/lab/gym/envs/managers/randomization/
+      - embodichain/lab/gym/envs/managers/events.py
+    related_topics:
+      - manager-functor
+      - env-framework
+    status: active

--- a/agent_context/conventions/naming.md
+++ b/agent_context/conventions/naming.md
@@ -1,0 +1,20 @@
+# Agent Context Naming
+
+Directory and index naming rules:
+
+- Topic directories use kebab-case ids, for example:
+  - `env-framework`
+  - `manager-functor`
+  - `ik-solvers`
+- `agent_context/MAP.yaml` is the only topic registry for agents.
+- Each topic entry must have:
+  - `id`
+  - `title`
+  - `aliases`
+  - `keywords`
+  - `paths`
+  - `source_of_truth`
+  - `related_topics`
+  - `status`
+- Sphinx documentation lives under `docs/source/` and is the human-facing reference.
+  Agent context files under `agent_context/topics/` summarize operational knowledge for agents.

--- a/agent_context/conventions/topic-lifecycle.md
+++ b/agent_context/conventions/topic-lifecycle.md
@@ -1,0 +1,50 @@
+# Agent Context Topic Lifecycle
+
+Use these rules when a request changes project context, adds a new topic, or updates an existing topic.
+
+## When code behavior changes
+
+If a change affects an existing routed topic, update the matching files under `agent_context/topics/...` in the same change.
+
+Typical triggers:
+
+- entry-point changes
+- lifecycle/state-machine changes
+- config field changes
+- manager or functor signature changes
+- new solver, sensor, or robot added
+
+## How to refresh an existing topic
+
+1. Identify the topic in `agent_context/MAP.yaml`
+2. Re-read the current source-of-truth files listed in that topic entry
+3. Rewrite the topic markdown so it reflects the current implementation, not old intent
+4. Keep the file concise and operational:
+   - entry points
+   - invariants
+   - common failure modes
+
+Explicit refresh requests such as `refresh <topic> context` or
+`根据当前实现重写 <topic> 上下文` should follow this exact flow.
+
+## How to create a new topic from current code
+
+1. Pick a stable kebab-case topic id
+2. Write one Markdown file under `agent_context/topics/<topic-id>/`
+3. Summarize the current behavior from source files, not from stale notes
+4. Add a topic entry to `agent_context/MAP.yaml` with:
+   - `id`
+   - `title`
+   - `aliases`
+   - `keywords`
+   - `paths`
+   - `source_of_truth`
+   - `related_topics`
+   - `status`
+5. If the routing rule or recommended usage changed, update:
+   - `AGENTS.md`
+   - `skills/project-dev-context/`
+
+## Rule
+
+Do not let topic markdown drift from the code. If the routed context becomes stale, treat that as part of the same maintenance task.

--- a/agent_context/conventions/writing-style.md
+++ b/agent_context/conventions/writing-style.md
@@ -1,0 +1,14 @@
+# Agent Context Writing Style
+
+Use these rules when adding or updating files under `agent_context/`:
+
+1. Keep each context file topic-focused. One file should answer one class of request.
+2. Put actionable engineering facts first:
+   - entry points
+   - source-of-truth files
+   - invariants
+   - common failure modes
+3. Prefer short sections over narrative prose.
+4. Record behavior, ownership, and workflow constraints; avoid long background history.
+5. If a topic depends on existing Sphinx documentation, reference its path under `docs/source/` instead of copying the full document.
+6. If the context changes the working route for an agent, update `agent_context/MAP.yaml` in the same change.

--- a/agent_context/topics/configclass-pattern/configclass-pattern.md
+++ b/agent_context/topics/configclass-pattern/configclass-pattern.md
@@ -1,0 +1,159 @@
+# @configclass Pattern
+
+## Entry Points
+
+| What | Path |
+|------|------|
+| Decorator + helpers | `embodichain/utils/configclass.py` |
+| Public exports | `embodichain/utils/__init__.py` — exports `configclass`, `is_configclass`, `set_seed`, `GLOBAL_SEED` |
+| MISSING sentinel | Re-exported from `dataclasses.MISSING` (used inside configclass files) |
+
+Import:
+```python
+from embodichain.utils import configclass
+from dataclasses import MISSING
+```
+
+## Overview
+
+`@configclass` is a decorator wrapping Python's `@dataclass` that fixes two pain points for configuration objects:
+
+1. **Missing type annotations** — automatically infers annotations from default values so unannotated members are not silently ignored.
+2. **Mutable defaults** — wraps mutable defaults (lists, dicts, nested objects) in `field(default_factory=...)` automatically, avoiding the standard dataclass `ValueError`.
+
+It also adds runtime utility methods and deep-copies all mutable members in `__post_init__` to prevent shared-state bugs.
+
+**Origin**: Adapted from Isaac Lab's `configclass` implementation (`isaaclab.utils.configclass`).
+
+## @configclass Decorator — What It Adds
+
+When `@configclass` decorates a class, the following happens (in order):
+
+1. **`_add_annotation_types(cls)`** — scans the MRO and adds type annotations for any class member that lacks one (deduced from the default value's type). Raises `TypeError` if a `MISSING` field has no annotation.
+
+2. **`_process_mutable_types(cls)`** — converts mutable default values (lists, dicts, class instances) into `field(default_factory=lambda: deepcopy(default))` to satisfy dataclass rules.
+
+3. **`__post_init__` injection** — installs (or augments) `__post_init__` with `custom_post_init`, which deep-copies every non-callable, non-property, non-dunder attribute. This prevents instances from sharing mutable state.
+
+4. **Utility methods attached**:
+   - `to_dict()` → recursive dict conversion (handles nested configclasses, torch tensors, callables).
+   - `replace(**kwargs)` → returns a new instance with specified fields replaced (delegates to `dataclasses.replace`).
+   - `copy(**kwargs)` → alias for `replace`.
+   - `validate()` → recursively checks for `MISSING` values; raises `TypeError` listing all missing fields.
+
+5. **Wrapped with `@dataclass`** — the class is finally passed through the standard `dataclass()` call.
+
+### Difference vs Plain @dataclass
+
+| Feature | `@dataclass` | `@configclass` |
+|---------|-------------|----------------|
+| Unannotated members | Silently ignored | Auto-annotated from default type |
+| Mutable defaults (list, dict) | `ValueError` | Auto-wrapped in `default_factory` |
+| Nested configclass defaults | Shared across instances | Deep-copied per instance |
+| `to_dict()` | Not available | Recursive conversion |
+| `validate()` | Not available | Checks for MISSING fields |
+| `replace()` / `copy()` | `dataclasses.replace()` | Attached as method |
+
+## MISSING Sentinel
+
+`MISSING` (from `dataclasses`) marks required fields that must be provided at instantiation:
+
+```python
+@configclass
+class RobotCfg:
+    name: str = MISSING       # caller MUST provide
+    num_joints: int = MISSING  # caller MUST provide
+    speed: float = 1.0         # optional with default
+```
+
+- Constructing `RobotCfg()` without `name` or `num_joints` raises `TypeError` from dataclass.
+- Calling `cfg.validate()` after construction checks for any `MISSING` values that slipped through (e.g., in nested configs) and raises `TypeError` listing them.
+
+## Nested Configs
+
+Configclasses compose hierarchically:
+
+```python
+@configclass
+class SensorCfg:
+    width: int = 640
+    height: int = 480
+
+@configclass
+class RobotCfg:
+    name: str = MISSING
+    camera: SensorCfg = SensorCfg()  # auto-wrapped in default_factory
+```
+
+Each `RobotCfg()` instance gets its own deep copy of `SensorCfg()` — no shared state.
+
+### update_class_from_dict
+
+`update_class_from_dict(obj, data, _ns="")` performs recursive in-place updates from a dict:
+
+- Nested `Mapping` values → recurse into sub-object.
+- Iterable values → matched by length; recursed if elements are mappings.
+- Callable members → resolved from string via `string_to_callable()`.
+- Type mismatches → `ValueError`.
+- Unknown keys → `KeyError`.
+
+This powers config loading from YAML/JSON files.
+
+## Usage Patterns
+
+### Algorithm config (RL)
+
+```python
+# embodichain/agents/rl/utils/config.py
+@configclass
+class AlgorithmCfg:
+    device: str = "cuda"
+    learning_rate: float = 3e-4
+    batch_size: int = 64
+    gamma: float = 0.99
+    gae_lambda: float = 0.95
+    max_grad_norm: float = 0.5
+
+# embodichain/agents/rl/algo/ppo.py
+@configclass
+class PPOCfg(AlgorithmCfg):
+    n_epochs: int = 10
+    clip_coef: float = 0.2
+    ent_coef: float = 0.01
+    vf_coef: float = 0.5
+```
+
+### Manager/functor configs (env framework)
+
+```python
+@configclass
+class MyObservationCfg:
+    sensor_name: str = MISSING
+    scale: float = 1.0
+    noise_std: float = 0.0
+```
+
+### Checking for configclass
+
+```python
+from embodichain.utils import is_configclass
+
+is_configclass(PPOCfg)   # True — has 'validate' method
+is_configclass(dict)      # False
+```
+
+Note: `is_configclass` simply checks for the presence of a `validate` attribute.
+
+## Common Mistakes
+
+| Mistake | What Happens | Fix |
+|---------|-------------|-----|
+| Forgetting `MISSING` annotation | `TypeError: Missing type annotation for 'X'` at class definition time | Add explicit type annotation: `x: int = MISSING` |
+| Using `MISSING` without type hint | Decorator can't infer type from `MISSING` | Always annotate MISSING fields |
+| Sharing mutable nested defaults across subclasses | Usually safe due to `__post_init__` deepcopy, but watch out for very large objects (perf cost) | Acceptable for configs; avoid storing large tensors as defaults |
+| Overriding `__post_init__` | Your custom logic runs first, then `custom_post_init` deepcopies everything | Use `combined_function` behavior — both run; order: yours → deepcopy |
+| `validate()` not called | MISSING fields in nested configs go undetected until attribute access | Call `cfg.validate()` after construction to fail fast |
+| `to_dict()` on torch.Tensor | Returns the tensor directly (not converted to list/scalar) | Intentional — tensors are preserved as-is in the dict |
+| Callable fields in `to_dict()` | Converted to string via `callable_to_string()` | Use `string_to_callable()` to reverse when loading |
+| `update_class_from_dict` with extra keys | Raises `KeyError` | Only pass keys that exist on the target config |
+| `update_class_from_dict` length mismatch on lists | Raises `ValueError` | Source and target iterables must have the same length |

--- a/agent_context/topics/env-framework/env-framework.md
+++ b/agent_context/topics/env-framework/env-framework.md
@@ -1,0 +1,266 @@
+# env-framework
+
+> Topic: Environment framework — BaseEnv / EmbodiedEnv class hierarchy,
+> task registration, manager wiring, and lifecycle.
+
+---
+
+## Entry Points
+
+| File | Role |
+|---|---|
+| `embodichain/lab/gym/envs/base_env.py` | `BaseEnv(gym.Env)` + `EnvCfg` — low-level env loop |
+| `embodichain/lab/gym/envs/embodied_env.py` | `EmbodiedEnv(BaseEnv)` + `EmbodiedEnvCfg` — modular task base class |
+| `embodichain/lab/gym/utils/registration.py` | `@register_env` decorator + `REGISTERED_ENVS` registry + `make()` |
+| `embodichain/lab/gym/envs/tasks/__init__.py` | All concrete task imports (forces registration on import) |
+| `embodichain/lab/gym/envs/managers/__init__.py` | Manager re-exports: `EventManager`, `ObservationManager`, `RewardManager`, `ActionManager`, `DatasetManager` |
+| `embodichain/lab/gym/envs/wrapper/no_fail.py` | `NoFailWrapper` — forces `is_task_success() → True` |
+
+---
+
+## Overview
+
+The env framework provides a Gymnasium-compatible simulation loop for
+embodied manipulation tasks. All tasks inherit from **EmbodiedEnv**, which
+itself extends **BaseEnv(gym.Env)**. Managers (event, observation, reward,
+action, dataset) are optionally wired into the env via config fields and
+follow the Functor/FunctorCfg pattern.
+
+---
+
+## Architecture
+
+```
+gym.Env
+  └── BaseEnv            (EnvCfg)
+        └── EmbodiedEnv   (EmbodiedEnvCfg)
+              └── <YourTask>  (YourTaskCfg)
+```
+
+### BaseEnv (`base_env.py`)
+
+- Owns: `SimulationManager`, `Robot`, sensors dict, action/observation spaces.
+- Implements the full `step()` / `reset()` loop (see Lifecycle below).
+- Defines hook points subclasses override:
+  - `_setup_robot()` — load robot, set `single_action_space`. **Must** return `Robot`.
+  - `_prepare_scene()` — add scene assets.
+  - `_setup_sensors()` → `Dict[str, BaseSensor]`.
+  - `_init_sim_state()` — one-time post-scene init.
+  - `_initialize_episode(env_ids)` — per-episode reset / randomization.
+  - `_update_sim_state()` — called each step after physics.
+  - `evaluate()` → `{"success": ..., "fail": ...}`.
+  - `get_reward(obs, action, info)` → `torch.Tensor`.
+  - `_preprocess_action(action)` / `_postprocess_action(action)`.
+  - `_hook_after_sim_step(obs, action, rewards, dones, info)`.
+
+### EmbodiedEnv (`embodied_env.py`)
+
+- Adds declarative config fields: `robot`, `sensor`, `light`, `background`,
+  `rigid_object`, `rigid_object_group`, `articulation`, manager configs
+  (`events`, `observations`, `rewards`, `actions`, `dataset`), `extensions`.
+- Creates managers in `_init_sim_state()` from config.
+- Overrides `_extend_obs()` to run `ObservationManager.compute()`.
+- Overrides `_extend_reward()` to run `RewardManager.compute()` and add to
+  base reward.
+- Overrides `_initialize_episode()` to run event-manager `reset` mode,
+  dataset save, and manager resets.
+- Overrides `_update_sim_state()` to run event-manager `interval` mode.
+- Manages rollout buffer (expert or RL mode) via `_hook_after_sim_step()`.
+- `extensions` dict entries are set as attributes on both cfg and env instance.
+
+---
+
+## Task Registration
+
+### Decorator
+
+```python
+from embodichain.lab.gym.utils.registration import register_env
+
+@register_env("MyTask-v1", max_episode_steps=600)
+class MyTaskEnv(EmbodiedEnv):
+    ...
+```
+
+### Mechanics
+
+1. `register_env(uid)` is a class decorator defined in `registration.py`.
+2. It calls `register()` which stores an `EnvSpec` in the module-level
+   `REGISTERED_ENVS` dict, keyed by `uid`.
+3. It also calls `gym.register()` so the env is available via
+   `gym.make(uid)`.
+4. `kwargs` passed to `@register_env` must be **JSON-serialisable** (no
+   classes/types). A `RuntimeError` is raised otherwise.
+5. Use `override=True` to re-register an existing uid (useful in scripts/tests).
+
+### Gym ID convention
+
+Format: `<TaskName>-v<N>` (e.g. `PourWater-v3`, `PushCubeRL`).
+RL tasks sometimes drop the `-v<N>` suffix (`CartPoleRL`, `PushCubeRL`).
+
+### Instantiation
+
+```python
+from embodichain.lab.gym.utils.registration import make
+env = make("MyTask-v1", cfg=my_cfg)
+```
+
+Or via gymnasium: `gym.make("MyTask-v1")`.
+
+---
+
+## EmbodiedEnv Lifecycle
+
+### Construction (`__init__`)
+
+```
+EmbodiedEnv.__init__(cfg)
+  ├── bind extensions → cfg + self
+  ├── init manager slots to None
+  ├── super().__init__(cfg)  →  BaseEnv.__init__
+  │     ├── set seed, compute frequencies
+  │     ├── _setup_scene()
+  │     │     ├── create SimulationManager
+  │     │     ├── _setup_robot()  → Robot + single_action_space
+  │     │     ├── _prepare_scene()  → lights, background, objects
+  │     │     └── _setup_sensors() → sensors dict
+  │     ├── init GPU physics (if CUDA)
+  │     ├── open window (if not headless)
+  │     └── _init_sim_state()
+  │           ├── _apply_functor_filter() (strip visual rand if configured)
+  │           ├── create EventManager   (if cfg.events)
+  │           │     └── apply "startup" mode
+  │           ├── create ObservationManager (if cfg.observations)
+  │           ├── create RewardManager      (if cfg.rewards)
+  │           └── create ActionManager      (if cfg.actions)
+  │                 └── override single_action_space
+  ├── create DatasetManager (if cfg.dataset and not filter_dataset_saving)
+  └── init rollout buffer (if cfg.init_rollout_buffer)
+```
+
+### `reset(seed, options)`
+
+```
+reset(options)
+  ├── is_task_success() → save status before resetting
+  ├── sim.reset_objects_state(env_ids, excluded_uids)
+  ├── _initialize_episode(env_ids)
+  │     ├── dataset_manager.apply("save") for successful episodes
+  │     ├── event_manager.apply("reset", env_ids)
+  │     ├── observation_manager.reset(env_ids)
+  │     └── reward_manager.reset(env_ids)
+  ├── _elapsed_steps[env_ids] = 0
+  └── return get_obs(), get_info()
+```
+
+### `step(action)`
+
+```
+step(action)
+  ├── _preprocess_action(action)
+  ├── _step_action(action)           # subclass sends control to sim
+  ├── sim.update(dt, sim_steps_per_control)
+  ├── _update_sim_state()            # event_manager "interval" mode
+  ├── get_obs()
+  │     ├── robot.get_proprioception()[:, active_joint_ids]
+  │     ├── _get_sensor_obs()
+  │     └── _extend_obs()            # ObservationManager.compute()
+  ├── get_info() → evaluate()
+  ├── get_reward() + _extend_reward()  # RewardManager.compute()
+  ├── _postprocess_action(action)
+  ├── elapsed_steps += 1
+  ├── compute terminateds (success | fail), truncateds (time limit)
+  ├── _hook_after_sim_step()         # rollout buffer write
+  └── auto-reset done envs → reset(reset_ids)
+```
+
+---
+
+## Manager Integration
+
+Managers are **optional** — set the corresponding `EmbodiedEnvCfg` field to
+wire one in. Each manager follows the Functor/FunctorCfg pattern (see
+`manager-functor` topic).
+
+| Manager | Config field | Created in | Called during |
+|---|---|---|---|
+| `EventManager` | `cfg.events` | `_init_sim_state()` | startup, reset, interval (each step) |
+| `ObservationManager` | `cfg.observations` | `_init_sim_state()` | `_extend_obs()` on every `get_obs()` |
+| `RewardManager` | `cfg.rewards` | `_init_sim_state()` | `_extend_reward()` on every step |
+| `ActionManager` | `cfg.actions` | `_init_sim_state()` | overrides `single_action_space` |
+| `DatasetManager` | `cfg.dataset` | `__init__` (after super) | `_initialize_episode()` save mode |
+
+### Event manager modes
+
+- `startup` — runs once after `_init_sim_state()`.
+- `reset` — runs in `_initialize_episode()` for the reset env_ids.
+- `interval` — runs every step in `_update_sim_state()`.
+
+### Functor filter
+
+`cfg.filter_visual_rand = True` strips all visual randomization functors
+from the event config before the event manager is created.
+
+---
+
+## Creating a New Task
+
+Use the `/add-task-env` skill. It scaffolds:
+
+1. A new file under `embodichain/lab/gym/envs/tasks/<category>/`.
+2. `@register_env("<GymId>")` decorator on the class.
+3. `EmbodiedEnvCfg` subclass with robot, sensor, object configs.
+4. Stub implementations of `_setup_robot()`, `evaluate()`, `get_reward()`.
+5. Import entry in `tasks/__init__.py`.
+6. Test stub.
+
+### Minimal manual skeleton
+
+```python
+from embodichain.lab.gym.envs import EmbodiedEnv, EmbodiedEnvCfg
+from embodichain.lab.gym.utils.registration import register_env
+
+@configclass
+class MyTaskCfg(EmbodiedEnvCfg):
+    robot: RobotCfg = MISSING
+
+@register_env("MyTask-v1", max_episode_steps=300)
+class MyTaskEnv(EmbodiedEnv):
+    def __init__(self, cfg: MyTaskCfg = MyTaskCfg(), **kwargs):
+        super().__init__(cfg, **kwargs)
+
+    def _setup_robot(self, **kwargs) -> Robot:
+        # load robot, set self.single_action_space
+        ...
+
+    def evaluate(self, **kwargs) -> dict:
+        return {"success": ..., "fail": ...}
+
+    def get_reward(self, obs, action, info) -> torch.Tensor:
+        ...
+```
+
+---
+
+## Wrappers
+
+| Wrapper | Location | Purpose |
+|---|---|---|
+| `NoFailWrapper` | `envs/wrapper/no_fail.py` | Forces `is_task_success() → True` |
+| `TimeLimitWrapper` | `utils/registration.py` | Batched truncation via `elapsed_steps >= max_episode_steps` |
+
+---
+
+## Common Failure Modes
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `KeyError: "Env X not found in registry"` | Task module not imported → `@register_env` never ran | Add import to `tasks/__init__.py` |
+| `RuntimeError: non json dumpable kwargs` | Passing class/type objects to `@register_env(…, kwarg=SomeClass)` | Use string keys + lookup mapping instead |
+| `single_action_space is None` | `_setup_robot()` didn't set `self.single_action_space` | Set it before returning the Robot |
+| `_setup_robot()` returns `None` | Forgot to return the Robot instance | Ensure `return robot` |
+| Observation/reward manager has no effect | `cfg.observations` / `cfg.rewards` left as `None` | Set the manager config in your `EmbodiedEnvCfg` subclass |
+| Visual randomization still active during debug | `filter_visual_rand` not set | Set `cfg.filter_visual_rand = True` |
+| Dataset not saving | `filter_dataset_saving = True` or no `cfg.dataset` | Check both flags |
+| Rollout buffer overflow warning | `max_episode_steps` < actual episode length | Increase `max_episode_steps` or check termination logic |
+| `Env X already registered` warning | Duplicate import or re-registration | Use `override=True` in tests/scripts |

--- a/agent_context/topics/ik-solvers/ik-solvers.md
+++ b/agent_context/topics/ik-solvers/ik-solvers.md
@@ -1,0 +1,198 @@
+# ik-solvers
+
+> Topic: Inverse-kinematics solver subsystem — solver hierarchy,
+> available algorithms, configuration, seed sampling, and failure modes.
+
+---
+
+## Entry Points
+
+| File | Role |
+|---|---|
+| `embodichain/lab/sim/solvers/__init__.py` | Public re-exports for all solver classes and configs |
+| `embodichain/lab/sim/solvers/base_solver.py` | `BaseSolver` ABC + `SolverCfg` base config |
+| `embodichain/lab/sim/cfg.py` | `RobotCfg.solver_cfg` — where solver config is wired into a robot |
+| `embodichain/lab/sim/solvers/qpos_seed_sampler.py` | `QposSeedSampler` — random joint-seed generation |
+| `embodichain/lab/sim/solvers/null_space_posture_task.py` | `NullSpacePostureTask` — Pink null-space posture objective |
+| `embodichain/lab/sim/utility/solver_utils.py` | Helpers: `create_pk_serial_chain`, `build_reduced_pinocchio_robot`, `validate_iteration_params`, `compute_pinocchio_fk` |
+
+---
+
+## Overview
+
+Each robot can have one or more IK solvers (one per control part).
+Solvers share a common `BaseSolver` interface for FK, IK, Jacobian, TCP,
+and joint-limit management.  A `SolverCfg` subclass is instantiated
+inside `RobotCfg` and its `init_solver()` factory method produces the
+concrete `BaseSolver` instance at runtime.
+
+All solvers use a `pytorch_kinematics` serial chain (`pk_serial_chain`)
+for FK and Jacobian computation. `torch.compile` is applied to the FK
+path for performance.
+
+---
+
+## Solver Hierarchy
+
+```
+SolverCfg  (@configclass, abstract)
+  ├── SRSSolverCfg
+  ├── OPWSolverCfg
+  ├── PytorchSolverCfg
+  ├── PinocchioSolverCfg
+  ├── PinkSolverCfg
+  └── DifferentialSolverCfg
+
+BaseSolver  (ABCMeta)
+  ├── SRSSolver
+  ├── OPWSolver
+  ├── PytorchSolver
+  ├── PinocchioSolver
+  ├── PinkSolver
+  └── DifferentialSolver
+```
+
+`SolverCfg.init_solver()` is the abstract factory; each subclass
+overrides it to construct the matching `BaseSolver` subclass.
+
+---
+
+## Available Solvers
+
+| Solver | Algorithm | When to use | Key dependencies |
+|---|---|---|---|
+| **SRSSolver** | SRS analytical IK (7-DOF, elbow-sampling) | DexForce W1 arms; fast GPU-batched analytical solve via Warp kernels | `warp` |
+| **OPWSolver** | OPW analytical IK (6-DOF) | 6-DOF industrial arms with OPW kinematic structure | `warp`, `polars` |
+| **PytorchSolver** | Iterative damped-least-squares via `pytorch_kinematics` | General-purpose GPU solver; good default for arbitrary URDFs | `pytorch_kinematics` |
+| **PinocchioSolver** | Iterative IK via Pinocchio + optional CasADi | High-accuracy IK with full rigid-body dynamics model | `pinocchio`, `casadi` (optional) |
+| **PinkSolver** | Task-based IK via Pink (QP optimisation) | Multi-task IK (e.g., dual-arm, posture + EE control, null-space tasks) | `pinocchio`, `pink` |
+| **DifferentialSolver** | Differential IK (Jacobian pseudo-inverse / SVD / DLS) | Real-time velocity-level IK; supports relative-mode commands | (none beyond core) |
+
+---
+
+## Solver Interface
+
+### `SolverCfg` (base config)
+
+Key fields shared by all configs:
+
+| Field | Type | Purpose |
+|---|---|---|
+| `class_type` | `str` | Solver class name (used by `from_dict` factory) |
+| `urdf_path` | `str \| None` | Path to robot URDF |
+| `joint_names` | `list[str] \| None` | Joints to include; `None` = all |
+| `end_link_name` | `str` | End-effector link name |
+| `root_link_name` | `str` | Base link name |
+| `tcp` | `np.ndarray` | 4×4 tool-center-point transform |
+| `ik_nearest_weight` | `list[float] \| None` | Per-joint weight for nearest-solution selection |
+| `user_qpos_limits` | `list[float] \| None` | Optional custom joint limits `[2, DOF]` or `[DOF, 2]` |
+
+Factory: `cfg.init_solver(device=..., **kwargs) → BaseSolver`
+
+Dict factory: `SolverCfg.from_dict(dict) → SolverCfg` resolves `class_type` dynamically.
+
+### `BaseSolver` (abstract base)
+
+| Method | Signature | Notes |
+|---|---|---|
+| `get_ik` | `(target_pose: Tensor[4,4], joint_seed, num_samples) → (success: Tensor, joints: Tensor)` | Abstract. Returns `(num_envs,)` bool + `(num_envs, dof)` joint positions |
+| `get_fk` | `(qpos: Tensor) → Tensor[batch,4,4]` | Concrete. Uses compiled `pk_serial_chain` FK + TCP |
+| `get_jacobian` | `(qpos, locations, jac_type) → Tensor` | Concrete. Returns `(batch, 6, dof)` full / `(batch, 3, dof)` trans/rot |
+| `set_tcp` / `get_tcp` | `(np.ndarray[4,4])` | Set/get tool-center-point |
+| `set_qpos_limits` / `get_qpos_limits` | limits as list/Tensor | Set/get per-joint limits |
+| `update_with_robot_limit` | `(robot_qpos_limits: Tensor[DOF,2])` | Clamp solver limits to robot limits |
+| `set_ik_nearest_weight` / `get_ik_nearest_weight` | per-joint weights | Controls nearest-solution ranking |
+
+---
+
+## Configuration
+
+### In `RobotCfg` (`embodichain/lab/sim/cfg.py`)
+
+```python
+@configclass
+class RobotCfg(ArticulationCfg):
+    solver_cfg: Union[SolverCfg, Dict[str, SolverCfg], None] = None
+```
+
+- **Single-part robot**: `solver_cfg = PytorchSolverCfg(...)`.
+- **Multi-part robot** (e.g., dual-arm): `solver_cfg = {"right_arm": SRSSolverCfg(...), "left_arm": SRSSolverCfg(...)}`.
+  Keys must match `control_parts` names in `RobotCfg`.
+
+### Iterative solver common params
+
+`PytorchSolverCfg`, `PinocchioSolverCfg`, `PinkSolverCfg`, and
+`DifferentialSolverCfg` share these fields:
+
+| Field | Default | Purpose |
+|---|---|---|
+| `pos_eps` | `5e-4` | Position convergence tolerance |
+| `rot_eps` | `5e-4` | Rotation convergence tolerance |
+| `max_iterations` | 500–1000 | Iteration cap |
+| `dt` | `0.1` | Numerical integration step |
+| `damp` | `1e-6` | Damping for numerical stability |
+| `is_only_position_constraint` | `False` | Ignore orientation in IK |
+| `num_samples` | 5–30 | Random seeds per solve |
+
+### DifferentialSolver-specific
+
+- `ik_method`: `"pinv"`, `"svd"`, `"trans"`, `"dls"` — Jacobian inversion strategy.
+- `ik_params`: auto-populated defaults per method (e.g., `k_val`, `lambda_val`).
+- `command_type`: `"position"` or `"pose"`.
+- `use_relative_mode`: delta commands relative to current pose.
+
+### PinkSolver-specific
+
+- `variable_input_tasks` / `fixed_input_tasks`: lists of `pink.tasks.FrameTask` for QP optimisation.
+- `mesh_path`: path for Pinocchio URDF mesh loading.
+- `show_ik_warnings` / `fail_on_joint_limit_violation`: error-handling behaviour.
+
+### SRSSolver-specific
+
+- `dh_params`, `link_lengths`, `rotation_directions`, `T_b_ob`, `T_e_oe`: kinematic model params.
+- `sort_ik`: whether to rank solutions by distance to seed.
+- Requires `num_envs` in `init_solver()`.
+
+### OPWSolver-specific
+
+- `a1, a2, b, c1–c4, offsets, flip_axes, has_parallelogram`: OPW kinematic parameters.
+- `safe_margin`: joint-limit safety margin in radians.
+
+---
+
+## Seed Sampling and Null-Space Tasks
+
+### `QposSeedSampler` (`qpos_seed_sampler.py`)
+
+Used by iterative solvers (e.g., `PytorchSolver`) to generate joint-seed
+batches for IK multi-start:
+
+- `__init__(num_samples, dof, device)`
+- `sample(qpos_seed, lower_limits, upper_limits, batch_size) → Tensor[batch*num_samples, dof]`
+  - First sample = provided seed; remaining are uniform-random within limits.
+- `repeat_target_xpos(target_xpos, num_samples)` — repeats target poses to match expanded seed batch.
+
+### `NullSpacePostureTask` (`null_space_posture_task.py`)
+
+A `pink.tasks.Task` subclass for posture control in the null space of
+higher-priority tasks.
+
+- Error: `e(q) = M · (q* − q)` where `M` is a joint-selection mask.
+- Jacobian: null-space projector `N(q) = I − J_primary⁺ · J_primary`.
+- Used exclusively with `PinkSolver` for multi-task QP IK (e.g., controlling
+  posture while satisfying end-effector constraints).
+
+---
+
+## Common Failure Modes
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `get_ik` returns `success=False` for all envs | Target pose unreachable or too few samples | Increase `num_samples`; verify target is within workspace |
+| Joint limits mismatch warnings at init | `user_qpos_limits` shape is wrong | Must be `[2, DOF]` or `[DOF, 2]` |
+| `"Kinematic chain is not initialized"` in FK | `pk_serial_chain` creation failed | Check `urdf_path`, `end_link_name`, `root_link_name` are valid |
+| Solver picks distant IK solution | `ik_nearest_weight` not tuned | Set per-joint weights to prefer important joints |
+| `ImportError` for pinocchio / pink / warp | Optional dependency missing | Install: `pip install pin==2.7.0`, `pip install pin-pink==3.4.0`, or `pip install warp-lang` |
+| `solver_cfg` keys don't match `control_parts` | Multi-part robot misconfiguration | Dict keys in `solver_cfg` must exactly match `control_parts` names |
+| DifferentialSolver oscillates near target | `damp` too low or `dt` too large | Increase `damp` or decrease `dt` |
+| Pink solver ignores orientation | `is_only_position_constraint = True` | Set to `False` for full-pose IK |

--- a/agent_context/topics/manager-functor/manager-functor.md
+++ b/agent_context/topics/manager-functor/manager-functor.md
@@ -1,0 +1,183 @@
+# Manager / Functor Pattern
+
+## Entry Points
+
+| What | Path |
+|------|------|
+| Base classes (`ManagerBase`, `Functor`) | `embodichain/lab/gym/envs/managers/manager_base.py` |
+| All config classes (`FunctorCfg`, `EventCfg`, `ObservationCfg`, `RewardCfg`, `ActionTermCfg`, `DatasetFunctorCfg`, `SceneEntityCfg`) | `embodichain/lab/gym/envs/managers/cfg.py` |
+| Observation manager + built-in functors | `managers/observation_manager.py`, `managers/observations.py` |
+| Reward manager + built-in functors | `managers/reward_manager.py`, `managers/rewards.py` |
+| Event manager + built-in functors | `managers/event_manager.py`, `managers/events.py` |
+| Action manager + built-in terms | `managers/action_manager.py`, `managers/actions.py` |
+| Dataset manager + built-in recorders | `managers/dataset_manager.py`, `managers/datasets.py` |
+| Randomization functors (event sub-type) | `managers/randomization/` (spatial, visual, physics, geometry) |
+
+All paths relative to `embodichain/lab/gym/envs/`.
+
+---
+
+## Overview
+
+Managers orchestrate collections of **functors** that run at specific points in the environment step loop.
+Each manager owns a typed config (`@configclass`) whose attributes are `FunctorCfg` (or subclass) instances.
+At init, the manager resolves every `FunctorCfg.func` (string → callable or class → instance), validates argument signatures against `FunctorCfg.params`, resolves `SceneEntityCfg` objects to scene indices, and groups functors by `mode`.
+
+**Key invariant**: The config attribute name becomes the functor's unique identifier within that manager.
+
+---
+
+## Manager Types
+
+| Manager | Config class per functor | Modes | `compute` / `apply` signature (beyond `self`) |
+|---------|------------------------|-------|-----------------------------------------------|
+| `ObservationManager` | `ObservationCfg` | `modify`, `add` | `compute(obs) → EnvObs` |
+| `RewardManager` | `RewardCfg` | `add`, `replace` | `compute(obs, action, info) → (reward, info_dict)` |
+| `EventManager` | `EventCfg` | `startup`, `reset`, `interval`, user-defined | `apply(mode, env_ids)` |
+| `ActionManager` | `ActionTermCfg` | `pre`, `post` | `process_actions(actions) → EnvAction` |
+| `DatasetManager` | `DatasetFunctorCfg` | `save` | `step(obs, action, done, info)` |
+
+---
+
+## FunctorCfg Pattern
+
+```python
+from embodichain.lab.gym.envs.managers.cfg import FunctorCfg, SceneEntityCfg
+
+FunctorCfg(
+    func=my_function_or_class,   # Callable | str (dot-path) | Functor subclass
+    params={                      # kwargs forwarded to func after positional args
+        "entity_cfg": SceneEntityCfg(uid="cube"),
+        "scale": 1.0,
+    },
+    extra={"shape": (3,)},        # metadata (e.g. observation output shape)
+)
+```
+
+- `func` can be a **string** (resolved via `string_to_callable` at init) or a direct reference.
+- `params` values of type `SceneEntityCfg` are auto-resolved to joint/body indices when the sim starts.
+- Subclass configs add fields: `EventCfg.mode`, `EventCfg.interval_step`, `RewardCfg.weight`, `ObservationCfg.name`, `ActionTermCfg.mode`.
+
+---
+
+## Two Functor Styles
+
+### Function-style
+
+Plain function. The manager calls it directly with positional env args + `**params`.
+
+**Observation functor** (mode `"add"`):
+```python
+def get_object_pose(
+    env: EmbodiedEnv,
+    obs: EnvObs,            # positional: current obs dict
+    entity_cfg: SceneEntityCfg = None,
+    to_matrix: bool = True,
+) -> torch.Tensor:
+    ...
+```
+
+**Reward functor**:
+```python
+def distance_between_objects(
+    env: EmbodiedEnv,
+    obs: dict,
+    action: EnvAction,
+    info: dict,
+    source_entity_cfg: SceneEntityCfg = None,
+    target_entity_cfg: SceneEntityCfg = None,
+    exponential: bool = False,
+    sigma: float = 1.0,
+) -> torch.Tensor:
+    ...
+```
+
+**Event functor**:
+```python
+def randomize_mass(
+    env: EmbodiedEnv,
+    env_ids: Sequence[int] | None,
+    entity_cfg: SceneEntityCfg = None,
+    mass_range: tuple[float, float] = (0.5, 2.0),
+) -> None:
+    ...
+```
+
+### Class-style
+
+Inherit from `Functor`. Manager instantiates the class at init (`func=MyClass` → `MyClass(cfg, env)`), then calls the instance on each step.
+
+```python
+from embodichain.lab.gym.envs.managers import Functor, FunctorCfg
+
+class compute_exteroception(Functor):
+    def __init__(self, cfg: FunctorCfg, env: EmbodiedEnv):
+        super().__init__(cfg, env)
+        # allocate persistent buffers here
+
+    def __call__(self, env: EmbodiedEnv, obs: EnvObs, **params) -> torch.Tensor:
+        # return observation tensor
+        ...
+
+    def reset(self, env_ids=None) -> None:
+        # optional: reset internal state
+        ...
+```
+
+**When to use class-style**: functor needs persistent state, buffers, or expensive one-time setup.
+
+**`ActionTerm`** is a special class-style functor (inherits `Functor`) that must implement `process_action(action) → EnvAction`, `input_key` (property), and `action_dim` (property).
+
+---
+
+## Manager Lifecycle
+
+### Initialization (env `__init__`)
+1. Task config instantiates manager configs (e.g., `ObservationCfg(...)` per functor).
+2. Manager `__init__` calls `_prepare_functors()`:
+   - Iterates config attributes, calls `_resolve_common_functor_cfg()` per functor.
+   - Validates `func` is callable, checks param signatures match (`min_argc` varies by manager).
+   - Resolves `SceneEntityCfg` → joint/body indices (deferred until sim starts via callback).
+   - If `func` is a class, instantiates it: `func = func(cfg=functor_cfg, env=env)`.
+   - Groups functors by `mode` into `_mode_functor_names` / `_mode_functor_cfgs`.
+
+### Per-step execution (env `step`)
+1. **Actions**: `ActionManager.process_actions(raw_actions)` → robot control commands.
+2. **Sim step**: physics advances.
+3. **Observations**: `ObservationManager.compute(obs)` → updated obs dict.
+4. **Rewards**: `RewardManager.compute(obs, action, info)` → `(total_reward, reward_info)`.
+5. **Events**: `EventManager.apply("interval")` for interval-mode functors (step counter checked internally).
+
+### On reset
+1. `EventManager.apply("reset", env_ids)` — domain randomization etc.
+2. All managers' `.reset(env_ids)` — resets class-style functors via `functor.reset(env_ids)`.
+
+---
+
+## Adding New Functors
+
+Use the **`/add-functor`** skill. It scaffolds:
+- Correct function/class signature for the target manager type.
+- Proper imports and `__all__` export.
+- Placement in the right module (`observations.py`, `rewards.py`, `events.py`, `randomization/`, etc.).
+
+Manual checklist if not using the skill:
+1. Write function or `Functor` subclass in the appropriate module.
+2. Add to `__all__` in that module.
+3. Register in the task's config class as a `FunctorCfg` / `ObservationCfg` / `RewardCfg` / `EventCfg` attribute.
+4. Ensure `params` keys match the function's keyword arguments (excluding positional env args).
+
+---
+
+## Common Failure Modes
+
+| Symptom | Cause |
+|---------|-------|
+| `TypeError: ... is not of type FunctorCfg` | Config attribute is not a `FunctorCfg` subclass (e.g., raw dict or wrong type). |
+| `AttributeError: ... is not callable` | `func` is a string that failed to resolve or points to a non-callable. |
+| `ValueError: expects mandatory parameters ...` | `params` dict keys don't match the functor's non-default kwargs (after the positional env args). |
+| `ValueError: scene entity '...' does not exist` | `SceneEntityCfg.uid` doesn't match any asset in `SimulationManager`. Check spelling / scene setup. |
+| `TypeError: ... is not of type ManagerTermBase` | Class-style functor doesn't inherit from `Functor`. |
+| Stale tensor references / data mutation | Function-style functor returns un-cloned mutable tensor. Clone before returning. |
+| `interval` event fires for wrong envs | `EventCfg.is_global=False` (default) means per-env counters; set `True` for global interval. |
+| Observation shape mismatch | `extra={"shape": ...}` doesn't match actual returned tensor shape. |

--- a/agent_context/topics/motion-planning/motion-planning.md
+++ b/agent_context/topics/motion-planning/motion-planning.md
@@ -1,0 +1,168 @@
+# Motion Planning
+
+## Entry Points
+
+| What | Path |
+|---|---|
+| Planner registry | `embodichain/lab/sim/planners/__init__.py` |
+| Base planner class & config | `embodichain/lab/sim/planners/base_planner.py` → `BasePlanner`, `BasePlannerCfg`, `PlanOptions` |
+| TOPPRA planner | `embodichain/lab/sim/planners/toppra_planner.py` → `ToppraPlanner`, `ToppraPlannerCfg`, `ToppraPlanOptions` |
+| Motion generator | `embodichain/lab/sim/planners/motion_generator.py` → `MotionGenerator`, `MotionGenCfg`, `MotionGenOptions` |
+| Planner utilities & data types | `embodichain/lab/sim/planners/utils.py` → `PlanState`, `PlanResult`, `MoveType`, `MovePart`, `TrajectorySampleMethod` |
+
+## Overview
+
+The planning stack has two layers:
+1. **BasePlanner** — low-level trajectory planner that takes a list of `PlanState` waypoints and produces a `PlanResult` with joint trajectories.
+2. **MotionGenerator** — high-level wrapper that composes a planner with optional interpolation, IK resolution, and multi-part coordination.
+
+All planners resolve their robot at init via `SimulationManager.get_instance().get_robot(cfg.robot_uid)`.
+
+## Planner Hierarchy
+
+```
+BasePlanner (ABC)
+  └─ ToppraPlanner        Time-optimal path parameterization
+
+MotionGenerator           Wraps any BasePlanner; adds interpolation and multi-part support
+```
+
+Config hierarchy:
+```
+BasePlannerCfg            robot_uid (MISSING), planner_type
+  └─ ToppraPlannerCfg     planner_type = "toppra"
+
+MotionGenCfg              planner_cfg (MISSING — must be a BasePlannerCfg subclass)
+
+PlanOptions               (empty base)
+  └─ ToppraPlanOptions    constraints, sample_method, sample_interval
+
+MotionGenOptions          start_qpos, control_part, plan_opts, is_interpolate,
+                          interpolate_nums, is_linear, interpolate_position_step,
+                          interpolate_angle_step
+```
+
+## Available Planners
+
+### ToppraPlanner
+
+Time-optimal path parameterization using the [toppra](https://github.com/hungpham2511/toppra) library.
+
+- **Dependency**: `pip install toppra==0.6.3` (import-time error if missing).
+- **Single-instance only**: raises `NotImplementedError` if `robot.num_instances > 1`.
+- **Method**: `plan(target_states, options=ToppraPlanOptions()) → PlanResult`
+
+`ToppraPlanOptions` fields:
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `constraints` | `dict` | `{"velocity": 0.2, "acceleration": 0.5}` | Per-joint or scalar limits |
+| `sample_method` | `TrajectorySampleMethod` | `QUANTITY` | `TIME`, `QUANTITY`, or `DISTANCE` |
+| `sample_interval` | `float \| int` | `0.01` | Time interval (seconds) or sample count depending on method |
+
+### MotionGenerator
+
+Unified interface for trajectory planning with optional pre-interpolation.
+
+- Wraps a `BasePlanner` instance (resolved from `planner_cfg.planner_type`).
+- Supported planner types: `{"toppra": (ToppraPlanner, ToppraPlannerCfg)}`.
+- `MotionGenCfg.planner_cfg` is **MISSING** — must be provided.
+
+`MotionGenOptions` fields:
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `start_qpos` | `torch.Tensor \| None` | `None` | Override starting joint config; `None` = use current robot state |
+| `control_part` | `str \| None` | `None` | Robot control part name (must match `RobotCfg.control_parts` key) |
+| `plan_opts` | `PlanOptions \| None` | `None` | Passed to the underlying planner |
+| `is_interpolate` | `bool` | `False` | Pre-interpolate waypoints before planning |
+| `interpolate_nums` | `int \| list[int]` | `10` | Points per segment (scalar or per-segment list) |
+| `is_linear` | `bool` | `False` | `True` = Cartesian linear interpolation; `False` = joint-space |
+| `interpolate_position_step` | `float` | `0.002` | Cartesian step size (meters) or joint step size (radians) |
+| `interpolate_angle_step` | `float` | `π/90` | Angular step in joint space (radians); only if `is_linear=False` |
+
+## Planner Interface
+
+### PlanState (input)
+
+Describes one waypoint or action:
+
+| Field | Type | Notes |
+|---|---|---|
+| `move_type` | `MoveType` | `TOOL`, `EEF_MOVE`, `JOINT_MOVE`, `SYNC`, `PAUSE` |
+| `move_part` | `MovePart` | `LEFT`, `RIGHT`, `BOTH`, `TORSO`, `ALL` |
+| `xpos` | `torch.Tensor \| None` | 4×4 target TCP pose (for `EEF_MOVE`) |
+| `qpos` | `torch.Tensor \| None` | Target joint angles `(DOF,)` (for `JOINT_MOVE`) |
+| `is_open` | `bool` | Tool open/close (for `TOOL`) |
+| `is_world_coordinate` | `bool` | `True` = world frame; `False` = relative |
+| `pause_seconds` | `float` | Duration for `PAUSE` move type |
+
+### PlanResult (output)
+
+| Field | Type | Notes |
+|---|---|---|
+| `success` | `bool \| torch.Tensor` | Whether planning succeeded |
+| `xpos_list` | `torch.Tensor \| None` | EEF poses `(N, 4, 4)` |
+| `positions` | `torch.Tensor \| None` | Joint positions `(N, DOF)` |
+| `velocities` | `torch.Tensor \| None` | Joint velocities `(N, DOF)` |
+| `accelerations` | `torch.Tensor \| None` | Joint accelerations `(N, DOF)` |
+| `dt` | `torch.Tensor \| None` | Per-step time durations `(N,)` |
+| `duration` | `float \| torch.Tensor` | Total trajectory time (seconds) |
+
+### MoveType enum
+
+| Value | Meaning |
+|---|---|
+| `TOOL` | Tool open/close command |
+| `EEF_MOVE` | End-effector Cartesian move (IK + trajectory) |
+| `JOINT_MOVE` | Joint-space move (trajectory planning only) |
+| `SYNC` | Synchronized dual-arm movement |
+| `PAUSE` | Pause for `pause_seconds` |
+
+### MovePart enum
+
+| Value | Meaning |
+|---|---|
+| `LEFT` | Left arm/EEF |
+| `RIGHT` | Right arm/EEF |
+| `BOTH` | Both arms/EEFs |
+| `TORSO` | Torso (humanoid) |
+| `ALL` | All joints |
+
+## Configuration
+
+### Registering a new planner
+
+1. Create a `BasePlanner` subclass with a `plan()` method decorated with `@validate_plan_options`.
+2. Create a `BasePlannerCfg` subclass with a unique `planner_type` string.
+3. Optionally create a `PlanOptions` subclass for planner-specific options.
+4. Register in `MotionGenerator._support_planner_dict`:
+   ```python
+   _support_planner_dict = {
+       "toppra": (ToppraPlanner, ToppraPlannerCfg),
+       "my_planner": (MyPlanner, MyPlannerCfg),
+   }
+   ```
+5. Export from `embodichain/lab/sim/planners/__init__.py`.
+
+### validate_plan_options decorator
+
+Applied to `plan()` methods to type-check the `options` argument at runtime. Supports three styles:
+- `@validate_plan_options` — bare; validates against base `PlanOptions`.
+- `@validate_plan_options()` — called with no args; same as above.
+- `@validate_plan_options(options_cls=MyPlanOptions)` — custom options class.
+
+### Constraint checking
+
+`BasePlanner.is_satisfied_constraint(vels, accs, constraints)` verifies trajectory outputs stay within limits. Tolerance: 10% for velocity, 25% for acceleration. Supports batch dimensions `(B, N, DOF)`.
+
+## Common Failure Modes
+
+- **`robot_uid` is MISSING** — `BasePlannerCfg.robot_uid` defaults to `MISSING`. Forgetting to set it raises `ValueError` at planner init.
+- **Robot not found** — planner init calls `SimulationManager.get_instance().get_robot(uid)`. If the robot hasn't been added to the sim yet, this returns `None` and raises `ValueError`.
+- **toppra not installed** — `ToppraPlanner` import fails with `ImportError` at module load time if `toppra==0.6.3` is not installed.
+- **Multi-instance robot with ToppraPlanner** — `ToppraPlanner.__init__` raises `NotImplementedError` if `robot.num_instances > 1`. Use a batch-capable planner or single-instance setup.
+- **Wrong PlanOptions subclass** — `@validate_plan_options(options_cls=ToppraPlanOptions)` rejects non-matching options types. Passing a base `PlanOptions()` to `ToppraPlanner.plan()` will error.
+- **MotionGenerator planner_type not registered** — if `planner_cfg.planner_type` is not in `_support_planner_dict`, `MotionGenerator.__init__` fails. Register new planners there first.
+- **Interpolation with unsupported MoveType** — pre-interpolation in `MotionGenOptions` only works for `EEF_MOVE` and `JOINT_MOVE`. Using it with `TOOL`, `SYNC`, or `PAUSE` is ignored or produces unexpected results.
+- **Constraint tolerance** — `is_satisfied_constraint` allows 10% velocity / 25% acceleration overshoot. Dense waypoint trajectories may appear to violate constraints but pass validation.

--- a/agent_context/topics/randomization/randomization.md
+++ b/agent_context/topics/randomization/randomization.md
@@ -1,0 +1,185 @@
+# Randomization
+
+## Entry Points
+
+| What | Path |
+|---|---|
+| Randomization module root | `embodichain/lab/gym/envs/managers/randomization/` |
+| Physics randomizers | `embodichain/lab/gym/envs/managers/randomization/physics.py` |
+| Visual randomizers | `embodichain/lab/gym/envs/managers/randomization/visual.py` |
+| Spatial randomizers | `embodichain/lab/gym/envs/managers/randomization/spatial.py` |
+| Geometry randomizers | `embodichain/lab/gym/envs/managers/randomization/geometry.py` |
+| `EventCfg` (how randomizers are wired) | `embodichain/lab/gym/envs/managers/cfg.py` |
+| `EventManager` (runtime dispatch) | `embodichain/lab/gym/envs/managers/event_manager.py` |
+| Event functors (non-randomization events) | `embodichain/lab/gym/envs/managers/events.py` |
+
+## Overview
+
+All randomization functions are implemented as **event functors**. They follow the standard functor signature `(env, env_ids, entity_cfg, **params) -> None` and are registered via `EventCfg` in a task's event config. The `EventManager` dispatches them at the configured mode (`startup`, `reset`, or `interval`).
+
+The `__init__.py` of the randomization package re-exports everything via `from .physics import *` etc.
+
+## Randomization Types
+
+### Physics (`physics.py`)
+
+| Function | Target | Key params |
+|---|---|---|
+| `randomize_rigid_object_mass` | `RigidObject` mass | `mass_range`, `relative` |
+| `randomize_rigid_object_center_of_mass` | `RigidObject` CoM offset | `com_pos_offset_range` |
+| `randomize_articulation_mass` | `Articulation` link masses | `mass_range` (uniform or per-link dict), `link_names` (regex), `relative` |
+
+- `relative=True` adds sampled value to the initial/default mass instead of replacing.
+- `randomize_articulation_mass` supports a `dict[str, tuple]` for per-link ranges; when used, `link_names` is ignored.
+- Link names are resolved via `resolve_matching_names` (regex matching).
+
+### Visual (`visual.py`)
+
+| Function | Target | Key params |
+|---|---|---|
+| `set_rigid_object_visual_material` | Deterministic material set | `mat_cfg` (`VisualMaterialCfg` or dict) |
+| `set_rigid_object_group_visual_material` | Group material set | `mat_cfg` |
+| `randomize_visual_material` | Random material properties | (varies) |
+| `randomize_camera_extrinsics` | Camera pose | `pos_range`, `euler_range` (attach mode) or `eye_range`, `target_range`, `up_range` (look-at mode) |
+| `randomize_camera_intrinsics` | Camera intrinsic params | (varies) |
+| `randomize_light` | Light pos/color/intensity | `position_range`, `color_range`, `intensity_range` |
+| `randomize_emission_light` | Emission light props | (varies) |
+| `randomize_indirect_lighting` | Indirect lighting | (varies) |
+
+- Camera extrinsics auto-detect mode: if `extrinsics.parent` is set → attach mode (pos/euler perturbation via `set_local_pose`); if `extrinsics.eye` is set → look-at mode (eye/target/up perturbation via `look_at`).
+- `set_rigid_object_visual_material` is deterministic (not random) but uses the same functor mechanism for fixed material assignment at reset.
+- Light randomization applies the **same values across all envs** (documented limitation).
+
+### Spatial (`spatial.py`)
+
+| Function | Target | Key params |
+|---|---|---|
+| `randomize_rigid_object_pose` | Object position/rotation | `position_range`, `rotation_range` (Euler degrees), `relative_position`, `relative_rotation`, `physics_update_step` |
+| `randomize_robot_eef_pose` | Robot end-effector pose | `position_range`, `rotation_range` |
+| `randomize_robot_qpos` | Robot joint positions | (varies) |
+| `randomize_articulation_root_pose` | Articulation root | (varies) |
+| `randomize_target_pose` | Target pose | (varies) |
+
+- Helper: `get_random_pose(init_pos, init_rot, ...)` generates batched random 4×4 poses.
+- Rotation ranges are in **degrees** (converted to radians internally).
+- `relative_position=True` (default) adds offset to initial position; `relative_rotation=False` (default) replaces rotation.
+- After setting pose, `clear_dynamics()` is called to zero out velocities.
+- `physics_update_step > 0` triggers `env.sim.update(step=N)` to let physics settle after randomization.
+
+### Geometry (`geometry.py`)
+
+| Function | Target | Key params |
+|---|---|---|
+| `randomize_rigid_object_scale` | Single object body scale | `scale_factor_range`, `same_scale_all_axes` |
+| `randomize_rigid_objects_scale` | Multiple objects | `entity_cfgs` (list), `shared_sample` |
+| `randomize_rigid_object_body_scale` | *(deprecated)* | Redirects to `randomize_rigid_object_scale` |
+
+- Scale is **multiplicative** (factor), not absolute size.
+- `same_scale_all_axes=True` → single scalar sampled and replicated to x/y/z.
+- `shared_sample=True` → one scale sample shared across all objects in the list.
+- `_normalize_env_ids` helper: if `env_ids is None`, targets all environments.
+
+## Randomization as Events
+
+Randomizers are wired into tasks using `EventCfg`, which extends `FunctorCfg`:
+
+```python
+@configclass
+class EventCfg(FunctorCfg):
+    mode: Literal["startup", "interval", "reset"] = "reset"
+    interval_step: int = 10
+    is_global: bool = False
+```
+
+### Modes
+
+| Mode | When applied | Use case |
+|---|---|---|
+| `startup` | Once when environment initializes | One-time scene setup (e.g., fixed material assignment) |
+| `reset` | Every environment reset | Domain randomization per episode |
+| `interval` | Every `interval_step` env steps | Continuous perturbation during episode |
+
+### `is_global`
+
+- `True` → same interval counter for all envs.
+- `False` → per-env independent interval counters.
+
+### Wiring example
+
+```python
+@configclass
+class MyTaskEventCfg:
+    randomize_obj_mass = EventCfg(
+        func=randomize_rigid_object_mass,
+        mode="reset",
+        params={
+            "entity_cfg": SceneEntityCfg(uid="target_object"),
+            "mass_range": (0.1, 0.5),
+            "relative": False,
+        },
+    )
+
+    randomize_obj_pose = EventCfg(
+        func=randomize_rigid_object_pose,
+        mode="reset",
+        params={
+            "entity_cfg": SceneEntityCfg(uid="target_object"),
+            "position_range": ([-0.05, -0.05, 0.0], [0.05, 0.05, 0.0]),
+            "rotation_range": ([0, 0, -45], [0, 0, 45]),
+        },
+    )
+```
+
+Each `EventCfg` attribute in the config class becomes a named event functor managed by `EventManager`.
+
+## How to Add a Randomizer
+
+1. Use the `/add-functor` skill to scaffold the function with correct signature.
+2. Place function-style randomizers in the appropriate file under `embodichain/lab/gym/envs/managers/randomization/` (physics, visual, spatial, or geometry).
+3. Signature: `def randomize_*(env: EmbodiedEnv, env_ids: torch.Tensor | None, entity_cfg: SceneEntityCfg, **params) -> None`.
+4. Add the function name to `__all__` in the source file.
+5. The `__init__.py` uses wildcard imports, so `__all__` membership is sufficient for export.
+6. Wire it in a task config via `EventCfg(func=your_function, mode="reset", params={...})`.
+
+For class-style randomizers (stateful), inherit from `Functor` and implement `__init__(cfg, env)` + `__call__(env, env_ids, ...)`.
+
+## Configuration
+
+### `FunctorCfg` (base)
+
+```python
+@configclass
+class FunctorCfg:
+    func: Callable | Functor = MISSING     # function or callable class
+    params: dict[str, Any] = dict()         # keyword args passed to func
+    extra: dict[str, Any] = dict()          # metadata (e.g., output shape)
+```
+
+### `SceneEntityCfg`
+
+Used in `params` to reference simulation objects by `uid`. The manager resolves the entity from `SimulationManager` at initialization.
+
+### Range conventions
+
+- Position ranges: `tuple[list[float], list[float]]` → `([x_min, y_min, z_min], [x_max, y_max, z_max])`
+- Rotation ranges: same shape, values in **degrees**
+- Mass ranges: `tuple[float, float]` → `(min, max)` or `dict[str, tuple]` for per-link
+- Scale ranges: `tuple[list[float], list[float]]` → `([sx_min, sy_min, sz_min], [sx_max, sy_max, sz_max])` or `[[s_min], [s_max]]` when `same_scale_all_axes=True`
+
+### Sampling
+
+All randomizers use `embodichain.utils.math.sample_uniform(lower, upper, size)` for uniform sampling.
+
+## Common Failure Modes
+
+| Symptom | Likely cause |
+|---|---|
+| Randomizer silently does nothing | `entity_cfg.uid` not found in `sim.get_rigid_object_uid_list()` — all randomizers early-return on UID mismatch |
+| `ValueError` on link name | `mass_range` dict key doesn't match any `articulation.link_names` |
+| Camera randomization error | Extrinsics config has neither `parent` nor `eye` set — unsupported mode |
+| Light randomization not per-env | By design: `randomize_light` applies same values across all envs |
+| CoM randomization warning on static object | Object is `is_non_dynamic` — CoM cannot be randomized |
+| Scale has no visible effect | `scale_factor_range` is `None` — function returns immediately |
+| Deprecated warning on `randomize_rigid_object_body_scale` | Migrate to `randomize_rigid_object_scale` with `scale_factor_range` parameter |
+| Pose randomization leaves residual velocity | `clear_dynamics()` is called, but if `physics_update_step` is not set, objects may still drift on next step |
+| `env_ids` is `None` at `interval` mode | `_normalize_env_ids` converts `None` to `torch.arange(env.num_envs)` — this is safe |

--- a/agent_context/topics/rl-training/rl-training.md
+++ b/agent_context/topics/rl-training/rl-training.md
@@ -1,0 +1,171 @@
+# RL Training
+
+## Entry Points
+
+| What | Path |
+|------|------|
+| CLI entry | `embodichain/agents/rl/train.py` → `parse_args()` + `train_from_config(config_path)` |
+| Trainer class | `embodichain/agents/rl/utils/trainer.py` → `Trainer` |
+| Package init | `embodichain/agents/rl/__init__.py` — re-exports `algo`, `buffer`, `models`, `utils` |
+
+Run training:
+```bash
+python -m embodichain.agents.rl.train --config <path-to-yaml-or-json> [--distributed | --no-distributed]
+```
+
+## Overview
+
+The RL subsystem implements on-policy reinforcement learning with a modular pipeline:
+
+1. **Config** — JSON/YAML file defines `trainer`, `policy`, and `algorithm` blocks.
+2. **Environment** — Built via `build_env()` from `embodichain.lab.gym.envs.tasks.rl`.
+3. **Policy** — Neural-network module (`Policy` ABC) producing actions from observations.
+4. **Collector** — Steps the env, writes transitions into a preallocated `TensorDict`.
+5. **Buffer** — `RolloutBuffer` owns the preallocated storage; marks it full after collection.
+6. **Algorithm** — Consumes the rollout, computes losses, and updates policy weights.
+7. **Trainer** — Orchestrates the collect → update → log → eval → checkpoint loop.
+
+All rollout data flows as `TensorDict` objects (from the `tensordict` library).
+
+## Architecture
+
+```
+train_from_config()
+  ├─ build_env()                     → Gym env
+  ├─ build_policy(policy_block, ...) → Policy (ActorCritic | ActorOnly | custom)
+  ├─ build_algo(name, cfg, policy)   → Algorithm (PPO | GRPO)
+  └─ Trainer(policy, env, algorithm, ...)
+       ├─ RolloutBuffer  [buffer/standard_buffer.py]
+       ├─ SyncCollector  [collector/sync_collector.py]
+       └─ .train(total_timesteps)
+            loop:
+              _collect_rollout()  →  buffer.start_rollout() → collector.collect() → buffer.add()
+              algorithm.update(buffer.get())
+              _log_train(losses)
+              _eval_once()  (if eval_freq hit)
+              save_checkpoint()  (if save_freq hit)
+```
+
+## PPO Algorithm
+
+**Source**: `embodichain/agents/rl/algo/ppo.py`
+
+- Config: `PPOCfg(AlgorithmCfg)` — `n_epochs=10`, `clip_coef=0.2`, `ent_coef=0.01`, `vf_coef=0.5`.
+- Inherits `AlgorithmCfg` defaults: `lr=3e-4`, `batch_size=64`, `gamma=0.99`, `gae_lambda=0.95`, `max_grad_norm=0.5`.
+- `update(rollout)` flow:
+  1. `compute_gae(rollout, gamma, gae_lambda)` — writes `advantage` and `return` into the TensorDict.
+  2. `transition_view(rollout, flatten=True)` — drops padded final slot, flattens to `[N*T]`.
+  3. For `n_epochs` × minibatch iterations:
+     - Evaluate current policy: `policy.evaluate_actions(batch)` → `logprobs`, `entropy`, `values`.
+     - Clipped surrogate objective + value loss + entropy bonus.
+     - Adam step with `max_grad_norm` clipping.
+
+### GRPO Algorithm
+
+**Source**: `embodichain/agents/rl/algo/grpo.py`
+
+- Config: `GRPOCfg(AlgorithmCfg)` — `group_size=4`, `kl_coef=0.02`, `ent_coef=0.0`, `reset_every_rollout=True`, `truncate_at_first_done=True`.
+- Maintains a frozen `ref_policy` deepcopy for KL penalty when `kl_coef > 0`.
+- Requires `group_size >= 2` for within-group advantage normalization.
+
+### Algorithm Registry
+
+**Source**: `embodichain/agents/rl/algo/__init__.py`
+
+```python
+_ALGO_REGISTRY = {"ppo": (PPOCfg, PPO), "grpo": (GRPOCfg, GRPO)}
+build_algo(name, cfg_kwargs, policy, device, distributed=False)
+```
+
+When `distributed=True`, wraps the policy in `DistributedDataParallel` before passing to the algorithm.
+
+## Rollout Buffer
+
+**Source**: `embodichain/agents/rl/buffer/standard_buffer.py`
+
+- `RolloutBuffer(num_envs, rollout_len, obs_dim, action_dim, device)`.
+- Preallocates a single TensorDict with batch shape `[num_envs, rollout_len + 1]`.
+- The `+1` slot holds the bootstrap observation/value; transition-only fields (`action`, `reward`, `done`) pad the final index.
+- API: `start_rollout()` → returns the shared TensorDict for the collector to write into; `add(rollout)` → marks full; `get(flatten=True)` → returns transition view and clears.
+- **Invariant**: the buffer holds at most one rollout at a time. Calling `start_rollout()` when full raises `RuntimeError`.
+
+### Buffer Utilities
+
+**Source**: `embodichain/agents/rl/buffer/utils.py`
+
+- `transition_view(rollout, flatten)` — slices `[:, :-1]` on transition fields, optionally reshapes to `[N*T]`.
+- `iterate_minibatches(rollout, batch_size, device)` — yields shuffled minibatches from a flattened rollout.
+
+## Actor-Critic Models
+
+**Source**: `embodichain/agents/rl/models/`
+
+### Policy ABC (`policy.py`)
+- `Policy(nn.Module, ABC)` — requires `forward()`, `get_value()`, `evaluate_actions()`.
+- `get_action()` — convenience wrapper calling `forward()` under `torch.no_grad()`.
+- All methods consume and return `TensorDict`.
+
+### ActorCritic (`actor_critic.py`)
+- Gaussian policy with learnable `log_std` per action dim (clamped `[-5, 2]`).
+- Requires externally injected `actor` and `critic` `nn.Module` instances.
+- `forward(td)` → samples action from `Normal(actor(obs), exp(log_std))`, writes `action`, `sample_log_prob`, `value`.
+
+### ActorOnly (`actor_only.py`)
+- Same interface but `value` is always zeros (for algorithms like GRPO that don't use a critic).
+
+### MLP (`mlp.py`)
+- `MLP(nn.Sequential)` — configurable hidden dims, activation, LayerNorm, dropout, orthogonal init.
+
+### Policy Registry (`__init__.py`)
+```python
+_POLICY_REGISTRY: {"actor_critic": ActorCritic, "actor_only": ActorOnly}
+build_policy(policy_block, obs_space, action_space, device, actor, critic)
+build_mlp_from_cfg(module_cfg, in_dim, out_dim)  # expects {"type": "mlp", "network_cfg": {...}}
+```
+
+## Training Pipeline
+
+**Source**: `embodichain/agents/rl/utils/trainer.py`
+
+`Trainer.__init__` creates `RolloutBuffer` and `SyncCollector`.
+
+`Trainer.train(total_timesteps)` loop:
+1. `_collect_rollout()` — calls `buffer.start_rollout()`, then `collector.collect(buffer_size, rollout, on_step_callback)`, then `buffer.add(rollout)`.
+2. `algorithm.update(buffer.get(flatten=False))` — algorithm decides its own flatten/GAE logic.
+3. `_log_train(losses)` — writes to TensorBoard + optional W&B.
+4. Periodic `_eval_once(num_episodes)` and `save_checkpoint()`.
+
+Distributed training:
+- `train_from_config` initializes NCCL process group, offsets seed by rank.
+- Only rank 0 creates log dirs, TensorBoard writer, and W&B.
+- Timestamps are broadcast from rank 0 to ensure consistent run directories.
+
+### Collector
+
+**Source**: `embodichain/agents/rl/collector/sync_collector.py`
+
+`SyncCollector(env, policy, device, reset_every_rollout)`:
+- `collect(num_steps, rollout, on_step_callback)` — steps env synchronously, writing obs/action/reward/done into the preallocated rollout TensorDict.
+- Observations are flattened via `flatten_dict_observation()` before storage.
+- Requires a preallocated rollout (`rollout=None` raises `ValueError`).
+
+### Helper Utilities
+
+**Source**: `embodichain/agents/rl/utils/helper.py`
+
+- `flatten_dict_observation(obs: TensorDict)` → `[num_envs, obs_dim]` tensor.
+- `dict_to_tensordict(obs_dict, device)` → converts env observation mapping to TensorDict.
+
+## Common Failure Modes
+
+| Symptom | Likely Cause |
+|---------|-------------|
+| `RuntimeError: RolloutBuffer already contains a rollout` | Called `start_rollout()` without consuming via `get()`. |
+| `ValueError: Preallocated rollout batch size mismatch` | `buffer_size` in trainer config doesn't match `num_steps` passed to collector. |
+| `ValueError: Algorithm 'X' not found` | Algo name not in `_ALGO_REGISTRY`. Check `get_registered_algo_names()`. |
+| `ValueError: ActorCritic policy requires external 'actor' and 'critic' modules` | Config uses `actor_critic` policy but doesn't define `actor`/`critic` MLP blocks in the JSON. |
+| `ValueError: Configured policy.action_dim=N does not match env action dim M` | `policy.action_dim` in config disagrees with the env's action manager. |
+| `RuntimeError: torch.distributed is not initialized` | `distributed=True` but `init_process_group()` was not called (launch via `torchrun`). |
+| `GRPO: group_size >= 2` | GRPO requires at least 2 environments per group for normalization. |
+| NaN losses | Check `log_std` bounds, gradient clipping, and reward scale. `max_grad_norm` defaults to 0.5. |
+| Stale observations after reset | `SyncCollector` resets obs via `_reset_env()` on init; set `reset_every_rollout=True` if episodes must fully reset between rollouts. |

--- a/agent_context/topics/robot-system/robot-system.md
+++ b/agent_context/topics/robot-system/robot-system.md
@@ -1,0 +1,112 @@
+# Robot System
+
+## Entry Points
+
+| What | Path |
+|---|---|
+| Robot runtime class | `embodichain/lab/sim/objects/robot.py` → `Robot` |
+| RobotCfg base config | `embodichain/lab/sim/cfg.py` → `RobotCfg` (line ~1455) |
+| ArticulationCfg parent | `embodichain/lab/sim/cfg.py` → `ArticulationCfg` (line ~1345) |
+| JointDrivePropertiesCfg | `embodichain/lab/sim/cfg.py` → `JointDrivePropertiesCfg` (line ~654) |
+| Robot registry (all robots) | `embodichain/lab/sim/robots/__init__.py` |
+| DexforceW1 config package | `embodichain/lab/sim/robots/dexforce_w1/` |
+| CobotMagic config | `embodichain/lab/sim/robots/cobotmagic.py` |
+| Add-robot tutorial | `docs/source/tutorial/add_robot.rst` |
+
+## Overview
+
+`Robot` extends `Articulation` (which extends `BatchEntity`). It adds:
+- **Control parts** — named groups of joints (e.g. `left_arm`, `right_eef`) that can be driven independently.
+- **IK solvers** — per-part solver config (`solver_cfg` dict keyed by control-part name).
+- **Planners** — motion planner attachment point.
+
+A `Robot` is instantiated with a `RobotCfg` and a list of DexSim `Articulation` entities.
+
+## RobotCfg Pattern
+
+Inheritance chain:
+
+```
+ObjectBaseCfg          uid, init_pos, init_rot, init_local_pose
+  └─ ArticulationCfg   fpath, drive_pros, attrs, link_attrs, fix_base,
+  │                     disable_self_collision, init_qpos, body_scale,
+  │                     build_pk_chain, use_usd_properties
+      └─ RobotCfg      control_parts, urdf_cfg, solver_cfg, drive_pros (override default to "force")
+          ├─ DexforceW1Cfg   version, arm_kind, with_default_eef
+          └─ CobotMagicCfg   (dual-arm defaults)
+```
+
+Key fields on `RobotCfg`:
+
+| Field | Type | Purpose |
+|---|---|---|
+| `control_parts` | `Dict[str, List[str]] \| None` | Part name → joint names (supports regex like `JOINT[1-6]`) |
+| `urdf_cfg` | `URDFCfg \| None` | Multi-component URDF assembly (e.g. left_arm + right_arm) |
+| `solver_cfg` | `SolverCfg \| Dict[str, SolverCfg] \| None` | IK solver config; dict keys must match `control_parts` keys |
+| `drive_pros` | `JointDrivePropertiesCfg` | Default drive type is `"force"` (overrides Articulation's `"none"`) |
+
+All robot configs support `from_dict(init_dict)` class method for dict-based construction.
+
+## Control Parts
+
+`control_parts` maps a human-readable part name to a list of joint names:
+
+```python
+control_parts = {
+    "left_arm": ["LEFT_JOINT1", ..., "LEFT_JOINT6"],
+    "left_eef": ["LEFT_JOINT7", "LEFT_JOINT8"],
+    "right_arm": ["RIGHT_JOINT1", ..., "RIGHT_JOINT6"],
+    "right_eef": ["RIGHT_JOINT7", "RIGHT_JOINT8"],
+}
+```
+
+- Joint names support **regex patterns** (e.g. `"JOINT[1-6]"`) — expanded at init.
+- When `control_parts` is set, `solver_cfg` **must** be a dict with matching keys.
+- `Robot.get_joint_ids(name)` returns joint IDs for a part; `None` returns all joints.
+- `Robot.get_link_names(name)` returns child link names for a part.
+- Internal `ControlGroup` dataclass stores `joint_names`, `joint_ids`, `link_names` per part.
+
+## Drive Properties
+
+`JointDrivePropertiesCfg` controls the physics drive for joints:
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `drive_type` | `"force" \| "acceleration" \| "none"` | `"force"` (on RobotCfg) | `"none"` means no applied force |
+| `stiffness` | `float \| Dict[str, float]` | `1e4` | Per-joint via dict; keys support regex |
+| `damping` | `float \| Dict[str, float]` | `1e3` | Same |
+| `max_effort` | `float \| Dict[str, float]` | `1e10` | Max torque/force |
+| `max_velocity` | `float \| Dict[str, float]` | `1e10` | rad/s or m/s |
+| `friction` | `float \| Dict[str, float]` | `0.0` | Joint friction |
+
+When using a dict, keys are joint names or regex patterns matching joint names. Control-part names can also be used as keys (resolved via `ArticulationCfg` logic).
+
+## Adding a New Robot
+
+Full guide: `docs/source/tutorial/add_robot.rst`
+
+Minimal checklist:
+1. Create a `@configclass` inheriting `RobotCfg`.
+2. Define `urdf_cfg` with URDF component paths and transforms.
+3. Define `control_parts` mapping part names to joint name lists.
+4. Set `drive_pros` with appropriate stiffness/damping per joint or part.
+5. Configure `solver_cfg` (one `SolverCfg` per control part).
+6. For complex robots with multiple variants, use a sub-package with `types.py`, `params.py`, `utils.py`, `cfg.py` (see `dexforce_w1/` as example).
+7. Export from `embodichain/lab/sim/robots/__init__.py`.
+8. Add robot docs in `docs/source/resources/robot/` and update `docs/source/resources/robot/index.rst`.
+
+## Available Robots
+
+| Robot | Config Class | Module | Structure | Notes |
+|---|---|---|---|---|
+| DexForce W1 | `DexforceW1Cfg` | `embodichain/lab/sim/robots/dexforce_w1/` | Package (`cfg.py`, `types.py`, `params.py`, `utils.py`) | Humanoid; versions: V021; arm kinds: ANTHROPOMORPHIC, INDUSTRIAL; component types: chassis, torso, eyes, head, left/right arm/hand |
+| CobotMagic | `CobotMagicCfg` | `embodichain/lab/sim/robots/cobotmagic.py` | Single file | Dual-arm; 6-DOF arms + 2-DOF grippers; uses OPW solver |
+
+## Common Failure Modes
+
+- **`solver_cfg` keys don't match `control_parts` keys** — solver init silently uses wrong part or errors at IK time.
+- **Regex joint names not expanded** — if robot is not properly initialized, regex patterns like `JOINT[1-6]` remain unexpanded. Always construct via `from_dict()` or let `Robot.__init__` handle expansion.
+- **`drive_type="none"` inherited from ArticulationCfg** — if you inherit `ArticulationCfg` directly instead of `RobotCfg`, the default drive type is `"none"` (no forces applied). Override to `"force"`.
+- **Missing `urdf_cfg` for multi-component robots** — single-file robots use `fpath`; multi-component robots (e.g. dual-arm) require `urdf_cfg` with component transforms.
+- **Mimic joints not excluded** — `get_joint_ids(remove_mimic=False)` includes mimic joints by default. Pass `remove_mimic=True` for active-only joints.
+- **`init_qpos` shape mismatch** — must be `(num_joints,)`. A wrong-length array causes silent truncation or index errors at sim start.

--- a/agent_context/topics/sensor-system/sensor-system.md
+++ b/agent_context/topics/sensor-system/sensor-system.md
@@ -1,0 +1,123 @@
+# Sensor System
+
+## Entry Points
+
+| What | Path |
+|---|---|
+| Sensor registry | `embodichain/lab/sim/sensors/__init__.py` |
+| Base sensor class & config | `embodichain/lab/sim/sensors/base_sensor.py` → `BaseSensor`, `SensorCfg` |
+| Camera | `embodichain/lab/sim/sensors/camera.py` → `Camera`, `CameraCfg` |
+| Stereo camera | `embodichain/lab/sim/sensors/stereo.py` → `StereoCamera`, `StereoCameraCfg` |
+| Contact sensor | `embodichain/lab/sim/sensors/contact_sensor.py` → `ContactSensor`, `ContactSensorCfg` |
+
+## Overview
+
+All sensors inherit from `BaseSensor`, which extends `BatchEntity`. Each sensor:
+- Is configured via a `SensorCfg` subclass (uses `@configclass`).
+- Maintains a `TensorDict` data buffer (`_data_buffer`) sized `[num_envs]`.
+- Must implement `update()` and `get_data()`.
+- Supports dynamic instantiation via `SensorCfg.from_dict()`, which resolves the config class from `sensor_type` string.
+
+## Sensor Hierarchy
+
+```
+ObjectBaseCfg
+  └─ SensorCfg            sensor_type, OffsetCfg, from_dict(), get_data_types()
+      ├─ CameraCfg         width, height, intrinsics, extrinsics, enable_* flags
+      │   └─ StereoCameraCfg   intrinsics_right, left_to_right_pos/rot, enable_disparity
+      └─ ContactSensorCfg  rigid_uid_list, articulation_cfg_list, max_contacts_per_env
+
+BatchEntity
+  └─ BaseSensor            _data_buffer (TensorDict), SUPPORTED_DATA_TYPES
+      ├─ Camera
+      │   └─ StereoCamera
+      └─ ContactSensor
+```
+
+## Available Sensors
+
+| Sensor | Config | `sensor_type` string | Data Types | Notes |
+|---|---|---|---|---|
+| Camera | `CameraCfg` | `"Camera"` | color, depth, mask, normal, position | Single RGB-D camera; configurable intrinsics/extrinsics |
+| StereoCamera | `StereoCameraCfg` | `"StereoCamera"` | color/depth/mask/normal/position (left + right), disparity | Extends Camera; adds right camera with baseline transform |
+| ContactSensor | `ContactSensorCfg` | `"ContactSensor"` | contact data tensors | Collision detection between rigid bodies and articulation links; uses Warp kernels |
+
+## Sensor Configuration
+
+### SensorCfg.OffsetCfg
+
+Defines the sensor pose relative to its parent frame:
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `pos` | `Tuple[float, float, float]` | `(0, 0, 0)` | Position in parent frame |
+| `quat` | `Tuple[float, float, float, float]` | `(1, 0, 0, 0)` | Orientation as `(w, x, y, z)` quaternion |
+| `parent` | `str \| None` | `None` | Parent frame name (e.g. robot link); `None` = arena frame |
+
+The `transformation` property returns a `4×4 torch.Tensor` homogeneous matrix.
+
+### Dynamic Sensor Creation
+
+`SensorCfg.from_dict(init_dict)` creates the correct config class by looking up `init_dict["sensor_type"] + "Cfg"` in the sensors module. Nested configclass fields are recursively initialized via their own `from_dict()`.
+
+## Camera System
+
+### CameraCfg
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `width` | `int` | `640` | Image width in pixels |
+| `height` | `int` | `480` | Image height in pixels |
+| `near` | `float` | `0.005` | Near clipping plane (meters) |
+| `far` | `float` | `100.0` | Far clipping plane (meters) |
+| `intrinsics` | `Tuple[float, float, float, float]` | `(600, 600, 320, 240)` | `(fx, fy, cx, cy)` |
+| `enable_color` | `bool` | `True` | Enable RGBA output |
+| `enable_depth` | `bool` | `False` | Enable depth output |
+| `enable_mask` | `bool` | `False` | Enable instance segmentation mask |
+| `enable_normal` | `bool` | `False` | Enable surface normal output |
+| `enable_position` | `bool` | `False` | Enable 3D position output |
+
+### CameraCfg.ExtrinsicsCfg
+
+Extends `SensorCfg.OffsetCfg` with look-at support:
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `eye` | `Tuple[float,float,float] \| None` | `None` | Camera position |
+| `target` | `Tuple[float,float,float] \| None` | `None` | Look-at target |
+| `up` | `Tuple[float,float,float] \| None` | `None` | Up vector; defaults to `(0, 0, 1)` if `eye` is set |
+
+When `eye` is provided, the transformation is computed via `look_at_to_pose()`. Otherwise falls back to `pos`/`quat`.
+
+### StereoCameraCfg
+
+Extends `CameraCfg` with stereo-specific fields:
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `intrinsics_right` | `Tuple[float,float,float,float]` | `(600, 600, 320, 240)` | Right camera intrinsics |
+| `left_to_right_pos` | `Tuple[float,float,float]` | `(0.05, 0, 0)` | Baseline translation (5cm default) |
+| `left_to_right_rot` | `Tuple[float,float,float]` | `(0, 0, 0)` | Rotation in degrees |
+| `enable_disparity` | `bool` | `False` | Enable disparity map output |
+
+Properties `left_to_right` and `right_to_left` return `4×4` transform tensors. All enabled data types are duplicated for left and right (e.g. `color`, `color_right`).
+
+### ContactSensorCfg
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `rigid_uid_list` | `List[str]` | `[]` | UIDs of rigid bodies to monitor |
+| `articulation_cfg_list` | `List[ArticulationContactFilterCfg]` | `[]` | Articulation link filters |
+| `filter_need_both_actor` | `bool` | `True` | Require both actors in filter list |
+| `max_contacts_per_env` | `int` | `64` | Max contacts per environment |
+
+`ArticulationContactFilterCfg` specifies `articulation_uid` and `link_name_list` to filter which links report contacts.
+
+## Common Failure Modes
+
+- **`sensor_type` string mismatch** — `SensorCfg.from_dict()` looks up `sensor_type + "Cfg"` in the sensors module. A typo (e.g. `"camera"` instead of `"Camera"`) causes `AttributeError`.
+- **Depth not enabled** — `enable_depth` defaults to `False`. Accessing depth data without enabling it returns empty tensors.
+- **Parent frame not found** — `OffsetCfg.parent` must exactly match a link name in the scene. A wrong name silently places the sensor at the arena origin.
+- **Stereo baseline sign** — `left_to_right_pos` defines translation from left to right camera. Flipping the sign inverts the disparity.
+- **Contact sensor buffer overflow** — `max_contacts_per_env` caps the contact count. Exceeding it silently drops contacts; increase if the scene has dense collisions.
+- **View attribute flags** — `Camera.get_view_attrib()` computes `dr.ViewFlags` from enabled booleans. Adding a new data type requires both the `enable_*` flag and the corresponding `ViewFlags` bit.

--- a/skills/project-dev-context/SKILL.md
+++ b/skills/project-dev-context/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: project-dev-context
+description: Use when a request asks to reference, refresh, write, or register project development context so the agent resolves the topic through agent_context/MAP.yaml and reads or updates the mapped Markdown context files.
+---
+
+# Project Dev Context
+
+Use this skill when:
+- the request says `reference project development docs`
+- the request says `reference project context`
+- the request says `refresh project context`
+- the request says `update project context`
+- the request says `write project context`
+- the request says `参考项目开发文档`
+- the request says `参考项目上下文`
+- the request says `刷新项目上下文`
+- the request says `更新项目上下文`
+- the request says `写项目上下文`
+- the request names a known project topic such as `env-framework`, `manager-functor`, or `ik-solvers`
+
+## Start here
+
+- Read `agent_context/MAP.yaml` first
+- Read `agent_context/conventions/*.md` when creating or updating context files
+
+## Workflow
+
+1. Resolve the topic through `agent_context/MAP.yaml`
+2. Match in this order: exact `id`, then `aliases`, then `keywords`
+3. Choose the operation mode:
+   - **read**: load only the matched Markdown files under `agent_context/`
+   - **refresh existing topic**: re-read `source_of_truth` and rewrite the mapped topic Markdown so it matches current implementation
+   - **add new topic**: write a new topic Markdown file and register it in `agent_context/MAP.yaml`
+4. Load `agent_context/conventions/*.md` if you add or update context files
+5. Do not re-read `docs/source/` unless the user explicitly asks for Sphinx documentation
+
+This skill routes context. It does not replace the underlying source-of-truth files listed in each topic entry.
+
+## Explicit refresh mode
+
+Use explicit refresh mode when the request is phrased like:
+
+- `refresh <topic> context`
+- `update <topic> context`
+- `根据当前实现刷新 <topic> 上下文`
+- `重写 <topic> 项目上下文`
+
+In refresh mode:
+
+1. Resolve the topic in `agent_context/MAP.yaml`
+2. Re-read the files listed in `source_of_truth`
+3. Rewrite the mapped topic Markdown from current implementation, not stale notes
+4. Update `aliases`, `keywords`, `paths`, `related_topics` if needed
+
+## Update contract
+
+If code behavior changes a routed topic, update all relevant pieces in the same change:
+- the matching file under `agent_context/topics/...`
+- `agent_context/MAP.yaml` if topic metadata changed
+- `AGENTS.md` if routing guidance changed
+
+## Source-of-truth
+
+This skill does not store the project knowledge itself. The canonical project context lives in:
+- `agent_context/MAP.yaml`
+- `agent_context/topics/**/*.md`
+- `agent_context/conventions/*.md`
+
+## Map schema
+
+`agent_context/MAP.yaml` topic entry fields:
+
+- `id` — stable kebab-case identifier
+- `title` — human-readable title
+- `aliases` — alternate names for matching
+- `keywords` — search terms for fuzzy matching
+- `paths` — Markdown files under `agent_context/` to load
+- `source_of_truth` — source code files that define the behavior
+- `related_topics` — other topic ids for cross-reference
+- `status` — `active` or `deprecated`


### PR DESCRIPTION
## Overview

Add a structured agent context system for EmbodiChain following DexSim's pattern, enabling agents to access modular, topic-specific documentation instead of a monolithic reference file.

## Changes

- **agent_context/MAP.yaml** — Topic registry with 9 active topics (routing by id → aliases → keywords)
- **agent_context/conventions/*** — Writing style, naming, and lifecycle rules for context files
- **agent_context/topics/*** — 9 topic context files covering core subsystems:
  - `env-framework` — EmbodiedEnv lifecycle and task registration
  - `manager-functor` — Manager/Functor pattern and FunctorCfg
  - `ik-solvers` — IK solver system (SRS, OPW, pink, pinocchio, pytorch, differential)
  - `robot-system` — Robot configs, control parts, drive properties
  - `sensor-system` — Camera, stereo, contact sensors
  - `motion-planning` — TOPPRA and motion generator
  - `rl-training` — PPO, rollout buffer, actor-critic training pipeline
  - `configclass-pattern` — @configclass decorator and config patterns
  - `randomization` — Domain randomization managers

- **skills/project-dev-context/SKILL.md** — Canonical routing skill for resolving topics

- **AGENTS.md** — Added Section 0 for agent context routing; existing content preserved

## Design

Follows DexSim's agent context organization:
- Separation: Agent context (agent_context/) vs. human docs (docs/)
- Routing: MAP.yaml is the single registry; agents resolve by topic id, aliases, or keywords
- Operations: read, refresh, add-new-topic
- Conventions: Writing style, naming, lifecycle rules to keep context current
- Update contract: When code changes, routed context is updated in the same PR

## Adaptations for EmbodiChain

- No `developer_docs/MAP.yaml` (EmbodiChain uses Sphinx docs/ directly)
- Skills placed in `skills/` (matching existing convention)
- Topics are Python-only (simpler than DexSim's C++/Python mix)
