### PR TITLE
Add headless support to SimulationManager recording

### DIFF
--- a/docs/source/tutorial/create_scene.rst
+++ b/docs/source/tutorial/create_scene.rst
@@ -3,7 +3,7 @@ Creating a simulation scene
 
 .. currentmodule:: embodichain.lab.sim
 
-This tutorial shows how to create a basic simulation scene using SimulationManager. It covers the setup of the simulation context, adding rigid objects, and running the simulation loop.
+This tutorial shows how to create a basic simulation scene using SimulationManager. It covers the setup of the simulation context, adding rigid objects, running the simulation loop, and exporting a video automatically when the example runs in headless mode.
 
 The Code
 ~~~~~~~~
@@ -26,7 +26,7 @@ Configuring the simulation
 
 The first step is to configure the simulation environment. This is done using the :class:`SimulationManagerCfg` data class, which allows you to specify various parameters like window dimensions, headless mode, physics timestep, simulation device (CPU/GPU), and rendering options like ray tracing.
 
-Command-line arguments are parsed using ``argparse`` to allow for easy customization of the simulation from the terminal.
+Command-line arguments are parsed using ``argparse`` to allow for easy customization of the simulation from the terminal. In addition to the common launcher flags, this tutorial adds ``--record-steps``, ``--record-fps``, and ``--record-save-path`` for headless recording.
 
 .. literalinclude:: ../../../scripts/tutorials/sim/create_scene.py
    :language: python
@@ -41,34 +41,46 @@ There are two kinds of physics mode in :class:`SimulationManager`:
 Adding objects to the scene
 ---------------------------
 
-With the simulation context created, we can add objects. This tutorial demonstrates adding a dynamic rigid cube to the scene using the :meth:`SimulationManager.add_rigid_object` method. The object's properties, such as its shape, initial position, and physics attributes (mass, friction, restitution), are defined through a configuration object, :class:`cfg.RigidObjectCfg`.
+With the simulation context created, we can add objects. This tutorial demonstrates adding a dynamic rigid cube and a chair mesh to the scene using the :meth:`SimulationManager.add_rigid_object` method. Their properties, such as shape, initial pose, and physics attributes (mass, friction, restitution), are defined through :class:`cfg.RigidObjectCfg`.
 
 .. literalinclude:: ../../../scripts/tutorials/sim/create_scene.py
    :language: python
-   :start-at: # Add objects to the scene
-   :end-at: init_pos=[0.0, 0.0, 1.0],
+   :start-at: # Add cube object to the scene
+   :end-before: print("[INFO]: Scene setup complete!")
+
+Headless recording
+------------------
+
+When the script runs with ``--headless``, it uses :meth:`SimulationManager.start_window_record` with a fixed ``look_at`` camera pose. This is the same public recorder API used for viewer recording, but it now also supports headless execution without depending on a live window.
+
+The example starts recording before the simulation loop, runs for ``--record-steps`` physics steps, then stops the recorder and waits for the video export to finish before destroying the simulation.
+
+.. literalinclude:: ../../../scripts/tutorials/sim/create_scene.py
+   :language: python
+   :start-at: if args.headless:
+   :end-at:         print(f"[INFO]: Running {args.record_steps} steps before exporting the video")
 
 Running the simulation
 ----------------------
 
 The simulation is advanced through a loop in the ``run_simulation`` function. Before starting the loop, GPU physics is initialized if a CUDA device is used.
 
-Inside the loop, :meth:`SimulationManager.update` is called to step the physics simulation forward. The script also includes logic to calculate and print the Frames Per Second (FPS) to monitor performance. The simulation runs until it's manually stopped with ``Ctrl+C``.
+Inside the loop, :meth:`SimulationManager.update` is called to step the physics simulation forward. The script also includes logic to calculate and print the Frames Per Second (FPS) to monitor performance. In GUI mode the simulation runs until it is manually stopped with ``Ctrl+C``. In headless mode the loop exits automatically after the configured number of recording steps.
 
 .. literalinclude:: ../../../scripts/tutorials/sim/create_scene.py
    :language: python
