### PR TITLE
Refine release skill note conventions

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -22,7 +22,8 @@ Use this skill when the task is about an EmbodiChain release flow:
 
 EmbodiChain releases consistently use:
 
-- a versioned title like `EmbodiChain v0.2.1 Release Notes`
+- a GitHub release title that may be short, e.g. `V0.2.2`
+- a first body heading like `EmbodiChain v0.2.2 Release Notes`
 - `Highlights`
 - `Breaking Changes` when needed
 - `New Features`
@@ -33,6 +34,17 @@ EmbodiChain releases consistently use:
 - a short contributor summary
 
 Keep bullets short and action-oriented. Prefer the same wording style used in prior releases: feature-focused, PR-linked, and tied to the author.
+
+Use this exact bullet pattern for release-note items whenever attribution is known:
+
+- `Added emissive light mode to randomize_indirect_lighting by @yuecideng in #274`
+
+Format rules:
+
+- lead with the past-tense change description
+- append `by @<author> in #<pr>` for each merged PR bullet
+- keep `All Commits Since` entries attributed the same way
+- if a change has no PR number yet, resolve it before drafting the release notes
 
 ## What to check
 
@@ -50,4 +62,3 @@ When asked to draft a release, produce:
 2. a concise summary paragraph
 3. sectioned bullets in the repo's existing style
 4. any release blockers or verification notes
-

--- a/.agents/skills/release/references/release-patterns.md
+++ b/.agents/skills/release/references/release-patterns.md
@@ -35,10 +35,12 @@
 ## Style patterns
 
 - Releases are tag-based and follow semantic versioning with a `v` prefix.
+- The GitHub release title can be short, such as `V0.2.2`, while the first body heading stays `EmbodiChain v0.2.2 Release Notes`.
 - GitHub release bodies are structured, not free-form.
 - The first paragraph usually summarizes the main theme of the release.
 - Dependency upgrades and compatibility breaks are called out explicitly.
-- Feature bullets cite the contributor and PR number.
+- Feature bullets cite the contributor and PR number in the form `by @author in #123`.
+- Example: `Added emissive light mode to randomize_indirect_lighting by @yuecideng in #274`.
 - Documentation and CI/CD fixes are treated as first-class release content.
 
 ## Release workflow cues
@@ -46,4 +48,3 @@
 - Tag pushes trigger the release build path in `.github/workflows/`.
 - Release builds produce package distributions.
 - Docs builds preserve older versioned documentation when a new tag is published.
-


### PR DESCRIPTION
## Description

This PR updates the EmbodiChain release skill to codify the current release note conventions. It distinguishes the short GitHub release title from the in-body heading and requires contributor attribution in the `by @author in #123` format for release note bullets.

Dependencies: none

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (existing functionality will not work without user modification)
- [x] Documentation update

## Screenshots

N/A

## Checklist

- [x] I have run the `black .` command to format the code base.
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Dependencies have been updated, if applicable.