### PR TITLE
Harden docs Pages deployment

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -14,6 +14,16 @@ on:
         description: "Existing CI/CD Pipeline run ID to deploy from instead of rebuilding"
         required: false
         type: string
+      artifact_name:
+        description: "Artifact name to deploy when artifact_run_id is set"
+        required: false
+        default: "docs-site"
+        type: string
+      skip_cache_restore:
+        description: "Skip restoring the multi-version docs cache during manual rebuild"
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   actions: read
@@ -38,13 +48,35 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      - uses: actions/checkout@v4
+
       - name: Download docs site artifact from CI/CD Pipeline run
         uses: actions/download-artifact@v4
         with:
-          name: docs-site
+          name: ${{ github.event_name == 'workflow_run' && 'docs-site' || inputs.artifact_name }}
           run-id: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.id || inputs.artifact_run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path: ./docs-site
+
+      - name: Validate docs site artifact
+        shell: bash
+        run: |
+          SITE_URL="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}"
+          SOURCE_REF="${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || inputs.ref }}"
+          if [[ "${SOURCE_REF}" == v* ]]; then
+            python3 docs/scripts/validate_docs_site.py \
+              --build-dir ./docs-site \
+              --require-version "${SOURCE_REF}"
+          elif [[ "${SOURCE_REF}" == main || -z "${SOURCE_REF}" ]]; then
+            python3 docs/scripts/validate_docs_site.py \
+              --build-dir ./docs-site \
+              --require-version main \
+              --preserve-live-tags \
+              --site-base-url "${SITE_URL}"
+          else
+            python3 docs/scripts/validate_docs_site.py \
+              --build-dir ./docs-site
+          fi
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
@@ -81,6 +113,7 @@ jobs:
       - uses: ./.github/actions/activate-conda
 
       - name: Restore full multi-version docs site
+        if: ${{ !inputs.skip_cache_restore }}
         uses: actions/cache/restore@v4
         with:
           path: docs/build/html
@@ -136,6 +169,29 @@ jobs:
 
           python3 ${GITHUB_WORKSPACE}/docs/scripts/generate_versions_json.py \
             --build-dir .
+
+      - name: Clean docs artifact paths
+        shell: bash
+        run: |
+          python3 docs/scripts/clean_docs_artifact_paths.py \
+            --build-dir docs/build/html
+
+      - name: Validate docs site
+        shell: bash
+        run: |
+          SITE_URL="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}"
+          TARGET_REF="${{ inputs.ref != '' && inputs.ref || 'main' }}"
+          if [[ "${TARGET_REF}" == v* ]]; then
+            python3 docs/scripts/validate_docs_site.py \
+              --build-dir docs/build/html \
+              --require-version "${TARGET_REF}"
+          else
+            python3 docs/scripts/validate_docs_site.py \
+              --build-dir docs/build/html \
+              --require-version main \
+              --preserve-live-tags \
+              --site-base-url "${SITE_URL}"
+          fi
 
       - name: Upload docs site artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -129,6 +129,30 @@ jobs:
           python3 ${GITHUB_WORKSPACE}/docs/scripts/generate_versions_json.py \
             --build-dir .
 
