### PR TITLE
Fix Place TCP z-roll symmetry opt-in

### DIFF
--- a/docs/source/overview/sim/atomic_actions/builtin_actions.md
+++ b/docs/source/overview/sim/atomic_actions/builtin_actions.md
@@ -124,8 +124,13 @@ down to the target pose. On success, the returned `WorldState` clears `held_obje
 | `hand_interp_steps` | `5` | Waypoints for the gripper open phase |
 | `sample_interval` | `80` | Total waypoints across all three phases |
 
-**Target:** `EndEffectorPoseTarget(xpos=...)` — the EEF pose at release, a `torch.Tensor` of shape
-`(4, 4)`, `(n_envs, 4, 4)` or `(n_envs, n_waypoint, 4, 4)`.
+**Target:** `EndEffectorPoseTarget(xpos=..., tcp_symmetry="none")` — the EEF pose at
+release, a `torch.Tensor` of shape `(4, 4)`, `(n_envs, 4, 4)` or
+`(n_envs, n_waypoint, 4, 4)`. Keep the default
+`tcp_symmetry="none"` when the TCP orientation is strict. Use
+`tcp_symmetry="z_roll_180"` only when releasing with TCP x/y flipped is physically
+equivalent; `Place` then chooses the closer TCP z-roll 180 variant from
+`WorldState.last_qpos` and applies that same variant across all release waypoints.
 
 ![Place demo](../../../_static/atomic_actions/place.gif)
 

--- a/docs/source/overview/sim/atomic_actions/index.md
+++ b/docs/source/overview/sim/atomic_actions/index.md
@@ -64,7 +64,7 @@ and every action declares the target type, or tuple of target types, it accepts 
 
 | Target | Constructor | Used by |
 |---|---|---|
-| `EndEffectorPoseTarget` | `EndEffectorPoseTarget(xpos)` | `MoveEndEffector`, `Place`, `Press` |
+| `EndEffectorPoseTarget` | `EndEffectorPoseTarget(xpos, tcp_symmetry="none")` | `MoveEndEffector`, `Place`, `Press` |
 | `JointPositionTarget` | `JointPositionTarget(qpos)` | `MoveJoints` |
 | `NamedJointPositionTarget` | `NamedJointPositionTarget(name)` | `MoveJoints` |
 | `GraspTarget` | `GraspTarget(semantics)` | `PickUp` |
@@ -103,7 +103,7 @@ action's `TargetType` before calling `execute`:
 
 | Target | Holds | Accepted by |
 |---|---|---|
-| `EndEffectorPoseTarget(xpos)` | EEF pose tensor `(4,4)`, `(n_envs,4,4)` or `(n_envs, n_waypoint, 4, 4)` | `MoveEndEffector`, `Place`, `Press` |
+| `EndEffectorPoseTarget(xpos, tcp_symmetry="none")` | EEF pose tensor `(4,4)`, `(n_envs,4,4)` or `(n_envs, n_waypoint, 4, 4)`; `Place` may opt into TCP z-roll 180 equivalence | `MoveEndEffector`, `Place`, `Press` |
 | `JointPositionTarget(qpos)` | Control-part qpos tensor `(control_dof,)`, `(n_envs, control_dof)` or `(n_envs, n_waypoint, control_dof)` | `MoveJoints` |
 | `NamedJointPositionTarget(name)` | Name resolved from `MoveJointsCfg.named_joint_positions` | `MoveJoints` |
 | `GraspTarget(semantics)` | `ObjectSemantics` (affordance + entity) | `PickUp` |

--- a/embodichain/lab/sim/atomic_actions/core.py
+++ b/embodichain/lab/sim/atomic_actions/core.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import torch
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, ClassVar, TYPE_CHECKING
+from typing import Any, ClassVar, Literal, TYPE_CHECKING
 
 from embodichain.lab.sim.common import BatchEntity
 from embodichain.utils import configclass
@@ -68,7 +68,7 @@ class ObjectSemantics:
 
 @dataclass(frozen=True)
 class EndEffectorPoseTarget:
-    """End-effector pose target. Used by MoveEndEffector and Place."""
+    """End-effector pose target. Used by MoveEndEffector, Place, and Press."""
 
     xpos: torch.Tensor
     """Target end-effector homogeneous transform.
@@ -77,8 +77,24 @@ class EndEffectorPoseTarget:
 
     - ``(4, 4)`` or ``(n_envs, 4, 4)`` — a single waypoint.
     - ``(n_envs, n_waypoint, 4, 4)`` — a multi-waypoint trajectory; waypoints
-      are visited in order. (Only consumed as multi-waypoint by MoveEndEffector.)
+      are visited in order. (Consumed as multi-waypoint by MoveEndEffector and
+      Place.)
     """
+
+    tcp_symmetry: Literal["none", "z_roll_180"] = "none"
+    """Optional TCP-frame symmetry allowed by the target semantics.
+
+    ``"none"`` preserves the pose exactly. ``"z_roll_180"`` lets supporting
+    actions choose between the pose and its TCP z-roll 180 equivalent, which
+    flips TCP x/y while preserving TCP z and translation.
+    """
+
+    def __post_init__(self) -> None:
+        if self.tcp_symmetry not in ("none", "z_roll_180"):
+            raise ValueError(
+                "tcp_symmetry must be one of 'none' or 'z_roll_180', "
+                f"but got {self.tcp_symmetry!r}"
+            )
 
 
 @dataclass(frozen=True)

--- a/embodichain/lab/sim/atomic_actions/primitives/place.py
+++ b/embodichain/lab/sim/atomic_actions/primitives/place.py
@@ -24,6 +24,7 @@ import torch
 
 from embodichain.lab.sim.planners import MoveType, PlanState
 from embodichain.utils import configclass, logger
+from embodichain.utils.math import quat_error_magnitude, quat_from_matrix
 
 from ._helpers import arm_qpos_from_state
 from ..core import (
@@ -100,7 +101,6 @@ class Place(AtomicAction):
         place_xpos = self.builder.resolve_pose_target(target.xpos, n_envs=self.n_envs)
         if place_xpos.dim() == 3:
             place_xpos = place_xpos.unsqueeze(1)
-        n_waypoint = place_xpos.shape[1]
 
         start_arm_qpos = self.builder.resolve_start_qpos(
             arm_qpos_from_state(state, self.arm_joint_ids),
@@ -108,6 +108,11 @@ class Place(AtomicAction):
             arm_dof=self.arm_dof,
             control_part=self.cfg.control_part,
         )
+        if target.tcp_symmetry == "z_roll_180":
+            place_xpos = self._select_tcp_symmetric_place_variant(
+                place_xpos, start_arm_qpos
+            )
+        n_waypoint = place_xpos.shape[1]
         n_down, n_open, n_back = self.builder.split_three_phase(
             self.cfg.sample_interval,
             self.cfg.hand_interp_steps,
@@ -191,6 +196,37 @@ class Place(AtomicAction):
             ),
             next_state=state,
         )
+
+    def _select_tcp_symmetric_place_variant(
+        self, place_xpos: torch.Tensor, start_qpos: torch.Tensor
+    ) -> torch.Tensor:
+        """Choose the closest TCP z-roll variant for an opt-in place target."""
+        mirrored_place_xpos = place_xpos.clone()
+        mirrored_place_xpos[..., :3, 0] = -mirrored_place_xpos[..., :3, 0]
+        mirrored_place_xpos[..., :3, 1] = -mirrored_place_xpos[..., :3, 1]
+        place_variants = torch.stack([place_xpos, mirrored_place_xpos], dim=2)
+
+        start_xpos = self.robot.compute_fk(
+            qpos=start_qpos,
+            name=self.cfg.control_part,
+            to_matrix=True,
+        )
+        start_quat = quat_from_matrix(start_xpos[:, :3, :3])
+        first_waypoint_quat = quat_from_matrix(place_variants[:, 0, :, :3, :3])
+        start_quat = start_quat[:, None, :].expand_as(first_waypoint_quat)
+        rotation_error = quat_error_magnitude(
+            first_waypoint_quat.reshape(-1, 4),
+            start_quat.reshape(-1, 4),
+        ).reshape(self.n_envs, 2)
+        best_variant_idx = rotation_error.argmin(dim=1)
+
+        env_idx = torch.arange(self.n_envs, device=self.device)[:, None]
+        waypoint_idx = torch.arange(place_xpos.shape[1], device=self.device)[None, :]
+        return place_variants[
+            env_idx,
+            waypoint_idx,
+            best_variant_idx[:, None],
+        ]
 
 
 __all__ = ["Place", "PlaceCfg"]

--- a/tests/sim/atomic_actions/test_actions.py
+++ b/tests/sim/atomic_actions/test_actions.py
@@ -649,6 +649,90 @@ class TestPlaceAction:
         # start prepended to the 3 down-phase IK solutions -> 4 keyframes.
         assert captured["down_keyframes"].shape == (NUM_ENVS, 4, ARM_DOF)
 
+    def test_execute_preserves_release_pose_without_tcp_symmetry(self):
+        cfg = PlaceCfg(
+            hand_open_qpos=_hand_open(),
+            hand_close_qpos=_hand_close(),
+            sample_interval=20,
+            hand_interp_steps=4,
+        )
+        action = Place(self.mg, cfg)
+        state = WorldState(last_qpos=torch.zeros(NUM_ENVS, TOTAL_DOF))
+        rz_pi_pose = torch.eye(4)
+        rz_pi_pose[:3, :3] = torch.diag(torch.tensor([-1.0, -1.0, 1.0]))
+        seen_poses = []
+
+        def compute_ik(pose=None, name=None, joint_seed=None, **kwargs):
+            seen_poses.append(pose.clone())
+            return torch.ones(NUM_ENVS, dtype=torch.bool), joint_seed.clone()
+
+        def repeat_last_keyframe(trajectory, interp_num, device):
+            return trajectory[:, -1:, :].repeat(1, interp_num, 1)
+
+        self.mg.robot.compute_ik = Mock(side_effect=compute_ik)
+
+        with patch(
+            "embodichain.lab.sim.atomic_actions.trajectory.interpolate_with_distance",
+            side_effect=repeat_last_keyframe,
+        ):
+            result = action.execute(EndEffectorPoseTarget(xpos=rz_pi_pose), state)
+
+        assert result.success is True
+        assert len(seen_poses) == 3
+        assert torch.allclose(
+            seen_poses[1], rz_pi_pose.unsqueeze(0).repeat(NUM_ENVS, 1, 1)
+        )
+
+    def test_execute_with_tcp_symmetry_selects_closest_release_variant(self):
+        cfg = PlaceCfg(
+            hand_open_qpos=_hand_open(),
+            hand_close_qpos=_hand_close(),
+            sample_interval=20,
+            hand_interp_steps=4,
+            lift_height=0.1,
+        )
+        action = Place(self.mg, cfg)
+        state = WorldState(last_qpos=torch.zeros(NUM_ENVS, TOTAL_DOF))
+        rz_pi_pose = torch.eye(4)
+        rz_pi_pose[:3, :3] = torch.diag(torch.tensor([-1.0, -1.0, 1.0]))
+        seen_poses = []
+
+        def compute_ik(pose=None, name=None, joint_seed=None, **kwargs):
+            seen_poses.append(pose.clone())
+            return torch.ones(NUM_ENVS, dtype=torch.bool), joint_seed.clone()
+
+        def repeat_last_keyframe(trajectory, interp_num, device):
+            return trajectory[:, -1:, :].repeat(1, interp_num, 1)
+
+        self.mg.robot.compute_ik = Mock(side_effect=compute_ik)
+
+        with patch(
+            "embodichain.lab.sim.atomic_actions.trajectory.interpolate_with_distance",
+            side_effect=repeat_last_keyframe,
+        ):
+            result = action.execute(
+                EndEffectorPoseTarget(
+                    xpos=rz_pi_pose,
+                    tcp_symmetry="z_roll_180",
+                ),
+                state,
+            )
+
+        assert result.success is True
+        assert len(seen_poses) == 3
+        expected_release = torch.eye(4)
+        expected_retract = torch.eye(4)
+        expected_retract[2, 3] += cfg.lift_height
+        assert torch.allclose(
+            seen_poses[0], expected_retract.unsqueeze(0).repeat(NUM_ENVS, 1, 1)
+        )
+        assert torch.allclose(
+            seen_poses[1], expected_release.unsqueeze(0).repeat(NUM_ENVS, 1, 1)
+        )
+        assert torch.allclose(
+            seen_poses[2], expected_retract.unsqueeze(0).repeat(NUM_ENVS, 1, 1)
+        )
+
 
 # ---------------------------------------------------------------------------
 # Press

--- a/tests/sim/atomic_actions/test_core.py
+++ b/tests/sim/atomic_actions/test_core.py
@@ -45,6 +45,17 @@ class TestTypedTargets:
     def test_pose_target_holds_tensor(self):
         x = torch.eye(4)
         assert EndEffectorPoseTarget(xpos=x).xpos is x
+        assert EndEffectorPoseTarget(xpos=x).tcp_symmetry == "none"
+
+    def test_pose_target_can_declare_tcp_symmetry(self):
+        target = EndEffectorPoseTarget(xpos=torch.eye(4), tcp_symmetry="z_roll_180")
+        assert target.tcp_symmetry == "z_roll_180"
+
+    def test_pose_target_rejects_unknown_tcp_symmetry(self):
+        with pytest.raises(ValueError, match="tcp_symmetry"):
+            EndEffectorPoseTarget(
+                xpos=torch.eye(4), tcp_symmetry="yaw_90"  # type: ignore[arg-type]
+            )
 
     def test_pose_target_is_frozen(self):
         t = EndEffectorPoseTarget(xpos=torch.eye(4))


### PR DESCRIPTION
## Description

This PR adds an explicit TCP symmetry opt-in for `Place` release targets. `EndEffectorPoseTarget` now carries `tcp_symmetry`, defaulting to `"none"`, and `Place` only selects the nearest TCP z-roll 180 equivalent when the caller declares `tcp_symmetry="z_roll_180"`.

The symmetry selection is intentionally kept inside the `Place` primitive, matching the local action-scoped style used by #353 for `PickUp`. Documentation and regression tests cover the default strict-pose behavior and the opt-in Place behavior.

Dependencies: none.

Fixes: none.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (existing functionality will not work without user modification)
- [x] Documentation update

## Screenshots

N/A

## Checklist

- [ ] I have run the `black .` command to format the code base. (`black` is not installed in the current environment.)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Dependencies have been updated, if applicable.

## Verification

- `git diff --check`
- `python3 -m compileall -q embodichain/lab/sim/atomic_actions tests/sim/atomic_actions/test_actions.py tests/sim/atomic_actions/test_core.py`

Not run: `pytest` because the current `python3` environment is missing both `pytest` and `torch`. Not run: `black` because it is not installed in the current environment.