### PR TITLE
Fix GPU physics initialization sync

### DIFF
--- a/embodichain/lab/sim/objects/articulation.py
+++ b/embodichain/lab/sim/objects/articulation.py
@@ -932,7 +932,6 @@ class Articulation(BatchEntity):
                 )
             # TODO: in manual physics mode, the update should be explicitly called after
             # setting the pose to synchronize the state to renderer.
-            self._world.update(0.001)
 
         else:
             if pose.dim() == 2 and pose.shape[1] == 7:
@@ -956,6 +955,7 @@ class Articulation(BatchEntity):
                 data_type=ArticulationGPUAPIWriteType.ROOT_GLOBAL_POSE,
             )
             self._ps.gpu_compute_articulation_kinematic(gpu_indices=indices)
+        self._world.update(0.001)
 
     def get_local_pose(self, to_matrix=False) -> torch.Tensor:
         """Get local pose (root link pose) of the articulation.
@@ -1670,8 +1670,7 @@ class Articulation(BatchEntity):
             self._ps.gpu_compute_articulation_kinematic(
                 gpu_indices=self.body_data.gpu_indices[local_env_ids]
             )
-        else:
-            self._world.update(0.001)
+        self._world.update(0.001)
 
     def _set_default_joint_drive(self) -> None:
         """Set default joint drive parameters based on the configuration."""

--- a/embodichain/lab/sim/robots/cobotmagic.py
+++ b/embodichain/lab/sim/robots/cobotmagic.py
@@ -194,19 +194,21 @@ if __name__ == "__main__":
     torch.set_printoptions(precision=5, sci_mode=False)
 
     config = SimulationManagerCfg(
-        headless=False,
-        sim_device="cpu",
+        headless=True,
+        sim_device="cuda",
         num_envs=2,
         render_cfg=RenderCfg(renderer="fast-rt"),
     )
     sim = SimulationManager(config)
 
-    config = {
-        "init_pos": [0.0, 0.0, 1.0],
-    }
+    config = {"init_pos": [0.0, 0.0, 1.0], "init_qpos": [0.1] * 16}
 
     cfg = CobotMagicCfg.from_dict(config)
     robot = sim.add_robot(cfg=cfg)
+    sim.open_window()
+
+    if sim.is_use_gpu_physics:
+        sim.init_gpu_physics()
 
     print("CobotMagic added to the simulation.")
 

--- a/examples/sim/demo/grasp_cup_to_caffe.py
+++ b/examples/sim/demo/grasp_cup_to_caffe.py
@@ -419,7 +419,6 @@ def main():
     table = create_table(sim)
     caffe = create_caffe(sim)
     cup = create_cup(sim)
-    sim.update(step=1)
 
     # apply random perturbation
     apply_random_xy_perturbation(cup, max_perturbation=0.05)
@@ -427,6 +426,9 @@ def main():
 
     if not args.headless:
         sim.open_window()
+
+    if sim.is_use_gpu_physics:
+        sim.init_gpu_physics()
 
     run_simulation(sim, robot, cup, caffe)
 

--- a/scripts/tutorials/sim/atomic_actions.py
+++ b/scripts/tutorials/sim/atomic_actions.py
@@ -99,16 +99,12 @@ def initialize_simulation(args):
         width=1920,
         height=1080,
         headless=True,
-        sim_device="cuda",
+        sim_device=args.device,
         physics_dt=1.0 / 100.0,
         num_envs=args.num_envs,
         render_cfg=RenderCfg(renderer=args.renderer),
     )
     sim = SimulationManager(sim_cfg)
-
-    light = sim.add_light(
-        cfg=LightCfg(uid="main_light", intensity=50.0, init_pos=(0, 0, 2.0))
-    )
 
     return sim
 
@@ -251,9 +247,11 @@ def main():
         actions_cfg_list=[pickup_cfg, place_cfg, move_cfg],
     )
 
-    sim.init_gpu_physics()
     if not args.headless:
         sim.open_window()
+
+    if sim.is_use_gpu_physics:
+        sim.init_gpu_physics()
 
     # ------------------------------------------------------------------ #
     # Step 5: Describe the mug with ObjectSemantics                       #


### PR DESCRIPTION
# Description

This PR updates articulation pose synchronization so the simulation world is updated after both CPU and GPU pose writes. It also adjusts example/tutorial initialization to initialize GPU physics only when GPU physics is active, and after the optional window setup.

Fixes # (issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Enhancement (non-breaking change which improves an existing functionality)

## Screenshots

Not applicable.

## Verification

- `python -m black embodichain/lab/sim/objects/articulation.py embodichain/lab/sim/robots/cobotmagic.py examples/sim/demo/grasp_cup_to_caffe.py scripts/tutorials/sim/atomic_actions.py`
- `python -m py_compile embodichain/lab/sim/objects/articulation.py embodichain/lab/sim/robots/cobotmagic.py examples/sim/demo/grasp_cup_to_caffe.py scripts/tutorials/sim/atomic_actions.py`

## Notes

- The untracked `gym_project/` directory was intentionally excluded from this PR because it is generated data, is about 4.1 GB, and contains a plaintext `.env` with an API key.

## Checklist

- [ ] I have run the `black .` command to format the code base.
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Dependencies have been updated, if applicable.
