### PR TITLE
Fix excessive EEF rotation for symmetric grasps

### DIFF
--- a/embodichain/lab/sim/atomic_actions/actions.py
+++ b/embodichain/lab/sim/atomic_actions/actions.py
@@ -33,7 +33,12 @@ from typing import ClassVar
 
 from embodichain.lab.sim.planners import PlanState, MoveType
 from embodichain.utils import configclass, logger
-from embodichain.utils.math import matrix_from_quat, pose_inv, quat_from_matrix
+from embodichain.utils.math import (
+    matrix_from_quat,
+    pose_inv,
+    quat_error_magnitude,
+    quat_from_matrix,
+)
 
 from .affordance import AntipodalAffordance
 from .core import (
@@ -852,7 +857,14 @@ class PickUp(AtomicAction):
                 "PickUp requires an entity on the target semantics.", ValueError
             )
 
-        is_success, grasp_xpos = self._resolve_grasp_pose(sem)
+        start_arm_qpos = self.builder.resolve_start_qpos(
+            _arm_qpos_from_state(state, self.arm_joint_ids, self.robot_dof),
+            n_envs=self.n_envs,
+            arm_dof=self.arm_dof,
+            control_part=self.cfg.control_part,
+        )
+
+        is_success, grasp_xpos = self._resolve_grasp_pose(sem, start_arm_qpos)
         if not self.builder.all_envs_success(is_success):
             logger.log_warning("PickUp failed to resolve a grasp pose.")
             return self._fail(state)
@@ -861,13 +873,6 @@ class PickUp(AtomicAction):
         grasp_z = grasp_xpos[:, :3, 2]
         pre_grasp_xpos = self.builder.apply_local_offset(
             grasp_xpos, -grasp_z * self.cfg.pre_grasp_distance
-        )
-
-        start_arm_qpos = self.builder.resolve_start_qpos(
-            _arm_qpos_from_state(state, self.arm_joint_ids, self.robot_dof),
-            n_envs=self.n_envs,
-            arm_dof=self.arm_dof,
-            control_part=self.cfg.control_part,
         )
 
         n_approach, n_close, n_lift = self.builder.split_three_phase(
@@ -966,14 +971,13 @@ class PickUp(AtomicAction):
         )
 
     def _resolve_grasp_pose(
-        self, semantics: ObjectSemantics
+        self, semantics: ObjectSemantics, start_qpos: torch.Tensor
     ) -> tuple[torch.Tensor, torch.Tensor]:
         obj_poses = semantics.entity.get_local_pose(to_matrix=True)
         grasp_poses_result = semantics.affordance.get_valid_grasp_poses(
             obj_poses=obj_poses, approach_direction=self.approach_direction
         )
         n_envs = obj_poses.shape[0]
-        init_qpos = self.robot.get_qpos(name=self.cfg.control_part)
         n_max_pose = max(r[0].shape[0] for r in grasp_poses_result)
         grasp_xpos_padding = torch.zeros(
             (n_envs, n_max_pose, 4, 4), dtype=torch.float32, device=self.device
@@ -986,15 +990,18 @@ class PickUp(AtomicAction):
         )
         for i in range(n_envs):
             n_pose = grasp_poses_result[i][0].shape[0]
-            grasp_xpos_padding[i, :n_pose] = grasp_poses_result[i][0]
-            grasp_cost_padding[i, :n_pose] = grasp_poses_result[i][1]
-            grasp_xpos_padding[i, n_pose:] = grasp_poses_result[i][0][0]
-            grasp_cost_padding[i, n_pose:] = grasp_poses_result[i][1][0]
-        init_qpos_repeat = init_qpos[:, None, :].repeat(1, n_max_pose, 1)
-        ik_success, _ = self.robot.compute_batch_ik(
-            pose=grasp_xpos_padding,
-            name=self.cfg.control_part,
-            joint_seed=init_qpos_repeat,
+            grasp_poses = grasp_poses_result[i][0].to(
+                device=self.device, dtype=torch.float32
+            )
+            grasp_costs = grasp_poses_result[i][1].to(
+                device=self.device, dtype=torch.float32
+            )
+            grasp_xpos_padding[i, :n_pose] = grasp_poses
+            grasp_cost_padding[i, :n_pose] = grasp_costs
+            grasp_xpos_padding[i, n_pose:] = grasp_poses[0]
+            grasp_cost_padding[i, n_pose:] = grasp_costs[0]
+        grasp_xpos_padding, ik_success = self._select_symmetric_grasp_variants(
+            grasp_xpos_padding, start_qpos
         )
         grasp_cost_masked = torch.where(ik_success, grasp_cost_padding, 10000.0)
         best_cost, best_idx = grasp_cost_masked.min(dim=1)
@@ -1003,6 +1010,45 @@ class PickUp(AtomicAction):
             torch.arange(n_envs, device=self.device), best_idx
         ]
         return is_success, best_grasp_xpos
