### PR TITLE
Add press atomic action

### DIFF
--- a/embodichain/lab/sim/atomic_actions/__init__.py
+++ b/embodichain/lab/sim/atomic_actions/__init__.py
@@ -36,10 +36,12 @@ from .actions import (
     MoveObjectAction,
     PickUpAction,
     PlaceAction,
+    PressAction,
     MoveActionCfg,
     MoveObjectActionCfg,
     PickUpActionCfg,
     PlaceActionCfg,
+    PressActionCfg,
 )
 from .engine import (
     AtomicActionEngine,
@@ -62,10 +64,12 @@ __all__ = [
     "MoveObjectAction",
     "PickUpAction",
     "PlaceAction",
+    "PressAction",
     "MoveActionCfg",
     "MoveObjectActionCfg",
     "PickUpActionCfg",
     "PlaceActionCfg",
+    "PressActionCfg",
     # Engine
     "AtomicActionEngine",
     "register_action",

--- a/embodichain/lab/sim/atomic_actions/actions.py
+++ b/embodichain/lab/sim/atomic_actions/actions.py
@@ -362,6 +362,208 @@ class _HandCloseAction(MoveAction):
 
 
 @configclass
+class PressActionCfg(HandCloseActionCfg):
+    name: str = "press"
+    """Name of the action, used for identification and logging."""
+
+    hand_interp_steps: int = 8
+    """Number of waypoints for closing the gripper before pressing."""
+
+
+class PressAction(_HandCloseAction):
+    def __init__(
+        self,
+        motion_generator: MotionGenerator,
+        cfg: PressActionCfg | None = None,
+    ):
+        """
+        Initialize the atomic action.
+        Args:
+            motion_generator: The motion generator instance to use for planning.
+            cfg: Configuration for the action.
+        """
+        super().__init__(
+            motion_generator,
+            cfg=cfg if cfg is not None else PressActionCfg(),
+            cfg_name="PressActionCfg",
+        )
+
+    def _compute_press_waypoints(self) -> tuple[int, int, int]:
+        """Split waypoints into hand-close, down, and return phases."""
+        hand_waypoints = self.cfg.hand_interp_steps
+        if hand_waypoints < 1:
+            logger.log_error(
+                "hand_interp_steps must be at least 1 for PressActionCfg.",
+                ValueError,
+            )
+
+        motion_waypoints = self.cfg.sample_interval - hand_waypoints
+        down_waypoints = motion_waypoints // 2
+        back_waypoints = motion_waypoints - down_waypoints
+        if down_waypoints < 2 or back_waypoints < 2:
+            logger.log_error(
+                "Not enough waypoints for press trajectory. Please increase "
+                "sample_interval or decrease hand_interp_steps.",
+                ValueError,
+            )
+        return hand_waypoints, down_waypoints, back_waypoints
+
+    def _resolve_current_hand_qpos(
+        self, current_qpos: torch.Tensor | None
+    ) -> torch.Tensor:
+        """Resolve the hand qpos at the start of the press action."""
+        if current_qpos is None:
+            return self.robot.get_qpos(name=self.cfg.hand_control_part).to(
+                device=self.device, dtype=torch.float32
+            )
+
+        current_qpos = current_qpos.to(device=self.device, dtype=torch.float32)
+        if current_qpos.dim() == 1:
+            current_qpos = current_qpos.unsqueeze(0).repeat(self.n_envs, 1)
+        if current_qpos.shape[0] != self.n_envs:
+            logger.log_error(
+                f"current_qpos must have batch size {self.n_envs}, "
+                f"but got {current_qpos.shape[0]}",
+                ValueError,
+            )
+
+        hand_dof = len(self.hand_joint_ids)
+        if current_qpos.shape[1] == hand_dof:
+            return current_qpos
+        if current_qpos.shape[1] <= max(self.hand_joint_ids):
+            logger.log_error(
+                "current_qpos must be either hand qpos or full robot qpos.",
+                ValueError,
+            )
+        return current_qpos[:, self.hand_joint_ids]
+
+    def execute(
+        self,
+        target: Union[ObjectSemantics, torch.Tensor],
+        start_qpos: Optional[torch.Tensor] = None,
+        **kwargs,
+    ) -> tuple[bool, torch.Tensor, list[float]]:
+        """Close the gripper, press down to a target pose, then return."""
+        is_success, press_xpos = self._resolve_pose_target(
+            target, action_name=self.__class__.__name__
+        )
+        if not is_success:
+            logger.log_warning("Failed to resolve press target pose.")
+            return False, torch.empty(0), self.joint_ids
+
+        press_xpos = press_xpos.to(device=self.device, dtype=torch.float32)
+        start_qpos = self._resolve_start_qpos(start_qpos, self.arm_dof)
+        start_hand_qpos = self._resolve_current_hand_qpos(kwargs.get("current_qpos"))
+
+        n_close_waypoint, n_down_waypoint, n_back_waypoint = (
+            self._compute_press_waypoints()
+        )
+
+        start_xpos = self.robot.compute_fk(
+            qpos=start_qpos,
+            name=self.cfg.control_part,
+            to_matrix=True,
+        )
+
+        hand_close_path = self._interpolate_hand_qpos(
+            start_hand_qpos,
+            self.hand_close_qpos,
+            n_close_waypoint,
+        )
+        hand_close_trajectory = torch.zeros(
+            size=(self.n_envs, n_close_waypoint, self.dof),
+            dtype=torch.float32,
+            device=self.device,
+        )
+        hand_close_trajectory[:, :, : self.arm_dof] = start_qpos.unsqueeze(1)
+        hand_close_trajectory[:, :, self.arm_dof :] = hand_close_path
+
+        target_states_list = [
+            [
+                PlanState(xpos=press_xpos[i], move_type=MoveType.EEF_MOVE),
+            ]
+            for i in range(self.n_envs)
+        ]
+        is_success, down_plan_traj = self._plan_arm_trajectory(
+            target_states_list,
+            start_qpos,
+            n_down_waypoint,
+            self.arm_dof,
+        )
+        if not is_success:
+            logger.log_warning("Failed to plan press down trajectory.")
+            return False, torch.empty(0), self.joint_ids
+
+        down_trajectory = torch.zeros(
+            size=(self.n_envs, n_down_waypoint, self.dof),
+            dtype=torch.float32,
+            device=self.device,
+        )
+        down_trajectory[:, :, : self.arm_dof] = down_plan_traj
+        down_trajectory[:, :, self.arm_dof :] = self._repeat_hand_qpos(
+            self.hand_close_qpos,
+            n_down_waypoint,
+        )
+
+        press_qpos = down_plan_traj[:, -1, : self.arm_dof]
+        back_keyframes = torch.cat(
+            [press_qpos.unsqueeze(1), start_qpos.unsqueeze(1)],
+            dim=1,
+        )
+        back_plan_traj = interpolate_with_distance(
+            trajectory=back_keyframes,
+            interp_num=n_back_waypoint,
+            device=self.device,
+        )
+        back_trajectory = torch.zeros(
+            size=(self.n_envs, n_back_waypoint, self.dof),
+            dtype=torch.float32,
+            device=self.device,
+        )
+        back_trajectory[:, :, : self.arm_dof] = back_plan_traj
+        back_trajectory[:, :, self.arm_dof :] = self._repeat_hand_qpos(
+            self.hand_close_qpos,
+            n_back_waypoint,
+        )
+
+        if not torch.allclose(
+            self.robot.compute_fk(
+                qpos=back_plan_traj[:, -1, :],
+                name=self.cfg.control_part,
+                to_matrix=True,
+            )[:, :3, 3],
+            start_xpos[:, :3, 3],
+            rtol=1e-4,
+            atol=1e-4,
+        ):
+            logger.log_warning(
+                "Press return trajectory may not end at the original end-effector position."
+            )
+
+        trajectory = torch.cat(
+            [hand_close_trajectory, down_trajectory, back_trajectory],
+            dim=1,
+        )
+        return True, trajectory, self.joint_ids
+
+    def validate(self, target, start_qpos=None, **kwargs):
+        is_success, press_xpos = self._resolve_pose_target(
+            target, action_name=self.__class__.__name__
+        )
+        if not is_success:
+            return False
+
+        press_xpos = press_xpos.to(device=self.device, dtype=torch.float32)
+        start_qpos = self._resolve_start_qpos(start_qpos, self.arm_dof)
+        ik_success, _ = self.robot.compute_ik(
+            pose=press_xpos,
+            name=self.cfg.control_part,
+            joint_seed=start_qpos,
+        )
+        return self._all_envs_success(ik_success)
+
+
+@configclass
 class PickUpActionCfg(GraspActionCfg):
     name: str = "pick_up"
     """Name of the action, used for identification and logging."""

--- a/embodichain/lab/sim/atomic_actions/engine.py
+++ b/embodichain/lab/sim/atomic_actions/engine.py
@@ -187,13 +187,20 @@ class AtomicActionEngine:
         self, actions_cfg_list: Optional[List[ActionCfg]] = None
     ) -> Dict[str, "AtomicAction"]:
         actions: Dict[str, AtomicAction] = {}
-        from .actions import MoveAction, MoveObjectAction, PickUpAction, PlaceAction
+        from .actions import (
+            MoveAction,
+            MoveObjectAction,
+            PickUpAction,
+            PlaceAction,
+            PressAction,
+        )
 
         builtin_action_map: Dict[str, Type[AtomicAction]] = {
             "move": MoveAction,
             "pick_up": PickUpAction,
             "move_object": MoveObjectAction,
             "place": PlaceAction,
+            "press": PressAction,
         }
         if actions_cfg_list is not None:
             for cfg in actions_cfg_list:
@@ -246,6 +253,7 @@ class AtomicActionEngine:
             is_success, traj, joint_ids = atom_action.execute(
                 target=target,
                 start_qpos=start_qpos_part,
+                current_qpos=start_qpos,
                 action_context=self._action_context,
                 held_object_state=self._action_context.get("held_object_state"),
             )

--- a/scripts/tutorials/atomic_action/press_atomic_actions.py
+++ b/scripts/tutorials/atomic_action/press_atomic_actions.py
@@ -1,0 +1,394 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+"""Demonstrate PressAction on the center of a regular wooden block."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+import torch
+
+from embodichain.data import get_data_path
+from embodichain.lab.gym.utils.gym_utils import add_env_launcher_args_to_parser
+from embodichain.lab.sim import SimulationManager, SimulationManagerCfg
+from embodichain.lab.sim.material import VisualMaterialCfg
+from embodichain.lab.sim.atomic_actions import (
+    AtomicActionEngine,
+    MoveActionCfg,
+    PressActionCfg,
+)
+from embodichain.lab.sim.cfg import (
+    JointDrivePropertiesCfg,
+    LightCfg,
+    RenderCfg,
+    RigidBodyAttributesCfg,
+    RigidObjectCfg,
+    RobotCfg,
+    URDFCfg,
+)
+from embodichain.lab.sim.objects import RigidObject, Robot
+from embodichain.lab.sim.planners import MotionGenerator, MotionGenCfg, ToppraPlannerCfg
+from embodichain.lab.sim.shapes import CubeCfg
+from embodichain.lab.sim.solvers import PytorchSolverCfg
+from embodichain.utils import logger
+
+GRIPPER_URDF_PATH = "DH_PGI_140_80/DH_PGI_140_80.urdf"
+GRIPPER_HAND_JOINT_PATTERN = "GRIPPER_FINGER1_JOINT_1"
+GRIPPER_TCP_Z = 0.15
+
+MOVE_SAMPLE_INTERVAL = 60
+PRESS_SAMPLE_INTERVAL = 90
+HAND_INTERP_STEPS = 12
+POST_TRAJECTORY_STEPS = 180
+
+TABLE_SIZE = [1.0, 1.4, 0.05]
+TABLE_TOP_Z = -0.045
+BLOCK_SIZE = [0.12, 0.12, 0.06]
+BLOCK_CENTER = [-0.30, -0.12, TABLE_TOP_Z + 0.5 * BLOCK_SIZE[2]]
+PRESS_CLEARANCE = 0.13
+PRESS_SURFACE_OFFSET = 0.003
+DEFAULT_PRESS_TOLERANCE = 0.01
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Demonstrate PressAction on the center of a regular wooden block."
+    )
+    add_env_launcher_args_to_parser(parser)
+    parser.add_argument(
+        "--auto_play",
+        action="store_true",
+        help="Run the viewer demo without waiting for keyboard input.",
+    )
+    parser.add_argument(
+        "--debug_state",
+        action="store_true",
+        help="Log the block pose during replay.",
+    )
+    parser.add_argument(
+        "--press_tolerance",
+        type=float,
+        default=DEFAULT_PRESS_TOLERANCE,
+        help="XY tolerance in meters for checking whether press reaches block center.",
+    )
+    return parser.parse_args()
+
+
+def initialize_simulation(args: argparse.Namespace) -> SimulationManager:
+    cfg = SimulationManagerCfg(
+        headless=True,
+        sim_device=args.device,
+        render_cfg=RenderCfg(renderer=args.renderer),
+        physics_dt=1.0 / 100.0,
+        arena_space=2.5,
+    )
+    sim = SimulationManager(cfg)
+    sim.add_light(
+        cfg=LightCfg(
+            uid="main_light",
+            color=(0.6, 0.6, 0.6),
+            intensity=30.0,
+            init_pos=(1.0, 0.0, 3.0),
+        )
+    )
+    return sim
+
+
+def create_robot(sim: SimulationManager, position=(0.0, 0.0, 0.0)) -> Robot:
+    ur5_urdf_path = get_data_path("UniversalRobots/UR5/UR5.urdf")
+    gripper_urdf_path = get_data_path(GRIPPER_URDF_PATH)
+
+    cfg = RobotCfg(
+        uid="UR5",
+        urdf_cfg=URDFCfg(
+            components=[
+                {"component_type": "arm", "urdf_path": ur5_urdf_path},
+                {"component_type": "hand", "urdf_path": gripper_urdf_path},
+            ]
+        ),
+        drive_pros=JointDrivePropertiesCfg(
+            stiffness={"JOINT[0-9]": 1e4, GRIPPER_HAND_JOINT_PATTERN: 1e3},
+            damping={"JOINT[0-9]": 1e3, GRIPPER_HAND_JOINT_PATTERN: 1e2},
+            max_effort={"JOINT[0-9]": 1e5, GRIPPER_HAND_JOINT_PATTERN: 1e4},
+            drive_type="force",
+        ),
+        control_parts={
+            "arm": ["JOINT[0-9]"],
+            "hand": [GRIPPER_HAND_JOINT_PATTERN],
+        },
+        solver_cfg={
+            "arm": PytorchSolverCfg(
+                end_link_name="ee_link",
+                root_link_name="base_link",
+                tcp=[
+                    [1.0, 0.0, 0.0, 0.0],
+                    [0.0, 1.0, 0.0, 0.0],
+                    [0.0, 0.0, 1.0, GRIPPER_TCP_Z],
+                    [0.0, 0.0, 0.0, 1.0],
+                ],
+            )
+        },
+        init_qpos=[0.0, -1.57, 1.57, -1.57, -1.57, 0.0, 0.0, 0.0],
+        init_pos=position,
+    )
+    return sim.add_robot(cfg=cfg)
+
+
+def create_table(sim: SimulationManager) -> RigidObject:
+    cfg = RigidObjectCfg(
+        uid="table",
+        shape=CubeCfg(size=TABLE_SIZE),
+        body_type="static",
+        attrs=RigidBodyAttributesCfg(
+            dynamic_friction=0.8,
+            static_friction=0.9,
+        ),
+        init_pos=[-0.30, 0.10, TABLE_TOP_Z - 0.5 * TABLE_SIZE[2]],
+    )
+    return sim.add_rigid_object(cfg=cfg)
+
+
+def create_wooden_block(sim: SimulationManager) -> RigidObject:
+    cfg = RigidObjectCfg(
+        uid="wooden_block",
+        shape=CubeCfg(
+            size=BLOCK_SIZE,
+            visual_material=VisualMaterialCfg(
+                uid="wooden_block_mat",
+                base_color=[0.58, 0.32, 0.14, 1.0],
+                roughness=0.85,
+            ),
+        ),
+        body_type="static",
+        attrs=RigidBodyAttributesCfg(
+            dynamic_friction=0.8,
+            static_friction=0.9,
+        ),
+        init_pos=BLOCK_CENTER,
+    )
+    return sim.add_rigid_object(cfg=cfg)
+
+
+def settle_object(sim: SimulationManager, obj: RigidObject, step: int = 5) -> None:
+    if sim.device.type == "cuda":
+        sim.init_gpu_physics()
+    obj.reset()
+    sim.update(step=step)
+    obj.clear_dynamics()
+
+
+def get_hand_close_qpos(robot: Robot, device: torch.device) -> torch.Tensor:
+    hand_limits = robot.get_qpos_limits(name="hand")[0].to(
+        device=device, dtype=torch.float32
+    )
+    return hand_limits[:, 1]
+
+
+def make_top_down_eef_pose(position: torch.Tensor) -> torch.Tensor:
+    pose = torch.eye(4, dtype=torch.float32, device=position.device)
+    pose[:3, :3] = torch.tensor(
+        [
+            [-0.0539, -0.9985, -0.0022],
+            [-0.9977, 0.0540, -0.0401],
+            [0.0401, 0.0000, -0.9992],
+        ],
+        dtype=torch.float32,
+        device=position.device,
+    )
+    pose[:3, 3] = position
+    return pose
+
+
+def format_tensor(tensor: torch.Tensor) -> str:
+    rounded = (tensor.detach().cpu() * 10000.0).round() / 10000.0
+    return str(rounded.tolist())
+
+
+def log_block_state(block: RigidObject, label: str) -> None:
+    block_pose = block.get_local_pose(to_matrix=True)
+    logger.log_info(
+        f"{label}: pos={format_tensor(block_pose[0, :3, 3])}, "
+        f"z_axis={format_tensor(block_pose[0, :3, 2])}"
+    )
+
+
+def build_action_sequence(hand_close: torch.Tensor) -> list:
+    move_cfg = MoveActionCfg(
+        control_part="arm",
+        sample_interval=MOVE_SAMPLE_INTERVAL,
+    )
+    press_cfg = PressActionCfg(
+        control_part="arm",
+        hand_control_part="hand",
+        hand_close_qpos=hand_close,
+        sample_interval=PRESS_SAMPLE_INTERVAL,
+        hand_interp_steps=HAND_INTERP_STEPS,
+    )
+    return [move_cfg, press_cfg]
+
+
+def compute_press_center_check(
+    robot: Robot,
+    traj: torch.Tensor,
+    block: RigidObject,
+    tolerance: float,
+) -> tuple[bool, float, int, torch.Tensor, torch.Tensor]:
+    arm_joint_ids = robot.get_joint_ids(name="arm")
+    press_segment_start = MOVE_SAMPLE_INTERVAL + HAND_INTERP_STEPS
+    press_segment_end = MOVE_SAMPLE_INTERVAL + PRESS_SAMPLE_INTERVAL
+    arm_traj = traj[:, press_segment_start:press_segment_end, arm_joint_ids]
+    fk_pose = torch.stack(
+        [
+            robot.compute_fk(
+                qpos=waypoint.unsqueeze(0),
+                name="arm",
+                to_matrix=True,
+            )[0]
+            for waypoint in arm_traj[0]
+        ],
+        dim=0,
+    )
+
+    block_pose = block.get_local_pose(to_matrix=True)
+    block_center = block_pose[0, :3, 3]
+    block_top_z = block_center[2] + 0.5 * BLOCK_SIZE[2]
+    target_xy = block_center[:2]
+    target_z = block_top_z + PRESS_SURFACE_OFFSET
+
+    xy_error = torch.linalg.norm(fk_pose[:, :2, 3] - target_xy, dim=1)
+    z_error = torch.abs(fk_pose[:, 2, 3] - target_z)
+    combined_error = xy_error + z_error
+    best_idx = int(torch.argmin(combined_error).item())
+    best_pos = fk_pose[best_idx, :3, 3]
+    center_error = float(torch.linalg.norm(best_pos[:2] - target_xy).item())
+    return (
+        center_error <= tolerance,
+        center_error,
+        press_segment_start + best_idx,
+        best_pos,
+        torch.tensor(
+            [target_xy[0], target_xy[1], target_z],
+            dtype=torch.float32,
+            device=traj.device,
+        ),
+    )
+
+
+def run_press_demo(args: argparse.Namespace) -> None:
+    sim = initialize_simulation(args)
+    robot = create_robot(sim)
+    create_table(sim)
+    block = create_wooden_block(sim)
+
+    settle_object(sim, block, step=5)
+    motion_gen = MotionGenerator(
+        cfg=MotionGenCfg(planner_cfg=ToppraPlannerCfg(robot_uid=robot.uid))
+    )
+    hand_close = get_hand_close_qpos(robot, sim.device)
+    action_cfgs = build_action_sequence(hand_close)
+    atomic_engine = AtomicActionEngine(
+        motion_generator=motion_gen,
+        actions_cfg_list=action_cfgs,
+    )
+
+    sim.open_window()
+    if not args.auto_play:
+        input("Inspect the wooden block, then press Enter to plan...")
+
+    block_pose = block.get_local_pose(to_matrix=True)
+    block_top_z = block_pose[0, 2, 3] + 0.5 * BLOCK_SIZE[2]
+    press_position = block_pose[0, :3, 3].clone()
+    press_position[2] = block_top_z + PRESS_SURFACE_OFFSET
+    move_position = press_position.clone()
+    move_position[2] = block_top_z + PRESS_CLEARANCE
+
+    move_target = make_top_down_eef_pose(move_position)
+    press_target = make_top_down_eef_pose(press_position)
+
+    logger.log_info("Planning move -> press")
+    start_time = time.time()
+    is_success, traj = atomic_engine.execute_static(
+        target_list=[move_target, press_target]
+    )
+    cost_time = time.time() - start_time
+    logger.log_info(f"Plan trajectory cost time: {cost_time:.2f} seconds")
+    if not is_success:
+        logger.log_warning("Failed to plan press demo trajectory.")
+        return
+
+    is_center_hit, center_error, hit_step, hit_pos, expected_pos = (
+        compute_press_center_check(
+            robot=robot,
+            traj=traj,
+            block=block,
+            tolerance=args.press_tolerance,
+        )
+    )
+    logger.log_info(
+        "Press center check: "
+        f"success={is_center_hit}, "
+        f"xy_error={center_error:.4f} m, "
+        f"hit_step={hit_step}, "
+        f"hit_pos={format_tensor(hit_pos)}, "
+        f"expected={format_tensor(expected_pos)}"
+    )
+    if not is_center_hit:
+        logger.log_warning(
+            "PressAction planned trajectory did not reach the block center within "
+            f"{args.press_tolerance:.4f} m."
+        )
+        return
+
+    if not args.auto_play:
+        input("Press Enter to replay the press demo...")
+
+    log_stride = max(1, traj.shape[1] // 10)
+    for i in range(traj.shape[1]):
+        robot.set_qpos(traj[:, i, :])
+        sim.update(step=4)
+        if args.debug_state and (i % log_stride == 0 or i == traj.shape[1] - 1):
+            log_block_state(block, f"replay step {i}/{traj.shape[1] - 1}")
+        time.sleep(1e-2)
+
+    logger.log_info("PressAction returned the end-effector to the starting pose.")
+
+    final_qpos = traj[:, -1, :]
+    for i in range(POST_TRAJECTORY_STEPS):
+        robot.set_qpos(final_qpos)
+        sim.update(step=2)
+        if args.debug_state and i % max(1, POST_TRAJECTORY_STEPS // 5) == 0:
+            log_block_state(block, f"post step {i}/{POST_TRAJECTORY_STEPS - 1}")
+        time.sleep(1e-2)
+
+    if not args.auto_play:
+        input("Press Enter to exit the simulation...")
+
+
+def main() -> None:
+    args = parse_arguments()
+    run_press_demo(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tutorials/atomic_action/press_atomic_actions.py
+++ b/scripts/tutorials/atomic_action/press_atomic_actions.py
@@ -92,6 +92,14 @@ def parse_arguments() -> argparse.Namespace:
         default=DEFAULT_PRESS_TOLERANCE,
         help="XY tolerance in meters for checking whether press reaches block center.",
     )
+    parser.add_argument(
+        "--block_pos",
+        type=float,
+        nargs=2,
+        default=BLOCK_CENTER[:2],
+        metavar=("X", "Y"),
+        help="Initial XY position of the wooden block center.",
+    )
     return parser.parse_args()
 
 
@@ -169,7 +177,10 @@ def create_table(sim: SimulationManager) -> RigidObject:
     return sim.add_rigid_object(cfg=cfg)
 
 
-def create_wooden_block(sim: SimulationManager) -> RigidObject:
+def create_wooden_block(
+    sim: SimulationManager,
+    block_center: list[float],
+) -> RigidObject:
     cfg = RigidObjectCfg(
         uid="wooden_block",
         shape=CubeCfg(
@@ -185,7 +196,7 @@ def create_wooden_block(sim: SimulationManager) -> RigidObject:
             dynamic_friction=0.8,
             static_friction=0.9,
         ),
-        init_pos=BLOCK_CENTER,
+        init_pos=block_center,
     )
     return sim.add_rigid_object(cfg=cfg)
 
@@ -299,7 +310,12 @@ def run_press_demo(args: argparse.Namespace) -> None:
     sim = initialize_simulation(args)
     robot = create_robot(sim)
     create_table(sim)
-    block = create_wooden_block(sim)
+    block_center = [
+        args.block_pos[0],
+        args.block_pos[1],
+        TABLE_TOP_Z + 0.5 * BLOCK_SIZE[2],
+    ]
+    block = create_wooden_block(sim, block_center)
 
     settle_object(sim, block, step=5)
     motion_gen = MotionGenerator(


### PR DESCRIPTION
## Summary
- add PressAction and PressActionCfg to the atomic action registry/export path
- add a press tutorial that runs move -> press on a wooden block
- allow the press demo block XY position to be configured with --block_pos

## Validation
- python -m py_compile scripts/tutorials/atomic_action/press_atomic_actions.py
- python scripts/tutorials/atomic_action/press_atomic_actions.py --auto_play
- python scripts/tutorials/atomic_action/press_atomic_actions.py --auto_play --block_pos -0.25 -0.08

## Notes
- This is a stacked PR based on ljd/move_object_atomic_actions.