### PR TITLE
Fix cached docs artifact upload paths

### DIFF
--- a/docs/scripts/merge_published_site.py
+++ b/docs/scripts/merge_published_site.py
@@ -144,20 +144,30 @@ def _download_version_wget(site_base_url: str, version: str, dest: Path) -> None
         print(f"wget failed for {url} (exit {result.returncode})", file=sys.stderr)
         return
 
-    # wget may create dest.parent/<version>/ or nest extra path segments — normalize
+    # wget may create dest.parent/<version>/ or preserve extra URL path
+    # segments such as dest.parent/EmbodiChain/<version>/; normalize that.
     if not dest.is_dir():
-        candidates = list(dest.parent.glob(f"*/{version}"))
-        if len(candidates) == 1 and candidates[0].is_dir():
-            candidates[0].rename(dest)
-        else:
-            nested = dest.parent / version
-            if nested.is_dir() and nested != dest:
-                nested.rename(dest)
+        candidates = [
+            candidate
+            for candidate in dest.parent.rglob(version)
+            if candidate.is_dir() and candidate != dest
+        ]
+        candidates.sort(key=lambda candidate: len(candidate.parts))
+        for candidate in candidates:
+            if (candidate / "index.html").is_file():
+                candidate.rename(dest)
+                break
 
     if dest.is_dir():
         changes = normalize_artifact_paths(dest)
         if changes:
             print(f"Normalized {len(changes)} artifact path(s) in {version}.")
+
+    for directory in sorted(
+        dest.parent.rglob("*"), key=lambda item: len(item.parts), reverse=True
+    ):
+        if directory.is_dir() and not any(directory.iterdir()):
+            directory.rmdir()
 
 
 def merge_published_site(
@@ -181,6 +191,11 @@ def merge_published_site(
     build_dir = build_dir.resolve()
     build_dir.mkdir(parents=True, exist_ok=True)
     skip = skip_versions or frozenset()
+    initial_changes = normalize_artifact_paths(build_dir)
+    if initial_changes:
+        print(
+            f"Normalized {len(initial_changes)} existing artifact path(s) in build tree."
+        )
 
     manifest = load_versions_manifest(
         site_base_url=site_base_url,
@@ -218,6 +233,10 @@ def merge_published_site(
                 "Neither published_root nor site_base_url set; cannot merge.",
                 file=sys.stderr,
             )
+
+    final_changes = normalize_artifact_paths(build_dir)
+    if final_changes:
+        print(f"Normalized {len(final_changes)} artifact path(s) in build tree.")
 
     return merged
 

--- a/tests/docs/conftest.py
+++ b/tests/docs/conftest.py
@@ -38,3 +38,4 @@ _merge = _load_merge_module()
 load_versions_manifest = _merge.load_versions_manifest
 merge_published_site = _merge.merge_published_site
 normalize_artifact_paths = _merge.normalize_artifact_paths
+download_version_wget = _merge._download_version_wget

--- a/tests/docs/test_merge_published_site.py
+++ b/tests/docs/test_merge_published_site.py
@@ -20,11 +20,13 @@ from __future__ import annotations
 
 import json
 import shutil
+import subprocess
 from pathlib import Path
 
 import pytest
 
 from .conftest import (
+    download_version_wget,
     load_versions_manifest,
     merge_published_site,
     normalize_artifact_paths,
@@ -115,6 +117,26 @@ def test_merge_does_not_overwrite_existing_version(
     )
 
 
+def test_merge_normalizes_existing_cached_version(
+    build_dir: Path, published_site: Path
+) -> None:
+    """Cached version dirs must be cleaned even when merge skips them."""
+    static_dir = build_dir / "v0.2.0" / "_static"
+    static_dir.mkdir(parents=True)
+    query_file = static_dir / "clipboard.min.js?v=a7894cd8"
+    query_file.write_text("cached", encoding="utf-8")
+
+    merged = merge_published_site(
+        build_dir,
+        published_root=published_site,
+        skip_versions=frozenset({"main"}),
+    )
+
+    assert merged == ["v0.1.0"]
+    assert not query_file.exists()
+    assert (static_dir / "clipboard.min.js").read_text(encoding="utf-8") == "cached"
+
+
 def test_merge_skip_version_for_fresh_tag_build(
     build_dir: Path, published_site: Path
 ) -> None:
@@ -189,3 +211,30 @@ def test_normalize_artifact_paths_removes_duplicate_query_file(tmp_path: Path) -
     assert changes == [(query_file, None)]
     assert safe_file.read_text(encoding="utf-8") == "existing"
     assert not query_file.exists()
+
+
+def test_download_version_wget_promotes_repo_prefixed_output(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """GitHub Pages URLs may make wget create build/html/EmbodiChain/vX.Y.Z."""
+    build_dir = tmp_path / "build" / "html"
+    dest = build_dir / "v0.2.2"
+
+    def fake_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        static_dir = build_dir / "EmbodiChain" / "v0.2.2" / "_static"
+        static_dir.mkdir(parents=True)
+        (static_dir.parent / "index.html").write_text("nested", encoding="utf-8")
+        (static_dir / "clipboard.min.js?v=a7894cd8").write_text(
+            "copy", encoding="utf-8"
+        )
+        return subprocess.CompletedProcess(args=[], returncode=0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    download_version_wget("https://dexforce.github.io/EmbodiChain", "v0.2.2", dest)
+
+    assert (dest / "index.html").read_text(encoding="utf-8") == "nested"
+    assert (dest / "_static" / "clipboard.min.js").read_text(encoding="utf-8") == (
+        "copy"
+    )
+    assert not (build_dir / "EmbodiChain").exists()


### PR DESCRIPTION
## Description

This PR completes the docs artifact upload fix after the merged PR still failed on `_static/clipboard.min.js?v=a7894cd8`.

The remaining failure came from two paths missed by the first fix:

- restored docs cache entries could already contain invalid query-string filenames, and skipped cached versions were never normalized
- recursive `wget` can preserve the GitHub Pages repository path and create `build/html/EmbodiChain/v0.2.2/...`, so normalization ran against `build/html/v0.2.2` while the bad file lived elsewhere

This PR normalizes the whole restored build tree, promotes repo-prefixed `wget` output into the expected version directory, and removes empty leftover directories.

Dependencies: none

Fixes the repeated docs artifact upload failure from run `28218363303`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (existing functionality will not work without user modification)
- [ ] Documentation update

## Screenshots

N/A

## Checklist

- [x] I have run the `black .` command to format the code base.
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Dependencies have been updated, if applicable.

## Verification

- `black docs/scripts/merge_published_site.py tests/docs/conftest.py tests/docs/test_merge_published_site.py`
- `black --check docs/scripts/merge_published_site.py tests/docs/conftest.py tests/docs/test_merge_published_site.py`
- `pytest tests/docs -q --confcutdir=tests/docs`