+
+    def _select_symmetric_grasp_variants(
+        self, grasp_xpos: torch.Tensor, start_qpos: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Choose the TCP z-roll variant closest to the current end-effector pose."""
+        n_envs, n_pose = grasp_xpos.shape[:2]
+        mirrored_grasp_xpos = grasp_xpos.clone()
+        mirrored_grasp_xpos[..., :3, 0] = -mirrored_grasp_xpos[..., :3, 0]
+        mirrored_grasp_xpos[..., :3, 1] = -mirrored_grasp_xpos[..., :3, 1]
+        grasp_variants = torch.stack([grasp_xpos, mirrored_grasp_xpos], dim=2)
+
+        flattened_variants = grasp_variants.reshape(n_envs, n_pose * 2, 4, 4)
+        start_qpos_repeat = start_qpos[:, None, :].repeat(1, n_pose * 2, 1)
+        ik_success, _ = self.robot.compute_batch_ik(
+            pose=flattened_variants,
+            name=self.cfg.control_part,
+            joint_seed=start_qpos_repeat,
+        )
+        ik_success = ik_success.reshape(n_envs, n_pose, 2)
+
+        start_xpos = self.robot.compute_fk(
+            qpos=start_qpos,
+            name=self.cfg.control_part,
+            to_matrix=True,
+        )
+        start_quat = quat_from_matrix(start_xpos[:, :3, :3])
+        variant_quat = quat_from_matrix(grasp_variants[..., :3, :3])
+        start_quat = start_quat[:, None, None, :].expand_as(variant_quat)
+        rotation_error = quat_error_magnitude(
+            variant_quat.reshape(-1, 4),
+            start_quat.reshape(-1, 4),
+        ).reshape(n_envs, n_pose, 2)
+        rotation_error = torch.where(ik_success, rotation_error, torch.inf)
+        best_variant_idx = rotation_error.argmin(dim=2)
+
+        env_idx = torch.arange(n_envs, device=self.device)[:, None]
+        pose_idx = torch.arange(n_pose, device=self.device)[None, :]
+        selected_grasp_xpos = grasp_variants[env_idx, pose_idx, best_variant_idx]
+        return selected_grasp_xpos, ik_success.any(dim=2)
 
 
 # =============================================================================

--- a/embodichain/lab/sim/atomic_actions/actions.py
+++ b/embodichain/lab/sim/atomic_actions/actions.py
@@ -1014,21 +1014,12 @@ class PickUp(AtomicAction):
     def _select_symmetric_grasp_variants(
         self, grasp_xpos: torch.Tensor, start_qpos: torch.Tensor
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        """Choose the TCP z-roll variant closest to the current end-effector pose."""
+        """Choose the closest TCP z-roll variant, then validate reachability."""
         n_envs, n_pose = grasp_xpos.shape[:2]
         mirrored_grasp_xpos = grasp_xpos.clone()
         mirrored_grasp_xpos[..., :3, 0] = -mirrored_grasp_xpos[..., :3, 0]
         mirrored_grasp_xpos[..., :3, 1] = -mirrored_grasp_xpos[..., :3, 1]
         grasp_variants = torch.stack([grasp_xpos, mirrored_grasp_xpos], dim=2)
-
-        flattened_variants = grasp_variants.reshape(n_envs, n_pose * 2, 4, 4)
-        start_qpos_repeat = start_qpos[:, None, :].repeat(1, n_pose * 2, 1)
-        ik_success, _ = self.robot.compute_batch_ik(
-            pose=flattened_variants,
-            name=self.cfg.control_part,
-            joint_seed=start_qpos_repeat,
-        )
-        ik_success = ik_success.reshape(n_envs, n_pose, 2)
 
         start_xpos = self.robot.compute_fk(
             qpos=start_qpos,
@@ -1042,13 +1033,18 @@ class PickUp(AtomicAction):
             variant_quat.reshape(-1, 4),
             start_quat.reshape(-1, 4),
         ).reshape(n_envs, n_pose, 2)
-        rotation_error = torch.where(ik_success, rotation_error, torch.inf)
         best_variant_idx = rotation_error.argmin(dim=2)
 
         env_idx = torch.arange(n_envs, device=self.device)[:, None]
         pose_idx = torch.arange(n_pose, device=self.device)[None, :]
         selected_grasp_xpos = grasp_variants[env_idx, pose_idx, best_variant_idx]
-        return selected_grasp_xpos, ik_success.any(dim=2)
+        start_qpos_repeat = start_qpos[:, None, :].repeat(1, n_pose, 1)
+        ik_success, _ = self.robot.compute_batch_ik(
+            pose=selected_grasp_xpos,
+            name=self.cfg.control_part,
+            joint_seed=start_qpos_repeat,
+        )
+        return selected_grasp_xpos, ik_success
 
 
 # =============================================================================

--- a/tests/sim/atomic_actions/test_actions.py
+++ b/tests/sim/atomic_actions/test_actions.py
@@ -435,6 +435,49 @@ class TestPickUpAction:
         assert isinstance(result.next_state.held_object, HeldObjectState)
         assert result.next_state.held_object.semantics is sem
 
+    def test_execute_chooses_symmetric_grasp_variant_closest_to_start_pose(self):
+        cfg = PickUpCfg(
+            hand_open_qpos=_hand_open(),
+            hand_close_qpos=_hand_close(),
+            sample_interval=20,
+            hand_interp_steps=4,
+        )
+        action = PickUp(self.mg, cfg)
+
+        rz_pi_grasp = torch.eye(4)
+        rz_pi_grasp[:3, :3] = torch.diag(torch.tensor([-1.0, -1.0, 1.0]))
+        affordance = AntipodalAffordance()
+        affordance.get_valid_grasp_poses = Mock(
+            return_value=[
+                (rz_pi_grasp.unsqueeze(0), torch.tensor([0.5])) for _ in range(NUM_ENVS)
+            ]
+        )
+
+        entity = Mock()
+        entity.get_local_pose = Mock(
+            return_value=torch.eye(4).unsqueeze(0).repeat(NUM_ENVS, 1, 1)
+        )
+        sem = ObjectSemantics(
+            affordance=affordance,
+            geometry={},
+            label="mug",
+            entity=entity,
+        )
+
+        with patch(
+            "embodichain.lab.sim.atomic_actions.trajectory.interpolate_with_distance",
+            side_effect=lambda trajectory, interp_num, device: torch.zeros(
+                NUM_ENVS, interp_num, ARM_DOF
+            ),
+        ):
+            state = WorldState(last_qpos=torch.zeros(NUM_ENVS, TOTAL_DOF))
+            result = action.execute(GraspTarget(semantics=sem), state)
+
+        assert result.success is True
+        assert isinstance(result.next_state.held_object, HeldObjectState)
+        expected_grasp = torch.eye(4).unsqueeze(0).repeat(NUM_ENVS, 1, 1)
+        assert torch.allclose(result.next_state.held_object.grasp_xpos, expected_grasp)
+
 
 # ---------------------------------------------------------------------------
 # MoveHeldObject

--- a/tests/sim/atomic_actions/test_actions.py
+++ b/tests/sim/atomic_actions/test_actions.py
@@ -443,6 +443,8 @@ class TestPickUpAction:
             hand_interp_steps=4,
         )
         action = PickUp(self.mg, cfg)
+        compute_batch_ik = self.mg.robot.compute_batch_ik
+        self.mg.robot.compute_batch_ik = Mock(side_effect=compute_batch_ik)
 
         rz_pi_grasp = torch.eye(4)
         rz_pi_grasp[:3, :3] = torch.diag(torch.tensor([-1.0, -1.0, 1.0]))
@@ -477,6 +479,11 @@ class TestPickUpAction:
         assert isinstance(result.next_state.held_object, HeldObjectState)
         expected_grasp = torch.eye(4).unsqueeze(0).repeat(NUM_ENVS, 1, 1)
         assert torch.allclose(result.next_state.held_object.grasp_xpos, expected_grasp)
+        self.mg.robot.compute_batch_ik.assert_called_once()
+        ik_kwargs = self.mg.robot.compute_batch_ik.call_args.kwargs
+        assert ik_kwargs["pose"].shape == (NUM_ENVS, 1, 4, 4)
+        assert torch.allclose(ik_kwargs["pose"][:, 0], expected_grasp)
+        assert ik_kwargs["joint_seed"].shape == (NUM_ENVS, 1, ARM_DOF)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

This PR makes PickUp choose the TCP z-roll 180-degree symmetric grasp variant closest to the current end-effector orientation. The selection now uses `WorldState.last_qpos` as the start state, checks IK for both symmetric variants, and preserves the existing affordance grasp cost ranking across physical grasp candidates.

This avoids unnecessary end-effector flips when a parallel-jaw grasp affordance has an equivalent TCP frame.

Dependencies: none

Related issue: N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (existing functionality will not work without user modification)
- [ ] Documentation update

## Screenshots

N/A

## Checklist

- [x] I have run the `black .` command to format the code base.
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Dependencies have been updated, if applicable.

## Validation

- `conda run -n embodichain black --check --diff --color ./`
- `conda run -n embodichain pytest tests/sim/atomic_actions/test_actions.py -q`