### PR TITLE
Use URRobotCfg in demo UR robots

### DIFF
--- a/examples/sim/demo/pick_up_cloth.py
+++ b/examples/sim/demo/pick_up_cloth.py
@@ -31,20 +31,17 @@ from embodichain.lab.sim import SimulationManager, SimulationManagerCfg
 from embodichain.lab.sim.objects import Robot, SoftObject
 from embodichain.lab.sim.utility.action_utils import interpolate_with_distance
 from embodichain.lab.sim.shapes import MeshCfg
-from embodichain.lab.sim.solvers import PytorchSolverCfg
 from embodichain.data import get_data_path
 from embodichain.utils import logger
 from embodichain.lab.sim.cfg import (
     RenderCfg,
-    JointDrivePropertiesCfg,
-    RobotCfg,
     RigidObjectCfg,
     RigidBodyAttributesCfg,
     LightCfg,
     ClothObjectCfg,
     ClothPhysicalAttributesCfg,
-    URDFCfg,
 )
+from embodichain.lab.sim.robots import URRobotCfg
 import os
 from embodichain.lab.sim.shapes import MeshCfg, CubeCfg
 import tempfile
@@ -61,42 +58,47 @@ def create_robot(sim: SimulationManager, position=[0.0, 0.0, 0.0]):
     Returns:
         Robot: The configured robot instance added to the simulation.
     """
-    # Retrieve URDF paths for the robot arm and hand
-    ur10_urdf_path = get_data_path("UniversalRobots/UR10/UR10.urdf")
     gripper_urdf_path = get_data_path("DH_PGC_140_50_M/DH_PGC_140_50_M.urdf")
-    # Configure the robot with its components and control properties
-    cfg = RobotCfg(
-        uid="UR10",
-        urdf_cfg=URDFCfg(
-            components=[
-                {"component_type": "arm", "urdf_path": ur10_urdf_path},
-                {"component_type": "hand", "urdf_path": gripper_urdf_path},
-            ]
-        ),
-        drive_pros=JointDrivePropertiesCfg(
-            stiffness={"JOINT[0-9]": 1e4, "FINGER[1-2]": 1e2},
-            damping={"JOINT[0-9]": 1e3, "FINGER[1-2]": 1e1},
-            max_effort={"JOINT[0-9]": 1e5, "FINGER[1-2]": 1e3},
-            drive_type="force",
-        ),
-        control_parts={
-            "arm": ["JOINT[0-9]"],
-            "hand": ["FINGER[1-2]"],
-        },
-        solver_cfg={
-            "arm": PytorchSolverCfg(
-                end_link_name="ee_link",
-                root_link_name="base_link",
-                tcp=[
-                    [0.0, 1.0, 0.0, 0.0],
-                    [-1.0, 0.0, 0.0, 0.0],
-                    [0.0, 0.0, 1.0, 0.12],
-                    [0.0, 0.0, 0.0, 1.0],
-                ],
-            )
-        },
-        init_qpos=[0.0, -np.pi / 2, -np.pi / 2, np.pi / 2, -np.pi / 2, 0.0, 0.0, 0.0],
-        init_pos=position,
+    cfg = URRobotCfg.from_dict(
+        {
+            "robot_type": "ur10",
+            "uid": "UR10",
+            "urdf_cfg": {
+                "components": [
+                    {"component_type": "hand", "urdf_path": gripper_urdf_path},
+                ]
+            },
+            "drive_pros": {
+                "stiffness": {"FINGER[1-2]": 1e2},
+                "damping": {"FINGER[1-2]": 1e1},
+                "max_effort": {"FINGER[1-2]": 1e3},
+                "drive_type": "force",
+            },
+            "control_parts": {
+                "hand": ["FINGER[1-2]"],
+            },
+            "solver_cfg": {
+                "arm": {
+                    "tcp": [
+                        [0.0, 1.0, 0.0, 0.0],
+                        [-1.0, 0.0, 0.0, 0.0],
+                        [0.0, 0.0, 1.0, 0.12],
+                        [0.0, 0.0, 0.0, 1.0],
+                    ]
+                }
+            },
+            "init_qpos": [
+                0.0,
+                -np.pi / 2,
+                -np.pi / 2,
+                np.pi / 2,
+                -np.pi / 2,
+                0.0,
+                0.0,
+                0.0,
+            ],
+            "init_pos": position,
+        }
     )
     return sim.add_robot(cfg=cfg)
 

--- a/examples/sim/demo/press_softbody.py
+++ b/examples/sim/demo/press_softbody.py
@@ -30,20 +30,18 @@ from embodichain.lab.sim import SimulationManager, SimulationManagerCfg
 from embodichain.lab.sim.objects import Robot, SoftObject
 from embodichain.lab.sim.utility.action_utils import interpolate_with_distance
 from embodichain.lab.sim.shapes import MeshCfg
-from embodichain.lab.sim.solvers import PytorchSolverCfg
 from embodichain.data import get_data_path
 from embodichain.utils import logger
 from embodichain.lab.sim.cfg import (
     RenderCfg,
-    RobotCfg,
     LightCfg,
     SoftObjectCfg,
     SoftbodyVoxelAttributesCfg,
     SoftbodyPhysicalAttributesCfg,
-    URDFCfg,
 )
 from embodichain.lab.gym.utils.gym_utils import add_env_launcher_args_to_parser
 from embodichain.lab.sim.shapes import MeshCfg
+from embodichain.lab.sim.robots import URRobotCfg
 
 
 def parse_arguments():
@@ -92,33 +90,20 @@ def create_robot(sim: SimulationManager):
     Returns:
         Robot: The configured robot instance added to the simulation.
     """
