### PR TITLE
Auto-select default renderer based on GPU

### DIFF
--- a/docs/source/overview/sim/sim_manager.md
+++ b/docs/source/overview/sim/sim_manager.md
@@ -64,9 +64,31 @@ The {class}`~cfg.RenderCfg` class controls the rendering backend and quality set
 
 | Parameter | Type | Default | Description |
 | :--- | :--- | :--- | :--- |
-| `renderer` | `str` | `"hybrid"` | Renderer backend to use. Options are `'hybrid'` (ray tracing for shadows/reflections + rasterization), `'fast-rt'` (full ray tracing), and `'rt'` (offline ray-traced renderer for maximum visual fidelity). |
+| `renderer` | `str` | `"auto"` | Renderer backend to use. Options are `'auto'` (pick a default based on the detected GPU), `'hybrid'` (ray tracing for shadows/reflections + rasterization), `'fast-rt'` (full ray tracing), and `'rt'` (offline ray-traced renderer for maximum visual fidelity). |
 | `enable_denoiser` | `bool` | `True` | Whether to enable denoising. Only valid when `renderer` is `'hybrid'`, `'fast-rt'` or `'rt'`. |
 | `spp` | `int` | `64` | Samples per pixel for ray tracing rendering. Only valid when `renderer` is `'hybrid'`, `'fast-rt'` or `'rt'` and `enable_denoiser` is `False`. |
