### PR TITLE
Update tutorial action switch frequency

### DIFF
--- a/scripts/tutorials/sim/create_robot.py
+++ b/scripts/tutorials/sim/create_robot.py
@@ -39,6 +39,9 @@ from embodichain.lab.sim.cfg import (
 from embodichain.data import get_data_path
 from embodichain.lab.gym.utils.gym_utils import add_env_launcher_args_to_parser
 
+ACTION_SWITCH_INTERVAL = 100
+ACTION_CYCLE_STEPS = 4 * ACTION_SWITCH_INTERVAL
+
 
 def main():
     """Main function to demonstrate robot simulation."""
@@ -94,7 +97,7 @@ def create_robot(sim):
     # Joint names in control_parts can be regex patterns
     CONTROL_PARTS = {
         "arm": [
-            "JOINT[1-6]",  # Matches JOINT1, JOINT2, ..., JOINT6
+            "joint[1-6]",  # Matches JOINT1, JOINT2, ..., JOINT6
         ],
         "hand": ["LEFT_.*"],  # Matches all joints starting with L_
     }
@@ -121,8 +124,8 @@ def create_robot(sim):
         ),
         control_parts=CONTROL_PARTS,
         drive_pros=JointDrivePropertiesCfg(
-            stiffness={"JOINT[1-6]": 1e4, "LEFT_.*": 1e3},
-            damping={"JOINT[1-6]": 1e3, "LEFT_.*": 1e2},
+            stiffness={"joint[1-6]": 1e4, "LEFT_.*": 1e3},
+            damping={"joint[1-6]": 1e3, "LEFT_.*": 1e2},
         ),
     )
 
@@ -171,20 +174,21 @@ def run_simulation(sim: SimulationManager, robot: Robot):
         while True:
             # Update physics
             sim.update(step=1)
+            cycle_step = step_count % ACTION_CYCLE_STEPS
 
-            if step_count % 4000 == 0:
+            if cycle_step == 0:
                 robot.set_qpos(qpos=arm_position1, joint_ids=arm_joint_ids)
                 print(f"Moving to arm position 1")
 
-            if step_count % 4000 == 1000:
+            if cycle_step == ACTION_SWITCH_INTERVAL:
                 robot.set_qpos(qpos=arm_position2, joint_ids=arm_joint_ids)
                 print(f"Moving to arm position 2")
 
-            if step_count % 4000 == 2000:
+            if cycle_step == 2 * ACTION_SWITCH_INTERVAL:
                 robot.set_qpos(qpos=hand_position_close, joint_ids=hand_joint_ids)
                 print(f"Closing hand")
 
-            if step_count % 4000 == 3000:
+            if cycle_step == 3 * ACTION_SWITCH_INTERVAL:
                 robot.set_qpos(qpos=hand_position_open, joint_ids=hand_joint_ids)
                 print(f"Opening hand")
 

--- a/scripts/tutorials/sim/create_sensor.py
+++ b/scripts/tutorials/sim/create_sensor.py
@@ -42,6 +42,9 @@ from embodichain.lab.sim.cfg import (
 from embodichain.lab.sim.shapes import CubeCfg
 from embodichain.data import get_data_path
 
+ACTION_SWITCH_INTERVAL = 100
+ACTION_CYCLE_STEPS = 2 * ACTION_SWITCH_INTERVAL
+
 
 def mask_to_color_map(mask, user_ids, fix_seed=True):
     """
@@ -179,7 +182,7 @@ def create_robot(sim):
     # Joint names in control_parts can be regex patterns
     CONTROL_PARTS = {
         "arm": [
-            "JOINT[1-6]",  # Matches JOINT1, JOINT2, ..., JOINT6
+            "joint[1-6]",  # Matches JOINT1, JOINT2, ..., JOINT6
         ],
         "hand": ["LEFT_.*"],  # Matches all joints starting with L_
     }
@@ -206,8 +209,8 @@ def create_robot(sim):
         ),
         control_parts=CONTROL_PARTS,
         drive_pros=JointDrivePropertiesCfg(
-            stiffness={"JOINT[1-6]": 1e4, "LEFT_.*": 1e3},
-            damping={"JOINT[1-6]": 1e3, "LEFT_.*": 1e2},
+            stiffness={"joint[1-6]": 1e4, "LEFT_.*": 1e3},
+            damping={"joint[1-6]": 1e3, "LEFT_.*": 1e2},
         ),
     )
 
@@ -300,15 +303,16 @@ def run_simulation(sim: SimulationManager, robot: Robot, camera: Camera):
         while True:
             # Update physics
             sim.update(step=1)
+            cycle_step = step_count % ACTION_CYCLE_STEPS
 
-            if step_count % 1001 == 0:
+            if cycle_step == 0:
                 robot.set_qpos(qpos=arm_position1, joint_ids=arm_joint_ids)
                 print(f"Moving to arm position 1")
 
                 # Refresh and get image from sensor
                 get_sensor_image(camera)
 
-            if step_count % 2003 == 0:
+            if cycle_step == ACTION_SWITCH_INTERVAL:
                 robot.set_qpos(qpos=arm_position2, joint_ids=arm_joint_ids)
                 print(f"Moving to arm position 2")
 

--- a/tests/sim/test_tutorial_action_switch_frequency.py
+++ b/tests/sim/test_tutorial_action_switch_frequency.py
@@ -1,0 +1,56 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+EXPECTED_ACTION_SWITCH_INTERVAL = 100
+SCRIPTS_ROOT = Path(__file__).resolve().parents[2] / "scripts" / "tutorials" / "sim"
+
+
+def _parse_module(script_name: str) -> ast.Module:
+    script_path = SCRIPTS_ROOT / script_name
+    return ast.parse(script_path.read_text(encoding="utf-8"))
+
+
+def _find_constant_value(module: ast.Module, constant_name: str) -> int | None:
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == constant_name:
+                return ast.literal_eval(node.value)
+    return None
+
+
+def test_create_robot_tutorial_uses_shared_action_switch_interval() -> None:
+    module = _parse_module("create_robot.py")
+
+    assert (
+        _find_constant_value(module, "ACTION_SWITCH_INTERVAL")
+        == EXPECTED_ACTION_SWITCH_INTERVAL
+    )
+
+
+def test_create_sensor_tutorial_uses_shared_action_switch_interval() -> None:
+    module = _parse_module("create_sensor.py")
+
+    assert (
+        _find_constant_value(module, "ACTION_SWITCH_INTERVAL")
+        == EXPECTED_ACTION_SWITCH_INTERVAL
+    )


### PR DESCRIPTION
## Description

This PR updates the `scripts/tutorials/sim/create_robot.py` and `scripts/tutorials/sim/create_sensor.py` tutorials to use an explicit shared action-switch interval, instead of hard-coded modulo values in the simulation loop.

It also adds a regression test to verify that both tutorial scripts keep the expected switch interval constant.

Dependencies: None.

Issue reference: None.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (existing functionality will not work without user modification)
- [ ] Documentation update

## Screenshots

Not applicable.

## Checklist

- [ ] I have run the `black .` command to format the code base.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] Dependencies have been updated, if applicable.

## Verification

- `pytest tests/sim/test_tutorial_action_switch_frequency.py -v`
  - `2 passed in 1.38s`