-    # Retrieve URDF paths for the robot arm and hand
-    ur10_urdf_path = get_data_path("UniversalRobots/UR10/UR10.urdf")
-
-    # Configure the robot with its components and control properties
-    cfg = RobotCfg(
-        uid="UR10",
-        urdf_cfg=URDFCfg(
-            components=[{"component_type": "arm", "urdf_path": ur10_urdf_path}]
-        ),
-        control_parts={
-            "arm": ["Joint[0-9]"],
-        },
-        solver_cfg={
-            "arm": PytorchSolverCfg(
-                end_link_name="ee_link",
-                root_link_name="base_link",
-                tcp=np.eye(4),
-            )
-        },
-        init_qpos=[
-            0.0,
-            -np.pi / 2,
-            -np.pi / 2,
-            np.pi / 2,
-            -np.pi / 2,
-            0.0,
-        ],
+    cfg = URRobotCfg.from_dict(
+        {
+            "robot_type": "ur10",
+            "uid": "UR10",
+            "solver_cfg": {"arm": {"tcp": np.eye(4)}},
+            "init_qpos": [
+                0.0,
+                -np.pi / 2,
+                -np.pi / 2,
+                np.pi / 2,
+                -np.pi / 2,
+                0.0,
+            ],
+        }
     )
     return sim.add_robot(cfg=cfg)
 

--- a/examples/sim/demo/scoop_ice.py
+++ b/examples/sim/demo/scoop_ice.py
@@ -30,9 +30,6 @@ from embodichain.lab.sim import SimulationManager, SimulationManagerCfg
 from embodichain.lab.sim.objects import Robot, RigidObject, RigidObjectGroup
 from embodichain.lab.sim.cfg import (
     RenderCfg,
-    JointDrivePropertiesCfg,
-    RobotCfg,
-    URDFCfg,
     RigidObjectCfg,
     RigidBodyAttributesCfg,
     ArticulationCfg,
@@ -42,10 +39,10 @@ from embodichain.lab.sim.cfg import (
 from embodichain.lab.sim.material import VisualMaterialCfg
 from embodichain.lab.sim.utility.action_utils import interpolate_with_distance
 from embodichain.lab.sim.shapes import MeshCfg, CubeCfg
-from embodichain.lab.sim.solvers import PytorchSolverCfg
 from embodichain.data import get_data_path
 from embodichain.utils import logger
 from embodichain.lab.gym.utils.gym_utils import add_env_launcher_args_to_parser
+from embodichain.lab.sim.robots import URRobotCfg
 
 
 def initialize_simulation(args):
@@ -112,8 +109,6 @@ def create_robot(sim):
     Returns:
         Robot: The configured robot instance added to the simulation.
     """
-    # Retrieve URDF paths for the robot arm and hand
-    ur10_urdf_path = get_data_path("UniversalRobots/UR10/UR10.urdf")
     hand_urdf_path = get_data_path(
         "BrainCoHandRevo1/BrainCoLeftHand/BrainCoLeftHand.urdf"
     )
@@ -122,61 +117,55 @@ def create_robot(sim):
     hand_attach_xpos = np.eye(4)
     hand_attach_xpos[:3, :3] = R.from_rotvec([90, 0, 0], degrees=True).as_matrix()
 
-    # Configure the robot with its components and control properties
-    cfg = RobotCfg(
-        uid="ur10_with_brainco",
-        urdf_cfg=URDFCfg(
-            components=[
-                {"component_type": "arm", "urdf_path": ur10_urdf_path},
-                {
-                    "component_type": "hand",
-                    "urdf_path": hand_urdf_path,
-                    "transform": hand_attach_xpos,
-                },
-            ]
-        ),
-        control_parts={
-            "arm": ["JOINT[0-9]"],
-            "hand": [
-                "LEFT_HAND_THUMB1",
-                "LEFT_HAND_THUMB2",
-                "LEFT_HAND_INDEX",
-                "LEFT_HAND_MIDDLE",
-                "LEFT_HAND_RING",
-                "LEFT_HAND_PINKY",
+    cfg = URRobotCfg.from_dict(
+        {
+            "robot_type": "ur10",
+            "uid": "ur10_with_brainco",
+            "urdf_cfg": {
+                "components": [
+                    {
+                        "component_type": "hand",
+                        "urdf_path": hand_urdf_path,
+                        "transform": hand_attach_xpos,
+                    },
+                ]
+            },
+            "control_parts": {
+                "hand": [
+                    "LEFT_HAND_THUMB1",
+                    "LEFT_HAND_THUMB2",
+                    "LEFT_HAND_INDEX",
+                    "LEFT_HAND_MIDDLE",
+                    "LEFT_HAND_RING",
+                    "LEFT_HAND_PINKY",
+                ],
+            },
+            "drive_pros": {
+                "stiffness": {"LEFT_[A-Z|_]+[0-9]?": 1e2},
+                "damping": {"LEFT_[A-Z|_]+[0-9]?": 1e1},
+                "max_effort": {"LEFT_[A-Z|_]+[0-9]?": 1e3},
+                "drive_type": "force",
+            },
+            "solver_cfg": {"arm": {"tcp": np.eye(4)}},
+            "init_qpos": [
+                0.0,
+                -np.pi / 2,
+                -np.pi / 2,
+                2.5,
+                -np.pi / 2,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.5,
+                -0.00016,
+                -0.00010,
+                -0.00013,
+                -0.00009,
+                0.0,
             ],
-        },
-        drive_pros=JointDrivePropertiesCfg(
-            stiffness={"JOINT[0-9]": 1e4, "LEFT_[A-Z|_]+[0-9]?": 1e2},
-            damping={"JOINT[0-9]": 1e3, "LEFT_[A-Z|_]+[0-9]?": 1e1},
-            max_effort={"JOINT[0-9]": 1e5, "LEFT_[A-Z|_]+[0-9]?": 1e3},
-            drive_type="force",
-        ),
-        solver_cfg={
-            "arm": PytorchSolverCfg(
-                end_link_name="ee_link",
-                root_link_name="base_link",
-                tcp=np.eye(4),
-            )
-        },
-        init_qpos=[
-            0.0,
-            -np.pi / 2,
-            -np.pi / 2,
-            2.5,
-            -np.pi / 2,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            1.5,
-            -0.00016,
-            -0.00010,
-            -0.00013,
-            -0.00009,
-            0.0,
-        ],
+        }
     )
 
     return sim.add_robot(cfg=cfg)

--- a/examples/sim/demo/scoop_ice.py
+++ b/examples/sim/demo/scoop_ice.py
@@ -34,6 +34,7 @@ from embodichain.lab.sim.cfg import (
     RigidBodyAttributesCfg,
     ArticulationCfg,
     RigidObjectGroupCfg,
+    JointDrivePropertiesCfg,
     LightCfg,
 )
 from embodichain.lab.sim.material import VisualMaterialCfg


### PR DESCRIPTION
## Description

This PR updates the UR-based demo scripts in `examples/sim/demo` to construct their robot configs from `URRobotCfg` instead of assembling the UR arm manually in each file.

It keeps each demo's tool-specific overrides in place, including attached hand URDFs, TCP offsets, drive parameters, and initial joint positions.

Dependencies: none

Issue reference: none

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which improves an existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (existing functionality will not work without user modification)
- [ ] Documentation update

## Screenshots

N/A

## Checklist

- [x] I have run the `black .` command to format the code base.
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Dependencies have been updated, if applicable.