-   :start-at: def run_simulation(sim: SimulationManager):
-   :end-at: last_step = step_count
+   :start-at: def run_simulation(
+   :end-before: except KeyboardInterrupt:
 
 Exiting the simulation
 ----------------------
 
-Upon exiting the simulation loop (e.g., by a ``KeyboardInterrupt``), it's important to clean up resources. The :meth:`SimulationManager.destroy` method is called in a ``finally`` block to ensure that the simulation is properly terminated and all allocated resources are released.
+Upon exiting the simulation loop (e.g., by a ``KeyboardInterrupt``), it's important to clean up resources. The example stops any active recording, waits for the background video export to finish, then calls :meth:`SimulationManager.destroy` in a ``finally`` block to ensure that the simulation is properly terminated and all allocated resources are released.
 
 .. literalinclude:: ../../../scripts/tutorials/sim/create_scene.py
    :language: python
    :start-at: except KeyboardInterrupt:
-   :end-at: sim.destroy()
+   :end-at:         print("[INFO]: Simulation terminated successfully")
 
 
 The Code Execution
@@ -82,11 +94,21 @@ To run the script and see the result, execute the following command:
 
 A window should appear showing a cube dropping onto a flat plane. To stop the simulation, you can either close the window or press ``Ctrl+C`` in the terminal.
 
-You can also pass arguments to customize the simulation. For example, to run in headless mode with `n` parallel environments using specified device:
+You can also pass arguments to customize the simulation. For example, to run in headless mode with ``n`` parallel environments using the specified device:
 
 .. code-block:: bash
 
    python scripts/tutorials/sim/create_scene.py --headless --num_envs <n> --device <cuda/cpu>
+
+In headless mode, the script records a video and saves it under ``outputs/videos`` by default. You can control the exported clip length and destination:
+
+.. code-block:: bash
+
+   python scripts/tutorials/sim/create_scene.py \
+       --headless \
+       --record-steps 1000 \
+       --record-fps 20 \
+       --record-save-path outputs/videos/my_scene.mp4
 
 Now that we have a basic understanding of how to create a scene, let's move on to more advanced topics.
 

--- a/embodichain/lab/sim/sim_manager.py
+++ b/embodichain/lab/sim/sim_manager.py
@@ -32,7 +32,7 @@ from pathlib import Path
 from copy import deepcopy
 from datetime import datetime
 from functools import cached_property
-from typing import List, Union, Dict, Union, Sequence
+from typing import Callable, List, Union, Dict, Union, Sequence
 from dataclasses import dataclass, asdict, field, MISSING
 
 # Global cache directories
@@ -89,6 +89,7 @@ from embodichain.lab.sim.cfg import (
 )
 from embodichain.lab.sim import VisualMaterial, VisualMaterialCfg
 from embodichain.utils import configclass, logger
+from embodichain.utils.math import look_at_to_pose
 
 __all__ = [
     "SimulationManager",
@@ -155,7 +156,7 @@ class SimulationManagerCfg:
 
 @dataclass
 class _WindowRecordState:
-    """Internal state for viewer-window recording."""
+    """Internal state for simulation recording."""
 
     time_step: float
     max_memory_bytes: int
@@ -163,9 +164,13 @@ class _WindowRecordState:
     video_name: str
     save_kwargs: dict[str, object]
     record_camera: object | None = None
+    pose_provider: Callable[[], np.ndarray] | None = None
+    fixed_pose: np.ndarray | None = None
     frames: list[np.ndarray] = field(default_factory=list)
     current_memory_bytes: int = 0
     last_capture_time: float = field(default_factory=time.time)
+    accumulated_sim_time: float = 0.0
+    capture_from_sim_update: bool = False
     task_status: int = TASK_RETURN.TASK_LOOP
     loop_handle: object | None = None
 
@@ -564,6 +569,13 @@ class SimulationManager:
                 physics_dt = self.sim_config.physics_dt
             for i in range(step):
                 self._world.update(physics_dt)
+                if (
+                    self._window_record_state is not None
+                    and self._window_record_state.capture_from_sim_update
+                ):
+                    self._step_window_record_from_sim_update(
+                        self._window_record_state, physics_dt
+                    )
 
         else:
             logger.log_warning("Physics simulation is not manually updated.")
@@ -1729,6 +1741,34 @@ class SimulationManager:
         """Check whether the viewer window is currently recording."""
         return self._window_record_state is not None
 
+    def _build_window_record_pose_from_look_at(
+        self,
+        eye: Sequence[float],
+        target: Sequence[float],
+        up: Sequence[float] = (0.0, 0.0, 1.0),
+    ) -> np.ndarray:
+        """Build a camera pose matrix for the recorder from look-at inputs."""
+        pose = look_at_to_pose(eye, target, up)[0].cpu().numpy()
+        pose[:3, 1] = -pose[:3, 1]
+        pose[:3, 2] = -pose[:3, 2]
+        return np.asarray(pose, dtype=np.float32)
+
+    def _resolve_window_record_pose(
+        self, state: _WindowRecordState
+    ) -> np.ndarray | None:
+        """Resolve the camera pose used by the recorder for the current frame."""
+        if state.pose_provider is not None:
+            pose = state.pose_provider()
+            return np.asarray(pose, dtype=np.float32)
+
+        if state.fixed_pose is not None:
+            return np.asarray(state.fixed_pose, dtype=np.float32)
+
+        if self._window is not None:
+            return np.asarray(self._window.get_pose_matrix(), dtype=np.float32)
+
+        return None
+
     def _step_window_record(self, state: _WindowRecordState) -> int:
         """Capture frames in the render thread without blocking the UI loop."""
         if state.task_status != TASK_RETURN.TASK_LOOP:
@@ -1739,14 +1779,19 @@ class SimulationManager:
             return state.task_status
 
         state.last_capture_time = now
+        return self._capture_window_record_frame(state)
+
+    def _capture_window_record_frame(self, state: _WindowRecordState) -> int:
+        """Render one frame for the active recording session."""
         frame: np.ndarray | None = None
-        if self._window is not None and state.record_camera is not None:
-            pose = np.asarray(self._window.get_pose_matrix(), dtype=np.float32)
+        pose = self._resolve_window_record_pose(state)
+        if pose is not None and state.record_camera is not None:
             state.record_camera.set_world_pose(pose)
             state.record_camera.render()
             rgb = np.asarray(state.record_camera.get_rgb_map())
             if rgb.size != 0:
                 frame = np.ascontiguousarray(rgb[..., :3])
+
         if frame is None:
             return state.task_status
 
@@ -1760,6 +1805,22 @@ class SimulationManager:
             state.task_status = TASK_RETURN.TASK_EXIT
 
         return state.task_status
+
+    def _step_window_record_from_sim_update(
+        self, state: _WindowRecordState, physics_dt: float
+    ) -> int:
+        """Capture recording frames based on simulation time progression."""
+        if state.task_status != TASK_RETURN.TASK_LOOP:
+            return state.task_status
+
+        state.accumulated_sim_time += physics_dt
+        if state.accumulated_sim_time + 1e-9 < state.time_step:
+            return state.task_status
+
+        state.accumulated_sim_time = max(
+            0.0, state.accumulated_sim_time - state.time_step
+        )
+        return self._capture_window_record_frame(state)
 
     def _save_window_record_worker(
         self,
@@ -1791,13 +1852,49 @@ class SimulationManager:
         fps: int = 20,
         max_memory: int = 1024,
         video_prefix: str = "viewer_record",
+        pose_provider: Callable[[], np.ndarray] | None = None,
+        fixed_pose: np.ndarray | None = None,
+        look_at: (
+            tuple[
+                Sequence[float],
+                Sequence[float],
+                Sequence[float],
+            ]
+            | None
+        ) = None,
+        use_sim_time: bool | None = None,
     ) -> bool:
-        """Start asynchronously recording the viewer by buffering frames from a hidden camera
-        that follows the live window camera pose.
+        """Start asynchronously recording the simulation to a video buffer.
+
+        The recorder can either follow the live viewer camera or run without a
+        window by using a fixed pose or a pose callback supplied by the caller.
         """
-        if self._window is None:
-            logger.log_warning("No simulation window available for viewer recording.")
+        if pose_provider is not None and fixed_pose is not None:
+            logger.log_error(
+                "Recorder accepts only one explicit pose source: `pose_provider` or `fixed_pose`."
+            )
+        if pose_provider is not None and look_at is not None:
+            logger.log_error(
+                "Recorder accepts only one explicit pose source: `pose_provider` or `look_at`."
+            )
+        if fixed_pose is not None and look_at is not None:
+            logger.log_error(
+                "Recorder accepts only one explicit pose source: `fixed_pose` or `look_at`."
+            )
+
+        if look_at is not None:
+            fixed_pose = self._build_window_record_pose_from_look_at(*look_at)
+
+        if pose_provider is None and fixed_pose is None and self._window is None:
+            logger.log_warning(
+                "No simulation window available for viewer recording. "
+                "Provide `pose_provider`, `fixed_pose`, or `look_at` to record in headless mode."
+            )
             return False
+
+        if use_sim_time is None:
+            use_sim_time = self._window is None
+
         width = self.sim_config.width
         height = self.sim_config.height
         if self._window_record_camera is None:
@@ -1820,21 +1917,43 @@ class SimulationManager:
             video_name=video_name,
             save_kwargs={"fps": fps},
             record_camera=record_camera,
+            pose_provider=pose_provider,
+            fixed_pose=(
+                None if fixed_pose is None else np.asarray(fixed_pose, dtype=np.float32)
+            ),
+            capture_from_sim_update=use_sim_time,
             last_capture_time=time.time() - time_step,
         )
 
-        def _window_record_loop(_: float) -> int:
-            return self._step_window_record(state)
+        if not state.capture_from_sim_update:
 
-        state.loop_handle = self._world.thread_rt().add_loop(
-            _window_record_loop, time_step
-        )
+            def _window_record_loop(_: float) -> int:
+                return self._step_window_record(state)
+
+            state.loop_handle = self._world.thread_rt().add_loop(
+                _window_record_loop, time_step
+            )
         self._window_record_state = state
 
-        logger.log_info(
-            f"Viewer recording started. Press 'r' again to stop and save to "
-            f"{os.path.join(output_dir, video_name + '.mp4')}"
+        follow_source = (
+            "live viewer pose"
+            if pose_provider is None and fixed_pose is None and self._window is not None
+            else "custom pose source"
         )
+        timing_source = (
+            "simulation time" if state.capture_from_sim_update else "wall time"
+        )
+        save_target = os.path.join(output_dir, video_name + ".mp4")
+        if self._window is not None:
+            logger.log_info(
+                f"Viewer recording started ({follow_source}, {timing_source}). Press 'r' again to stop and save to "
+                f"{save_target}"
+            )
+        else:
+            logger.log_info(
+                f"Viewer recording started ({follow_source}, {timing_source}). Call `stop_window_record()` to save to "
+                f"{save_target}"
+            )
         return True
 
     def stop_window_record(self, save_path: str | None = None) -> bool:
@@ -1879,6 +1998,16 @@ class SimulationManager:
             f"{os.path.join(output_dir, video_name + '.mp4')} in background."
         )
         return True
+
+    def wait_window_record_saves(self) -> None:
+        """Wait for all background video export threads to finish."""
+        alive_threads = []
+        for thread in self._window_record_save_threads:
+            if thread.is_alive():
+                thread.join()
+            if thread.is_alive():
+                alive_threads.append(thread)
+        self._window_record_save_threads = alive_threads
 
     def toggle_window_record(
         self,
@@ -2083,6 +2212,10 @@ class SimulationManager:
         # Clean up all gizmos before destroying the simulation
         for uid in list(self._gizmos.keys()):
             self.disable_gizmo(uid)
+
+        if self.is_window_recording():
+            self.stop_window_record()
+        self.wait_window_record_saves()
 
         import sys, gc
 

--- a/embodichain/lab/sim/sim_manager.py
+++ b/embodichain/lab/sim/sim_manager.py
@@ -32,7 +32,7 @@ from pathlib import Path
 from copy import deepcopy
 from datetime import datetime
 from functools import cached_property
-from typing import Callable, List, Union, Dict, Union, Sequence
+from typing import Callable, Dict, List, Sequence, Union
 from dataclasses import dataclass, asdict, field, MISSING
 
 # Global cache directories
@@ -1868,7 +1868,31 @@ class SimulationManager:
 
         The recorder can either follow the live viewer camera or run without a
         window by using a fixed pose or a pose callback supplied by the caller.
+
+        Args:
+            save_path: Optional output path for the recorded video.
+            fps: Target output frames per second. Must be positive.
+            max_memory: Maximum buffered frame memory in MB. Must be positive.
+            video_prefix: File name prefix used when ``save_path`` is not provided.
+            pose_provider: Optional callback that returns the current camera pose.
+            fixed_pose: Optional fixed 4x4 camera pose matrix.
+            look_at: Optional ``(eye, target, up)`` tuple used to derive a fixed pose.
+            use_sim_time: Whether to capture frames from simulation time instead of
+                wall time. Defaults to headless mode when no viewer window exists.
+
+        Returns:
+            bool: True if recording starts successfully, otherwise False.
         """
+        if self.is_window_recording():
+            logger.log_error(
+                "A viewer recording session is already active. Stop it before starting a new recording."
+            )
+        if fps <= 0:
+            logger.log_error(f"Viewer recording FPS must be positive, got {fps}.")
+        if max_memory <= 0:
+            logger.log_error(
+                f"Viewer recording max_memory must be positive, got {max_memory}."
+            )
         if pose_provider is not None and fixed_pose is not None:
             logger.log_error(
                 "Recorder accepts only one explicit pose source: `pose_provider` or `fixed_pose`."
@@ -2001,13 +2025,9 @@ class SimulationManager:
 
     def wait_window_record_saves(self) -> None:
         """Wait for all background video export threads to finish."""
-        alive_threads = []
         for thread in self._window_record_save_threads:
-            if thread.is_alive():
-                thread.join()
-            if thread.is_alive():
-                alive_threads.append(thread)
-        self._window_record_save_threads = alive_threads
+            thread.join()
+        self._window_record_save_threads = []
 
     def toggle_window_record(
         self,

--- a/scripts/tutorials/sim/create_scene.py
+++ b/scripts/tutorials/sim/create_scene.py
@@ -191,9 +191,7 @@ def run_simulation(
             sim.wait_window_record_saves()
 
         # Clean up resources
-        sim.destroy(exit_process=False)
-        SimulationManager.flush_cleanup_queue()
-        print("[INFO]: Simulation terminated successfully")
+        sim.destroy()
 
 
 if __name__ == "__main__":

--- a/scripts/tutorials/sim/create_scene.py
+++ b/scripts/tutorials/sim/create_scene.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
+from __future__ import annotations
+
 """
 This script demonstrates how to create a simulation scene using SimulationManager.
 It shows the basic setup of simulation context, adding objects, and sensors.
@@ -38,13 +40,31 @@ def main():
         description="Create a simulation scene with SimulationManager"
     )
     add_env_launcher_args_to_parser(parser)
+    parser.add_argument(
+        "--record-steps",
+        type=int,
+        default=1000,
+        help="Number of simulation steps to record before exiting in headless mode.",
+    )
+    parser.add_argument(
+        "--record-fps",
+        type=int,
+        default=20,
+        help="Output video FPS for headless recording.",
+    )
+    parser.add_argument(
+        "--record-save-path",
+        type=str,
+        default=None,
+        help="Optional mp4 output path for headless recording.",
+    )
     args = parser.parse_args()
 
     # Configure the simulation
     sim_cfg = SimulationManagerCfg(
         width=1920,
         height=1080,
-        headless=True,
+        headless=args.headless,
         physics_dt=1.0 / 100.0,  # Physics timestep (100 Hz)
         sim_device=args.device,
         render_cfg=RenderCfg(
@@ -97,15 +117,37 @@ def main():
     if not args.headless:
         sim.open_window()
 
+    if args.headless:
+        if not sim.start_window_record(
+            save_path=args.record_save_path,
+            fps=args.record_fps,
+            max_memory=2048,
+            video_prefix="create_scene_headless",
+            look_at=((2.6, -2.2, 1.6), (0.0, 0.0, 0.45), (0.0, 0.0, 1.0)),
+        ):
+            raise RuntimeError("Failed to start headless recording")
+        print("[INFO]: Headless recording enabled.")
+        print(
+            "[INFO]: The output path is reported by `SimulationManager.start_window_record()`."
+        )
+        print(f"[INFO]: Running {args.record_steps} steps before exporting the video")
+
     # Run the simulation
-    run_simulation(sim)
+    run_simulation(
+        sim,
+        max_steps=args.record_steps if args.headless else None,
+    )
 
 
-def run_simulation(sim: SimulationManager):
+def run_simulation(
+    sim: SimulationManager,
+    max_steps: int | None = None,
+):
     """Run the simulation loop.
 
     Args:
-        sim: The SimulationManager instance to run
+        sim: The SimulationManager instance to run.
+        max_steps: Optional maximum number of simulation steps to execute.
     """
 
     # Initialize GPU physics if using CUDA
@@ -135,11 +177,22 @@ def run_simulation(sim: SimulationManager):
                 last_time = current_time
                 last_step = step_count
 
+            if max_steps is not None and step_count >= max_steps:
+                print(
+                    f"[INFO]: Reached {max_steps} steps. Exporting headless recording..."
+                )
+                break
+
     except KeyboardInterrupt:
         print("\n[INFO]: Stopping simulation...")
     finally:
+        if sim.is_window_recording():
+            sim.stop_window_record()
+            sim.wait_window_record_saves()
+
         # Clean up resources
-        sim.destroy()
+        sim.destroy(exit_process=False)
+        SimulationManager.flush_cleanup_queue()
         print("[INFO]: Simulation terminated successfully")
 
 

--- a/tests/sim/test_sim_manager.py
+++ b/tests/sim/test_sim_manager.py
@@ -1,0 +1,185 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from embodichain.lab.sim.sim_manager import SimulationManager, _WindowRecordState
+
+DEFAULT_LOOK_AT = (
+    (2.6, -2.2, 1.6),
+    (0.0, 0.0, 0.45),
+    (0.0, 0.0, 1.0),
+)
+
+
+class FakeCamera:
+    """Simple camera stub for recorder unit tests."""
+
+    def __init__(self) -> None:
+        self._is_open = False
+        self.last_pose: np.ndarray | None = None
+        self.render_count = 0
+
+    def is_open(self) -> bool:
+        return self._is_open
+
+    def open_camera(self) -> None:
+        self._is_open = True
+
+    def close_camera(self) -> None:
+        self._is_open = False
+
+    def set_world_pose(self, pose: np.ndarray) -> None:
+        self.last_pose = np.asarray(pose, dtype=np.float32)
+
+    def render(self) -> None:
+        self.render_count += 1
+
+    def get_rgb_map(self) -> np.ndarray:
+        return np.full((4, 4, 4), 7, dtype=np.uint8)
+
+
+class FakeThreadRuntime:
+    """Runtime loop stub for viewer-timed recording."""
+
+    def __init__(self) -> None:
+        self.add_loop_calls: list[tuple[object, float]] = []
+
+    def add_loop(self, callback, time_step: float) -> str:
+        self.add_loop_calls.append((callback, time_step))
+        return "loop_handle"
+
+
+class FakeWorld:
+    """World stub exposing the render-thread loop API."""
+
+    def __init__(self) -> None:
+        self.thread_runtime = FakeThreadRuntime()
+
+    def thread_rt(self) -> FakeThreadRuntime:
+        return self.thread_runtime
+
+
+class FakeEnv:
+    """Environment stub that creates fake cameras."""
+
+    def __init__(self) -> None:
+        self.created_cameras: list[FakeCamera] = []
+
+    def create_camera(self, name: str, width: int, height: int) -> FakeCamera:
+        camera = FakeCamera()
+        self.created_cameras.append(camera)
+        return camera
+
+
+def _make_sim_manager(window: object | None = None) -> SimulationManager:
+    """Create a minimally initialized simulation manager for recorder tests."""
+    sim = object.__new__(SimulationManager)
+    sim.instance_id = 0
+    sim.sim_config = SimpleNamespace(width=64, height=48)
+    sim._window = window
+    sim._window_record_state = None
+    sim._window_record_camera = None
+    sim._window_record_save_threads = []
+    sim._env = FakeEnv()
+    sim._world = FakeWorld()
+    return sim
+
+
+def test_start_window_record_rejects_invalid_parameters() -> None:
+    sim = _make_sim_manager()
+
+    with pytest.raises(RuntimeError, match="FPS must be positive"):
+        sim.start_window_record(fps=0, look_at=DEFAULT_LOOK_AT)
+
+    with pytest.raises(RuntimeError, match="max_memory must be positive"):
+        sim.start_window_record(fps=20, max_memory=0, look_at=DEFAULT_LOOK_AT)
+
+
+def test_start_window_record_rejects_concurrent_sessions() -> None:
+    sim = _make_sim_manager()
+    sim._window_record_state = _WindowRecordState(
+        time_step=0.1,
+        max_memory_bytes=1024,
+        output_dir="/tmp",
+        video_name="existing",
+        save_kwargs={"fps": 20},
+    )
+
+    with pytest.raises(RuntimeError, match="already active"):
+        sim.start_window_record(look_at=DEFAULT_LOOK_AT)
+
+
+def test_headless_recording_uses_sim_time_and_captures_frames() -> None:
+    sim = _make_sim_manager()
+
+    assert sim.start_window_record(look_at=DEFAULT_LOOK_AT, fps=5, max_memory=1)
+    state = sim._window_record_state
+    assert state is not None
+    assert state.capture_from_sim_update is True
+    assert state.loop_handle is None
+    assert sim._window_record_camera is not None
+    assert sim._window_record_camera.is_open() is True
+    assert state.fixed_pose is not None
+    assert sim._world.thread_runtime.add_loop_calls == []
+
+    sim._step_window_record_from_sim_update(state, physics_dt=0.1)
+    assert len(state.frames) == 0
+
+    sim._step_window_record_from_sim_update(state, physics_dt=0.1)
+    assert len(state.frames) == 1
+    assert sim._window_record_camera.render_count == 1
+    np.testing.assert_allclose(
+        sim._window_record_camera.last_pose,
+        state.fixed_pose,
+    )
+
+
+def test_stop_window_record_waits_for_background_export(monkeypatch) -> None:
+    sim = _make_sim_manager()
+    assert sim.start_window_record(look_at=DEFAULT_LOOK_AT, fps=5, max_memory=1)
+    state = sim._window_record_state
+    assert state is not None
+    state.frames.append(np.zeros((4, 4, 3), dtype=np.uint8))
+
+    save_call: dict[str, object] = {}
+
+    def fake_save_window_record_worker(
+        frames: list[np.ndarray],
+        output_dir: str,
+        video_name: str,
+        save_kwargs: dict[str, object],
+    ) -> None:
+        save_call["frame_count"] = len(frames)
+        save_call["output_dir"] = output_dir
+        save_call["video_name"] = video_name
+        save_call["save_kwargs"] = save_kwargs
+
+    monkeypatch.setattr(
+        sim, "_save_window_record_worker", fake_save_window_record_worker
+    )
+
+    assert sim.stop_window_record() is True
+    sim.wait_window_record_saves()
+
+    assert save_call["frame_count"] == 1
+    assert save_call["save_kwargs"] == {"fps": 5}
+    assert sim._window_record_save_threads == []


### PR DESCRIPTION
## Description

This PR adds headless support to `SimulationManager.start_window_record()` and updates the `create_scene.py` tutorial to use the shared recording path when running without a window.

It also updates the `create_scene` documentation to describe the new recording flow and CLI options.

Dependencies: None

Fixes N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which improves an existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (existing functionality will not work without user modification)
- [ ] Documentation update

## Screenshots

- Headless tutorial run verified with `python scripts/tutorials/sim/create_scene.py --headless`
- Output video verified at `outputs/videos/create_scene_headless_2026-06-22-16-58-36.mp4`

## Checklist

- [x] I have run the `black .` command to format the code base.
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Dependencies have been updated, if applicable.
