### PR TITLE
Fix coordinated atomic action demo assets

### DIFF
--- a/docs/source/overview/sim/atomic_actions/index.md
+++ b/docs/source/overview/sim/atomic_actions/index.md
@@ -30,6 +30,7 @@ EndEffectorPoseTarget(xpos)                │
 JointPositionTarget(qpos)                  ├─ IK solve when pose-based
 NamedJointPositionTarget(name)             ├─ Motion plan / interpolation
 HeldObjectPoseTarget(pose)                 └─ Gripper interpolation when needed
+CoordinatedPickmentTarget(...)             │
 CoordinatedPlacementTarget(...)            │
                                                    │
                                            ActionResult
@@ -63,6 +64,7 @@ and every action declares the target type, or tuple of target types, it accepts 
 | `NamedJointPositionTarget` | `NamedJointPositionTarget(name)` | `MoveJoints` |
 | `GraspTarget` | `GraspTarget(semantics)` | `PickUp` |
 | `HeldObjectPoseTarget` | `HeldObjectPoseTarget(object_target_pose)` | `MoveHeldObject` |
+| `CoordinatedPickmentTarget` | `CoordinatedPickmentTarget(...)` | `CoordinatedPickment` |
 | `CoordinatedPlacementTarget` | `CoordinatedPlacementTarget(...)` | `CoordinatedPlacement` |
 
 `Target` is the union of these typed target dataclasses.
@@ -101,6 +103,7 @@ action's `TargetType` before calling `execute`:
 | `NamedJointPositionTarget(name)` | Name resolved from `MoveJointsCfg.named_joint_positions` | `MoveJoints` |
 | `GraspTarget(semantics)` | `ObjectSemantics` (affordance + entity) | `PickUp` |
 | `HeldObjectPoseTarget(object_target_pose)` | Desired held-object pose tensor | `MoveHeldObject` |
+| `CoordinatedPickmentTarget(...)` | Shared object semantics plus left/right grasp transforms and target object pose | `CoordinatedPickment` |
 | `CoordinatedPlacementTarget(...)` | Two held-object states plus object-centric placing/support target poses | `CoordinatedPlacement` |
 
 `WorldState` is threaded between actions and carries the robot's `last_qpos` plus an optional
@@ -111,6 +114,7 @@ action's `TargetType` before calling `execute`:
 | `PickUp` | Populates it (computed object-to-EEF transform) |
 | `MoveHeldObject` | Requires it; preserves it unchanged |
 | `Place` | Clears it to `None` |
+| `CoordinatedPickment` | Leaves `held_object` as `None` and populates `coordinated_held_object` |
 | `CoordinatedPlacement` | Returns the support arm's `HeldObjectState`; the placing object is released |
 | `MoveEndEffector` | Leaves it unchanged |
 | `MoveJoints` | Leaves it unchanged |
@@ -311,6 +315,7 @@ builtin_actions
   - `scripts/tutorials/atomic_action/move_held_object.py`
   - `scripts/tutorials/atomic_action/place.py`
   - `scripts/tutorials/atomic_action/press.py`
+  - `scripts/tutorials/atomic_action/coordinated_pickment.py`
   - `scripts/tutorials/atomic_action/coordinated_placement.py`
 
 Run a demo in headless CPU mode with `--auto_play --headless --device cpu` to record

--- a/docs/source/tutorial/atomic_actions.rst
+++ b/docs/source/tutorial/atomic_actions.rst
@@ -18,7 +18,7 @@ Key Features
   ``GraspTarget`` (wrapping an ``ObjectSemantics``), or ``HeldObjectPoseTarget``. The
   engine checks each step's target against the action's declared ``TargetType`` before running.
 - **Built-in primitives** — ``MoveEndEffector``, ``MoveJoints``, ``PickUp``, ``MoveHeldObject``,
-  ``Place``, and ``Press``
+  ``Place``, ``Press``, ``CoordinatedPickment``, and ``CoordinatedPlacement``
   cover the most common tabletop manipulation workflows out of the box.
   See :doc:`/overview/sim/atomic_actions/index` for configs and target types.
 - **Extensible registry** — custom action *classes* can be registered globally with
@@ -43,6 +43,8 @@ Focused demo scripts are available for the built-in primitives in the
 - ``move_held_object.py``
 - ``place.py``
 - ``press.py``
+- ``coordinated_pickment.py``
+- ``coordinated_placement.py``
 
 Each script supports interactive inspection by default. Add ``--auto_play`` to skip
 keyboard prompts, and combine it with ``--headless --device cpu`` to record an MP4 under
