### PR TITLE
Document coordinated atomic action tutorials

### DIFF
--- a/docs/source/overview/sim/atomic_actions/builtin_actions.md
+++ b/docs/source/overview/sim/atomic_actions/builtin_actions.md
@@ -171,6 +171,8 @@ while keeping both grippers closed. On success, the returned `WorldState` carrie
 **Target:** `CoordinatedPickmentTarget(...)` with a target object pose, object
 semantics, and left/right object-to-EEF transforms.
 
+**Tutorial:** `scripts/tutorials/atomic_action/coordinated_pickment.py`
+
 ![CoordinatedPickment demo](../../../_static/atomic_actions/coordinated_pickment.gif)
 
 ---
@@ -208,5 +210,7 @@ held objects.
 **Target:** `CoordinatedPlacementTarget(...)` with placing/support object target
 poses plus the corresponding `HeldObjectState` values. On success, the returned
 `WorldState.held_object` is the support object's held state.
+
+**Tutorial:** `scripts/tutorials/atomic_action/coordinated_placement.py`
 
 ![CoordinatedPlacement demo](../../../_static/atomic_actions/coordinated_placement.gif)


### PR DESCRIPTION
## Description

This PR updates `docs/source/overview/sim/atomic_actions/builtin_actions.md` to explicitly link the coordinated pickment and coordinated placement tutorial scripts from their built-in action sections. This makes the generated `builtin_actions.html` page directly reflect both coordinated demos.

Dependencies: none.

Fixes: none.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (existing functionality will not work without user modification)
- [x] Documentation update

## Validation

- [x] `git diff --check`
- [x] Verified `builtin_actions.md` includes both `CoordinatedPickment` and `CoordinatedPlacement` sections and tutorial links
- [ ] Sphinx docs build (not run: `sphinx` is not installed in this environment)

## Screenshots

Not applicable.

## Checklist

- [ ] I have run the `black .` command to format the code base.
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Dependencies have been updated, if applicable.