### PR TITLE
[debug] solve TYPE_CHECKING problem in shape.py

### DIFF
--- a/embodichain/lab/sim/shapes.py
+++ b/embodichain/lab/sim/shapes.py
@@ -80,6 +80,8 @@ class ShapeCfg:
             if hasattr(cfg, key):
                 attr = getattr(cfg, key)
                 if key == "visual_material" and isinstance(value, dict):
+                    from embodichain.lab.sim.material import VisualMaterialCfg
+
                     setattr(
                         cfg,
                         key,


### PR DESCRIPTION
# Description
Currently, the `VisualMaterialCfg` type in `shape.py` is imported only for static type checking and not at runtime; however, the `ShapeCfg.from_dict` function uses `VisualMaterialCfg`, resulting in a runtime error.

Fixes # (issue)
Simply import VisualMaterialCfg inside the ShapeCfg.from_dict function.
```
       for key, value in init_dict.items():
            if hasattr(cfg, key):
                attr = getattr(cfg, key)
                if key == "visual_material" and isinstance(value, dict):
                    from embodichain.lab.sim.material import VisualMaterialCfg

                    setattr(
                        cfg,
                        key,
                        VisualMaterialCfg.from_dict(value),
                    )
```
## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have run the `black .` command to format the code base.
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Dependencies have been updated, if applicable.