@@ -55,6 +57,8 @@ keyboard prompts, and combine it with ``--headless --device cpu`` to record an M
    python scripts/tutorials/atomic_action/pickup.py --headless --auto_play --device cpu
    python scripts/tutorials/atomic_action/move_held_object.py --headless --auto_play --device cpu
    python scripts/tutorials/atomic_action/place.py --headless --auto_play --device cpu
+   python scripts/tutorials/atomic_action/coordinated_pickment.py --headless --auto_play --device cpu
+   python scripts/tutorials/atomic_action/coordinated_placement.py --headless --auto_play --device cpu
 
 Typical Usage
 -------------

--- a/scripts/tutorials/atomic_action/coordinated_placement.py
+++ b/scripts/tutorials/atomic_action/coordinated_placement.py
@@ -108,10 +108,10 @@ def transform_baseline_pose(
 
 ARM_URDF_PATH = "UniversalRobots/UR5/UR5.urdf"
 GRIPPER_URDF_PATH = "DH_PGI_140_80/DH_PGI_140_80.urdf"
-SCRIPT_DIR = Path(__file__).resolve().parent
-TABLE_MESH_PATH = SCRIPT_DIR / "table.glb"
-BREAD_MESH_PATH = SCRIPT_DIR / "bread.glb"
-PAN_MESH_PATH = SCRIPT_DIR / "pan.glb"
+PLACEMENT_ASSET_ROOT = "CoordinatedPlacementAndPickment"
+TABLE_MESH_PATH = f"{PLACEMENT_ASSET_ROOT}/table.glb"
+BREAD_MESH_PATH = f"{PLACEMENT_ASSET_ROOT}/bread.glb"
+PAN_MESH_PATH = f"{PLACEMENT_ASSET_ROOT}/pan.glb"
 BREAD_LABEL = "bread"
 PAN_LABEL = "pan"
 GRIPPER_TCP_Z = 0.121
@@ -371,7 +371,7 @@ def create_table(sim: SimulationManager) -> RigidObject:
     return sim.add_rigid_object(
         cfg=RigidObjectCfg(
             uid="table",
-            shape=MeshCfg(fpath=str(TABLE_MESH_PATH)),
+            shape=MeshCfg(fpath=get_cached_data_path(TABLE_MESH_PATH)),
             attrs=RigidBodyAttributesCfg(
                 mass=10.0,
                 dynamic_friction=0.9,
@@ -390,7 +390,9 @@ def create_bread(sim: SimulationManager) -> RigidObject:
     return sim.add_rigid_object(
         cfg=RigidObjectCfg(
             uid="bread",
-            shape=MeshCfg(fpath=str(BREAD_MESH_PATH), compute_uv=False),
+            shape=MeshCfg(
+                fpath=get_cached_data_path(BREAD_MESH_PATH), compute_uv=False
+            ),
             attrs=RigidBodyAttributesCfg(
                 mass=0.01,
                 contact_offset=0.003,
@@ -413,7 +415,7 @@ def create_pan(sim: SimulationManager) -> RigidObject:
     return sim.add_rigid_object(
         cfg=RigidObjectCfg(
             uid="pan",
-            shape=MeshCfg(fpath=str(PAN_MESH_PATH), compute_uv=False),
+            shape=MeshCfg(fpath=get_cached_data_path(PAN_MESH_PATH), compute_uv=False),
             attrs=RigidBodyAttributesCfg(
                 mass=0.01,
                 dynamic_friction=0.97,


### PR DESCRIPTION
## Description

This PR updates the coordinated placement tutorial to load its table, bread, and pan meshes through the packaged `CoordinatedPlacementAndPickment` dataset instead of script-local GLB files. It also updates the atomic action docs so both coordinated demos and targets are discoverable.

Dependencies: none.

Fixes: none.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (existing functionality will not work without user modification)
- [x] Documentation update

## Validation

- [x] `git diff --check`
- [x] `python3 -m py_compile scripts/tutorials/atomic_action/coordinated_placement.py scripts/tutorials/atomic_action/coordinated_pickment.py`
- [ ] `black --check --diff --color ./` (not run: `black` is not installed in this environment)
- [ ] `python3 -m pytest tests/sim/atomic_actions/test_core.py tests/sim/atomic_actions/test_actions.py` (not run: `pytest` is not installed in this environment)
- [ ] Sphinx docs build (not run: `sphinx` is not installed in this environment)

## Screenshots

Not applicable.

## Checklist

- [ ] I have run the `black .` command to format the code base.
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Dependencies have been updated, if applicable.