+
+#### Automatic Renderer Selection
+
+By default (`renderer="auto"`), EmbodiChain selects the renderer based on the GPU detected at the configured `gpu_id` when the {class}`SimulationManager` is constructed:
+
+| GPU class | Examples | Selected renderer |
+| :--- | :--- | :--- |
+| RTX-series (consumer/workstation) | RTX 4090, RTX 6000 Ada | `hybrid` |
+| Datacenter accelerators | A100, A800, H100, H800, H200, H20 | `fast-rt` |
+| No CUDA device / unknown GPU | — | `hybrid` (fallback) |
+
+You can override the global default at runtime — useful for forcing a renderer across all simulations regardless of hardware:
+
+```python
+from embodichain.lab.sim import SimulationManager
+
+# Resolve the default from the current GPU, or force a specific backend.
+SimulationManager.set_default_renderer("auto")       # auto-detect from GPU
+SimulationManager.set_default_renderer("fast-rt")    # force full ray tracing
+```
+
+Setting `render_cfg.renderer` explicitly always takes precedence over auto-selection:
 
 ```python
 from embodichain.lab.sim import SimulationManagerCfg
@@ -74,7 +96,7 @@ from embodichain.lab.sim.cfg import RenderCfg
 
 sim_config = SimulationManagerCfg(
     render_cfg=RenderCfg(
-        renderer="fast-rt",    # Use full ray tracing
+        renderer="fast-rt",    # Use full ray tracing (overrides auto-selection)
         enable_denoiser=True,  # Enable denoising
         spp=64,                # Samples per pixel (used when denoiser is off)
     )

--- a/embodichain/lab/gym/utils/gym_utils.py
+++ b/embodichain/lab/gym/utils/gym_utils.py
@@ -772,8 +772,8 @@ def add_env_launcher_args_to_parser(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--renderer",
         type=str,
-        choices=["hybrid", "fast-rt", "rt"],
-        default="hybrid",
+        choices=["auto", "hybrid", "fast-rt", "rt"],
+        default="auto",
         help="Renderer backend to use for the simulation.",
     )
     parser.add_argument(

--- a/embodichain/lab/sim/cfg.py
+++ b/embodichain/lab/sim/cfg.py
@@ -45,7 +45,7 @@ from .shapes import ShapeCfg, MeshCfg
 #
 # The sentinel value ``"auto"`` defers the choice to GPU-based auto-selection
 # performed lazily when a :class:`SimulationManager` is constructed (see
-# :func:`embodichain.lab.sim.sim_manager.select_default_renderer`). Assigning a
+# :func:`embodichain.lab.sim.utility.render_utils.select_default_renderer`). Assigning a
 # concrete renderer here (e.g. in test fixtures) forces that renderer and takes
 # precedence over auto-selection.
 DEFAULT_RENDERER: Literal["auto", "hybrid", "fast-rt", "rt"] = "auto"

--- a/embodichain/lab/sim/cfg.py
+++ b/embodichain/lab/sim/cfg.py
@@ -41,16 +41,25 @@ from embodichain.utils.utility import key_in_nested_dict
 
 from .shapes import ShapeCfg, MeshCfg
 
-# Global default renderer settings for simulation
-DEFAULT_RENDERER: Literal["hybrid", "fast-rt", "rt"] = "hybrid"
+# Global default renderer settings for simulation.
+#
+# The sentinel value ``"auto"`` defers the choice to GPU-based auto-selection
+# performed lazily when a :class:`SimulationManager` is constructed (see
+# :func:`embodichain.lab.sim.sim_manager.select_default_renderer`). Assigning a
+# concrete renderer here (e.g. in test fixtures) forces that renderer and takes
+# precedence over auto-selection.
+DEFAULT_RENDERER: Literal["auto", "hybrid", "fast-rt", "rt"] = "auto"
 
 
 @configclass
 class RenderCfg:
-    renderer: Literal["hybrid", "fast-rt", "rt"] = "hybrid"
-    """Renderer backend to use for the simulation. Options are 'hybrid', 'fast-rt', and 'rt'.
+    renderer: Literal["auto", "hybrid", "fast-rt", "rt"] = "auto"
+    """Renderer backend to use for the simulation. Options are 'auto', 'hybrid', 'fast-rt', and 'rt'.
 
     Note:
+    - 'auto' selects a default renderer based on the detected GPU: RTX-series cards use
+        'hybrid', while datacenter cards (A100/A800, H100/H800/H200/H20) use 'fast-rt'.
+        If no CUDA device is available or the GPU is unknown, it falls back to 'hybrid'.
     - 'hybrid' uses ray tracing for shadows and reflections while keeping rasterization for primary rendering,
         providing a balance between performance and visual quality.
     - 'fast-rt' is a fully ray-traced renderer for maximum visual fidelity, but may have higher computational cost.
@@ -70,9 +79,17 @@ class RenderCfg:
             return Renderer.FASTRT
         elif self.renderer == "rt":
             return Renderer.OFFLINERT
+        elif self.renderer == "auto":
+            # 'auto' is normally resolved by the SimulationManager before this is
+            # called. If it reaches here (e.g. used standalone), fall back safely.
+            logger.log_warning(
+                "Renderer 'auto' was not resolved before converting to dexsim flags. "
+                "Falling back to 'hybrid'."
+            )
+            return Renderer.HYBRID
         else:
             logger.log_error(
-                f"Invalid renderer type '{self.renderer}' specified. Must be one of 'hybrid', 'fast-rt', or 'rt'."
+                f"Invalid renderer type '{self.renderer}' specified. Must be one of 'auto', 'hybrid', 'fast-rt', or 'rt'."
             )
 
 

--- a/embodichain/lab/sim/sim_manager.py
+++ b/embodichain/lab/sim/sim_manager.py
@@ -360,14 +360,15 @@ class SimulationManager:
         """Set the global default renderer used by new simulations.
 
         This updates :data:`embodichain.lab.sim.cfg.DEFAULT_RENDERER`, which is
-        consulted whenever a :class:`SimulationManagerCfg` is created with the
-        default ``render_cfg.renderer="auto"``.
+        consulted by :func:`embodichain.lab.sim.utility.render_utils.select_default_renderer`
+        when ``render_cfg.renderer="auto"`` is resolved during :class:`SimulationManager`
+        construction.
 
         Args:
             renderer: The renderer to set. One of ``"auto"``, ``"hybrid"``,
                 ``"fast-rt"``, or ``"rt"``. When ``"auto"``, the renderer is
                 resolved immediately from the detected GPU via
-                :func:`select_default_renderer`.
+                :func:`embodichain.lab.sim.utility.render_utils.select_default_renderer`.
             gpu_id: The CUDA device index to query when ``renderer="auto"``.
 
         Returns:

--- a/embodichain/lab/sim/sim_manager.py
+++ b/embodichain/lab/sim/sim_manager.py
@@ -355,6 +355,44 @@ class SimulationManager:
         """
         return instance_id in cls._instances
 
+    @classmethod
+    def set_default_renderer(cls, renderer: str = "auto", gpu_id: int = 0) -> str:
+        """Set the global default renderer used by new simulations.
+
+        This updates :data:`embodichain.lab.sim.cfg.DEFAULT_RENDERER`, which is
+        consulted whenever a :class:`SimulationManagerCfg` is created with the
+        default ``render_cfg.renderer="auto"``.
+
+        Args:
+            renderer: The renderer to set. One of ``"auto"``, ``"hybrid"``,
+                ``"fast-rt"``, or ``"rt"``. When ``"auto"``, the renderer is
+                resolved immediately from the detected GPU via
+                :func:`select_default_renderer`.
+            gpu_id: The CUDA device index to query when ``renderer="auto"``.
+
+        Returns:
+            The resolved renderer name that was set as the default.
+        """
+        from embodichain.lab.sim import cfg
+        from embodichain.lab.sim.utility.render_utils import select_default_renderer
+
+        valid = {"auto", "hybrid", "fast-rt", "rt"}
+        if renderer not in valid:
+            logger.log_error(
+                f"Invalid renderer '{renderer}'. Must be one of {sorted(valid)}."
+            )
+
+        if renderer == "auto":
+            # Force auto-detection regardless of any previously forced default.
+            cfg.DEFAULT_RENDERER = "auto"
+            resolved = select_default_renderer(gpu_id)
+        else:
+            resolved = renderer
+
+        cfg.DEFAULT_RENDERER = resolved
+        logger.log_info(f"Default renderer set to '{resolved}'.")
+        return resolved
+
     @cached_property
     def num_envs(self) -> int:
         """Get the number of arenas in the simulation.
@@ -409,6 +447,17 @@ class SimulationManager:
         world_config.cache_path = str(self._material_cache_dir)
         world_config.length_tolerance = sim_config.physics_config.length_tolerance
         world_config.speed_tolerance = sim_config.physics_config.speed_tolerance
+
+        if sim_config.render_cfg.renderer == "auto":
+            from embodichain.lab.sim.utility.render_utils import (
+                select_default_renderer,
+            )
+
+            resolved_renderer = select_default_renderer(sim_config.gpu_id)
+            logger.log_info(
+                f"Auto-selected '{resolved_renderer}' renderer for gpu_id={sim_config.gpu_id}."
+            )
+            sim_config.render_cfg.renderer = resolved_renderer
 
         world_config.renderer = sim_config.render_cfg.to_dexsim_flags()
         if sim_config.render_cfg.enable_denoiser is False:

--- a/embodichain/lab/sim/utility/__init__.py
+++ b/embodichain/lab/sim/utility/__init__.py
@@ -18,3 +18,4 @@ from .sim_utils import *
 from .mesh_utils import *
 from .gizmo_utils import *
 from .keyboard_utils import *
+from .render_utils import *

--- a/embodichain/lab/sim/utility/render_utils.py
+++ b/embodichain/lab/sim/utility/render_utils.py
@@ -1,0 +1,87 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import torch
+
+from embodichain.utils import logger
+
+__all__ = ["select_default_renderer"]
+
+# GPU name fragments that map to a fully ray-traced ('fast-rt') default. These
+# are datacenter accelerators where ray tracing throughput is preferred over the
+# rasterization fast-path used on consumer (RTX) cards.
+_FAST_RT_GPU_KEYWORDS = ("A100", "A800", "H100", "H800", "H200", "H20")
+
+
+def select_default_renderer(gpu_id: int = 0) -> str:
+    """Select the default renderer backend based on the detected GPU.
+
+    The selection rule is:
+
+    - If :data:`embodichain.lab.sim.cfg.DEFAULT_RENDERER` is set to a concrete
+      value (anything other than ``"auto"``), that value is honored. This lets
+      callers (e.g. test fixtures) force a renderer regardless of hardware.
+    - RTX-series cards use ``"hybrid"`` (ray tracing for shadows/reflections with
+      rasterized primary rendering).
+    - Datacenter cards (A100/A800, H100/H800/H200/H20) use ``"fast-rt"`` (fully
+      ray-traced rendering).
+    - If no CUDA device is available or the GPU name is unrecognized, falls back
+      to ``"hybrid"``.
+
+    Args:
+        gpu_id: The CUDA device index to query for selecting the renderer.
+
+    Returns:
+        The resolved renderer name, one of ``"hybrid"``, ``"fast-rt"``, or ``"rt"``.
+    """
+    from embodichain.lab.sim import cfg
+
+    # Explicit override takes precedence over hardware auto-detection.
+    if cfg.DEFAULT_RENDERER != "auto":
+        return cfg.DEFAULT_RENDERER
+
+    if not torch.cuda.is_available():
+        logger.log_info("No CUDA device available; defaulting renderer to 'hybrid'.")
+        return "hybrid"
+
+    try:
+        device_name = torch.cuda.get_device_name(gpu_id)
+    except Exception as exc:
+        logger.log_warning(
+            f"Failed to query GPU name for device {gpu_id} ({exc}). "
+            "Defaulting renderer to 'hybrid'."
+        )
+        return "hybrid"
+
+    upper_name = device_name.upper()
+    if any(keyword in upper_name for keyword in _FAST_RT_GPU_KEYWORDS):
+        logger.log_info(
+            f"Detected datacenter GPU '{device_name}'; selecting 'fast-rt' renderer."
+        )
+        return "fast-rt"
+
+    if "RTX" in upper_name:
+        logger.log_info(
+            f"Detected RTX GPU '{device_name}'; selecting 'hybrid' renderer."
+        )
+        return "hybrid"
+
+    logger.log_info(
+        f"Unrecognized GPU '{device_name}'; defaulting renderer to 'hybrid'."
+    )
+    return "hybrid"


### PR DESCRIPTION
## Description

This PR makes the simulation renderer default to `"auto"`, which selects a
backend based on the detected GPU when a `SimulationManager` is constructed:

- RTX-series cards -> `hybrid`
- Datacenter cards (A100/A800, H100/H800/H200/H20) -> `fast-rt`
- No CUDA device / unknown GPU -> `hybrid` (fallback)

GPU detection lives in `embodichain/lab/sim/utility/render_utils.py`
(`select_default_renderer`). The `SimulationManager.set_default_renderer()`
classmethod lets users force a backend at runtime, and an explicit
`render_cfg.renderer` always takes precedence over auto-selection. The
`--renderer` CLI arg gains an `auto` choice (now the default).

Detection is lazy (only on manager construction), so importing the config
module does not initialize a CUDA context.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which improves an existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (existing functionality will not work without user modification)
- [ ] Documentation update

## Checklist

- [x] I have run the `black .` command to format the code base.
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Dependencies have been updated, if applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)