+      - name: Clean docs artifact paths
+        if: github.event_name == 'push'
+        shell: bash
+        run: |
+          python3 docs/scripts/clean_docs_artifact_paths.py \
+            --build-dir docs/build/html
+
+      - name: Validate docs site
+        if: github.event_name == 'push'
+        shell: bash
+        run: |
+          SITE_URL="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}"
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            python3 docs/scripts/validate_docs_site.py \
+              --build-dir docs/build/html \
+              --require-version "${GITHUB_REF_NAME}"
+          else
+            python3 docs/scripts/validate_docs_site.py \
+              --build-dir docs/build/html \
+              --require-version main \
+              --preserve-live-tags \
+              --site-base-url "${SITE_URL}"
+          fi
+
       # Default-branch cache only (tag-scoped caches are not visible on main).
       - name: Save full multi-version docs site
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/docs/scripts/clean_docs_artifact_paths.py
+++ b/docs/scripts/clean_docs_artifact_paths.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+"""Remove filesystem-hostile wget query-string artifacts from docs builds."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+from pathlib import Path
+
+__all__ = ["clean_docs_artifact_paths"]
+
+_INVALID_ARTIFACT_CHARS = frozenset('"<>|*?\r\n')
+
+
+def _has_invalid_component(path: Path) -> bool:
+    return any(
+        any(char in part for char in _INVALID_ARTIFACT_CHARS) for part in path.parts
+    )
+
+
+def clean_docs_artifact_paths(build_dir: Path) -> list[Path]:
+    """Remove paths that GitHub artifact upload refuses.
+
+    ``wget`` preserves cache-busting query strings from links such as
+    ``clipboard.min.js?v=...`` as literal filenames. Those files are redundant
+    on a static Pages site because the real asset is served without the query
+    suffix, but ``actions/upload-artifact`` rejects them on portability grounds.
+
+    Args:
+        build_dir: Root of the generated docs site.
+
+    Returns:
+        Removed paths, relative to ``build_dir``.
+    """
+    build_dir = build_dir.resolve()
+    removed: list[Path] = []
+    if not build_dir.exists():
+        return removed
+
+    for path in sorted(build_dir.rglob("*"), key=lambda p: len(p.parts), reverse=True):
+        relative = path.relative_to(build_dir)
+        if not _has_invalid_component(relative):
+            continue
+        if path.is_dir():
+            shutil.rmtree(path)
+        else:
+            path.unlink(missing_ok=True)
+        removed.append(relative)
+
+    return sorted(removed)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Remove docs paths rejected by GitHub artifact upload"
+    )
+    parser.add_argument(
+        "--build-dir",
+        type=Path,
+        default=Path("build/html"),
+        help="Generated docs site root (default: build/html)",
+    )
+    args = parser.parse_args()
+
+    removed = clean_docs_artifact_paths(args.build_dir)
+    if removed:
+        print("Removed artifact-incompatible docs paths:")
+        for path in removed:
+            print(f"  {path}")
+    else:
+        print("No artifact-incompatible docs paths found.")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/scripts/validate_docs_site.py
+++ b/docs/scripts/validate_docs_site.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+"""Validate a generated multi-version documentation site before deployment."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import urlopen
+
+__all__ = [
+    "load_local_manifest",
+    "load_live_manifest",
+    "validate_docs_site",
+]
+
+
+def load_local_manifest(build_dir: Path) -> dict[str, Any]:
+    """Load the generated ``versions.json`` manifest."""
+    manifest_path = build_dir / "versions.json"
+    if not manifest_path.is_file():
+        raise FileNotFoundError(f"Missing docs manifest: {manifest_path}")
+    return json.loads(manifest_path.read_text(encoding="utf-8"))
+
+
+def load_live_manifest(site_base_url: str) -> dict[str, Any] | None:
+    """Load the currently published ``versions.json`` manifest, if available."""
+    manifest_url = f"{site_base_url.rstrip('/')}/versions.json"
+    try:
+        with urlopen(manifest_url, timeout=30) as response:
+            if response.status != 200:
+                return None
+            return json.loads(response.read().decode("utf-8"))
+    except (HTTPError, URLError, TimeoutError, json.JSONDecodeError) as exc:
+        print(f"No live docs manifest at {manifest_url}: {exc}", file=sys.stderr)
+        return None
+
+
+def _manifest_names(manifest: dict[str, Any]) -> set[str]:
+    return {
+        entry["name"]
+        for entry in manifest.get("versions", [])
+        if isinstance(entry, dict) and entry.get("name")
+    }
+
+
+def _live_tag_names(manifest: dict[str, Any]) -> set[str]:
+    return {
+        entry["name"]
+        for entry in manifest.get("versions", [])
+        if (
+            isinstance(entry, dict) and entry.get("name") and entry.get("type") == "tag"
+        )
+    }
+
+
+def _missing_version_dirs(build_dir: Path, versions: set[str]) -> list[str]:
+    return sorted(
+        version
+        for version in versions
+        if not (build_dir / version / "index.html").is_file()
+    )
+
+
+def validate_docs_site(
+    build_dir: Path,
+    *,
+    required_versions: set[str] | None = None,
+    preserve_live_tags: bool = False,
+    site_base_url: str | None = None,
+) -> None:
+    """Validate generated docs before publishing.
+
+    Args:
+        build_dir: Root of the generated site.
+        required_versions: Versions that must be present in the site.
+        preserve_live_tags: Whether all currently published tag versions must
+            still be present. Use this for ``main`` builds to prevent release
+            docs from being overwritten by a branch-only artifact.
+        site_base_url: Published site base URL used with ``preserve_live_tags``.
+
+    Raises:
+        FileNotFoundError: If required generated files are missing.
+        RuntimeError: If the manifest omits required versions.
+    """
+    build_dir = build_dir.resolve()
+    manifest = load_local_manifest(build_dir)
+    manifest_names = _manifest_names(manifest)
+    required = set(required_versions or set())
+
+    if preserve_live_tags:
+        if not site_base_url:
+            raise ValueError("site_base_url is required with preserve_live_tags")
+        live_manifest = load_live_manifest(site_base_url)
+        if live_manifest:
+            required.update(_live_tag_names(live_manifest))
+
+    missing_from_manifest = sorted(required - manifest_names)
+    if missing_from_manifest:
+        raise RuntimeError(
+            "Docs manifest is missing required versions: "
+            + ", ".join(missing_from_manifest)
+        )
+
+    missing_dirs = _missing_version_dirs(build_dir, required)
+    if missing_dirs:
+        raise FileNotFoundError(
+            "Docs site is missing required version directories: "
+            + ", ".join(missing_dirs)
+        )
+
+    manifest_dir_gaps = _missing_version_dirs(build_dir, manifest_names)
+    if manifest_dir_gaps:
+        raise FileNotFoundError(
+            "Docs manifest references missing version directories: "
+            + ", ".join(manifest_dir_gaps)
+        )
+
+    print(
+        "Validated docs site versions: "
+        + ", ".join(sorted(manifest_names, reverse=True))
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Validate generated multi-version docs before deployment"
+    )
+    parser.add_argument(
+        "--build-dir",
+        type=Path,
+        default=Path("build/html"),
+        help="Generated docs site root (default: build/html)",
+    )
+    parser.add_argument(
+        "--require-version",
+        action="append",
+        default=[],
+        help="Version that must be present in versions.json and as a directory",
+    )
+    parser.add_argument(
+        "--preserve-live-tags",
+        action="store_true",
+        help="Require all tag versions from the live site to be preserved",
+    )
+    parser.add_argument(
+        "--site-base-url",
+        default=None,
+        help="Published site base URL, e.g. https://org.github.io/EmbodiChain",
+    )
+    args = parser.parse_args()
+
+    validate_docs_site(
+        args.build_dir,
+        required_versions=set(args.require_version),
+        preserve_live_tags=args.preserve_live_tags,
+        site_base_url=args.site_base_url,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/docs/conftest.py
+++ b/tests/docs/conftest.py
@@ -21,19 +21,25 @@ import sys
 from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
-_SCRIPT = _REPO_ROOT / "docs" / "scripts" / "merge_published_site.py"
+_CLEAN_SCRIPT = _REPO_ROOT / "docs" / "scripts" / "clean_docs_artifact_paths.py"
+_MERGE_SCRIPT = _REPO_ROOT / "docs" / "scripts" / "merge_published_site.py"
+_VALIDATE_SCRIPT = _REPO_ROOT / "docs" / "scripts" / "validate_docs_site.py"
 
 
-def _load_merge_module():
-    spec = importlib.util.spec_from_file_location("merge_published_site", _SCRIPT)
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
     if spec is None or spec.loader is None:
-        raise ImportError(f"Cannot load {_SCRIPT}")
+        raise ImportError(f"Cannot load {path}")
     module = importlib.util.module_from_spec(spec)
-    sys.modules["merge_published_site"] = module
+    sys.modules[name] = module
     spec.loader.exec_module(module)
     return module
 
 
-_merge = _load_merge_module()
+_clean = _load_module("clean_docs_artifact_paths", _CLEAN_SCRIPT)
+_merge = _load_module("merge_published_site", _MERGE_SCRIPT)
+_validate = _load_module("validate_docs_site", _VALIDATE_SCRIPT)
+clean_docs_artifact_paths = _clean.clean_docs_artifact_paths
 load_versions_manifest = _merge.load_versions_manifest
 merge_published_site = _merge.merge_published_site
+validate_docs_site = _validate.validate_docs_site

--- a/tests/docs/test_clean_docs_artifact_paths.py
+++ b/tests/docs/test_clean_docs_artifact_paths.py
@@ -1,0 +1,39 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+"""Tests for docs artifact path cleanup."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .conftest import clean_docs_artifact_paths
+
+
+def test_clean_removes_wget_query_string_files(tmp_path: Path) -> None:
+    build_dir = tmp_path / "html"
+    static_dir = build_dir / "main" / "_static"
+    static_dir.mkdir(parents=True)
+    valid_asset = static_dir / "clipboard.min.js"
+    invalid_asset = static_dir / "clipboard.min.js?v=a7894cd8"
+    valid_asset.write_text("valid", encoding="utf-8")
+    invalid_asset.write_text("duplicate", encoding="utf-8")
+
+    removed = clean_docs_artifact_paths(build_dir)
+
+    assert removed == [Path("main/_static/clipboard.min.js?v=a7894cd8")]
+    assert valid_asset.is_file()
+    assert not invalid_asset.exists()

--- a/tests/docs/test_validate_docs_site.py
+++ b/tests/docs/test_validate_docs_site.py
@@ -1,0 +1,127 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+"""Tests for pre-deployment docs site validation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from .conftest import validate_docs_site
+
+
+def _write_site(root: Path, versions: list[str], latest: str | None = None) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "latest": latest or versions[0],
+        "versions": [
+            {
+                "name": version,
+                "url": f"./{version}/index.html",
+                "type": "tag" if version.startswith("v") else "branch",
+            }
+            for version in versions
+        ],
+    }
+    (root / "versions.json").write_text(json.dumps(manifest), encoding="utf-8")
+    for version in versions:
+        version_dir = root / version
+        version_dir.mkdir(parents=True, exist_ok=True)
+        (version_dir / "index.html").write_text(
+            f"<html>{version}</html>", encoding="utf-8"
+        )
+
+
+def test_validate_requires_release_version(tmp_path: Path) -> None:
+    build_dir = tmp_path / "build"
+    _write_site(build_dir, ["v0.2.2", "main"], latest="v0.2.2")
+
+    validate_docs_site(build_dir, required_versions={"v0.2.2"})
+
+
+def test_validate_fails_when_required_release_missing(tmp_path: Path) -> None:
+    build_dir = tmp_path / "build"
+    _write_site(build_dir, ["main"], latest="main")
+
+    with pytest.raises(RuntimeError, match="v0.2.2"):
+        validate_docs_site(build_dir, required_versions={"v0.2.2"})
+
+
+def test_validate_fails_when_manifest_points_to_missing_dir(tmp_path: Path) -> None:
+    build_dir = tmp_path / "build"
+    _write_site(build_dir, ["v0.2.2", "main"], latest="v0.2.2")
+    (build_dir / "v0.2.2" / "index.html").unlink()
+
+    with pytest.raises(FileNotFoundError, match="v0.2.2"):
+        validate_docs_site(build_dir)
+
+
+def test_validate_preserves_live_tags(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    build_dir = tmp_path / "build"
+    _write_site(build_dir, ["v0.2.2", "main"], latest="v0.2.2")
+
+    live_manifest = {
+        "latest": "v0.2.2",
+        "versions": [
+            {"name": "v0.2.2", "url": "./v0.2.2/index.html", "type": "tag"},
+            {"name": "main", "url": "./main/index.html", "type": "branch"},
+        ],
+    }
+
+    monkeypatch.setattr(
+        "validate_docs_site.load_live_manifest",
+        lambda site_base_url: live_manifest,
+    )
+
+    validate_docs_site(
+        build_dir,
+        required_versions={"main"},
+        preserve_live_tags=True,
+        site_base_url="https://example.invalid/EmbodiChain",
+    )
+
+
+def test_validate_rejects_main_only_site_when_live_has_tags(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    build_dir = tmp_path / "build"
+    _write_site(build_dir, ["main"], latest="main")
+
+    live_manifest = {
+        "latest": "v0.2.2",
+        "versions": [
+            {"name": "v0.2.2", "url": "./v0.2.2/index.html", "type": "tag"},
+            {"name": "main", "url": "./main/index.html", "type": "branch"},
+        ],
+    }
+
+    monkeypatch.setattr(
+        "validate_docs_site.load_live_manifest",
+        lambda site_base_url: live_manifest,
+    )
+
+    with pytest.raises(RuntimeError, match="v0.2.2"):
+        validate_docs_site(
+            build_dir,
+            required_versions={"main"},
+            preserve_live_tags=True,
+            site_base_url="https://example.invalid/EmbodiChain",
+        )


### PR DESCRIPTION
## Summary
- clean docs artifact paths that GitHub artifact upload rejects after restoring published site files
- validate docs artifacts before Pages deployment so main artifacts cannot drop published release tags
- add manual recovery controls for release-docs rebuilds

## Tests
- python -m pytest tests/docs -q --confcutdir=tests/docs
- black --target-version py311 --check docs/scripts/clean_docs_artifact_paths.py docs/scripts/validate_docs_site.py tests/docs/conftest.py tests/docs/test_clean_docs_artifact_paths.py tests/docs/test_validate_docs_site.py
- parsed .github/workflows/main.yml and .github/workflows/docs-pages.yml with PyYAML