### PR TITLE
Improve Gym overview recording documentation

### DIFF
--- a/docs/source/overview/gym/action_functors.md
+++ b/docs/source/overview/gym/action_functors.md
@@ -5,6 +5,13 @@
 
 This page lists all available action terms that can be used with the Action Manager. Action terms are configured using {class}`~cfg.ActionTermCfg` and are responsible for processing raw actions from the policy and converting them to the format expected by the robot (e.g., qpos, qvel, qf).
 
+## Quick Reference
+
+- Use this page when defining the policy-facing action space for RL or closed-loop control tasks.
+- Action terms are configured with {class}`~cfg.ActionTermCfg`.
+- Action terms transform one batched policy action into robot control commands for all environments.
+- Check each term's ``action_dim`` to determine how many values the policy must output.
+
 ````{tip}
 **Using an AI coding agent?** Use the **`/add-functor`** skill to scaffold a new action term with the correct class structure, `ActionTermCfg` registration, and module placement in `actions.py`.
 ````

--- a/docs/source/overview/gym/dataset_functors.md
+++ b/docs/source/overview/gym/dataset_functors.md
@@ -5,6 +5,10 @@
 
 This page lists all available dataset functors that can be used with the Dataset Manager. Dataset functors are configured using {class}`~cfg.DatasetFunctorCfg` and are responsible for collecting and saving episode data during environment interaction.
 
+```{note}
+This page covers structured dataset export. If you only need human-viewable debug or demo videos from a fixed camera, use {class}`~record.record_camera_data` on {doc}`event_functors`.
+```
+
 ````{tip}
 **Using an AI coding agent?** Use the **`/add-functor`** skill to scaffold a new dataset functor with the correct signature, `DatasetFunctorCfg` registration, and module placement in `datasets.py`.
 ````
@@ -77,6 +81,23 @@ The LeRobotRecorder saves the following data for each frame:
 - ``action``: Applied action
 - ``observation.images.{sensor_name}``: Camera images (if sensors present)
 - ``observation.images.{sensor_name}_right``: Right camera images (for stereo cameras)
+
+### Dataset Recording vs Video Recording
+
+```{list-table} Recording Options
+:header-rows: 1
+:widths: 30 35 35
+
+* - Need
+  - Use
+  - Why
+* - Training or imitation-learning data
+  - {class}`~datasets.LeRobotRecorder`
+  - Saves structured observation, action, and metadata for downstream pipelines.
+* - Quick qualitative inspection or demos
+  - {class}`~record.record_camera_data`
+  - Saves MP4 videos from a dedicated camera without creating a training dataset.
+```
 
 ## Usage Example
 

--- a/docs/source/overview/gym/env.md
+++ b/docs/source/overview/gym/env.md
@@ -109,31 +109,126 @@ The {class}`~envs.EmbodiedEnvCfg` class exposes the following additional paramet
 
 ```python
 from embodichain.lab.gym.envs import EmbodiedEnv, EmbodiedEnvCfg
+from embodichain.lab.gym.envs.managers import (
+    ActionTermCfg,
+    DatasetFunctorCfg,
+    EventCfg,
+    ObservationCfg,
+    RewardCfg,
+    SceneEntityCfg,
+)
 from embodichain.utils import configclass
 
 @configclass
+class MyEventCfg:
+    randomize_object_pose: EventCfg = EventCfg(
+        func="randomize_rigid_object_pose",
+        mode="reset",
+        params={
+            "entity_cfg": SceneEntityCfg(uid="cube"),
+            "position_range": [[-0.08, -0.08, 0.0], [0.08, 0.08, 0.0]],
+            "relative_position": True,
+        },
+    )
+    record_debug_video: EventCfg = EventCfg(
+        func="record_camera_data",
+        mode="interval",
+        interval_step=1,
+        params={
+            "name": "overview_cam",
+            "eye": (1.0, 0.0, 1.2),
+            "target": (0.0, 0.0, 0.4),
+            "save_path": "./outputs/videos",
+        },
+    )
+
+
+@configclass
+class MyObservationCfg:
+    object_pose: ObservationCfg = ObservationCfg(
+        func="get_object_pose",
+        mode="add",
+        name="object/cube/pose",
+        params={
+            "entity_cfg": SceneEntityCfg(uid="cube"),
+            "to_matrix": False,
+        },
+    )
+    normalized_qpos: ObservationCfg = ObservationCfg(
+        func="normalize_robot_joint_data",
+        mode="modify",
+        name="robot/qpos",
+        params={},
+    )
+
+
+@configclass
+class MyRewardCfg:
+    approach_target: RewardCfg = RewardCfg(
+        func="distance_to_target",
+        weight=1.0,
+        params={
+            "entity_cfg": SceneEntityCfg(uid="cube"),
+            "target_pose_key": "goal_pose",
+            "exponential": True,
+            "sigma": 0.2,
+        },
+    )
+    success_bonus: RewardCfg = RewardCfg(
+        func="success_reward",
+        weight=10.0,
+        params={},
+    )
+
+
+@configclass
+class MyActionCfg:
+    delta_qpos: ActionTermCfg = ActionTermCfg(
+        func="DeltaQposTerm",
+        params={"scale": 0.1},
+    )
+
+
+@configclass
+class MyDatasetCfg:
+    lerobot: DatasetFunctorCfg = DatasetFunctorCfg(
+        func="LeRobotRecorder",
+        params={
+            "save_path": "./outputs/datasets/my_task",
+            "robot_meta": {"robot_type": "my_robot", "control_freq": 25},
+            "instruction": {"lang": "move the cube to the goal"},
+            "use_videos": False,
+        },
+    )
+
+
+@configclass
 class MyTaskEnvCfg(EmbodiedEnvCfg):
-    # 1. Define Scene Components
-    robot = ...          # Robot configuration
-    sensor = [...]       # List of sensors (e.g., Cameras)
-    light = ...          # Lighting configuration
+    # Scene assets are task-specific and usually come from existing robot/object cfgs.
+    robot = ...
+    sensor = [...]
+    rigid_object = [...]
 
-    # 2. Define Objects
-    rigid_object = [...]       # Dynamic objects (e.g., tools, debris)
-    rigid_object_group = [...] # Object groups (efficient for many similar objects)
-    articulation = [...]       # Articulated objects (e.g., cabinets)
+    # Manager configs plug into the shared environment lifecycle.
+    events = MyEventCfg()
+    observations = MyObservationCfg()
+    rewards = MyRewardCfg()
+    actions = MyActionCfg()
+    dataset = MyDatasetCfg()
 
-    # 3. Define Managers
-    events = ...         # Event settings (Randomization, etc.)
-    observations = ...   # Custom observation spec
-    dataset = ...        # Data collection settings
-
-    # 4. Action Manager (for RL tasks)
-    actions = ...        # Action preprocessing (e.g., DeltaQposTerm with scale)
-    extensions = {       # Task-specific parameters (e.g., success_threshold)
+    init_rollout_buffer = True
+    extensions = {
         "success_threshold": 0.1,
     }
 ```
+
+This example shows the typical division of responsibilities:
+
+- ``events`` mutate or record the scene during ``startup``, ``reset``, or ``interval`` phases.
+- ``observations`` expose task state to policies or data pipelines.
+- ``rewards`` shape RL behavior.
+- ``actions`` define how policy outputs map to robot control commands.
+- ``dataset`` controls structured episode export, independent from debug-video recording.
 
 ## Manager Systems
 
@@ -184,6 +279,10 @@ The manager operates in a single mode ``"save"`` which handles both recording an
  * ``robot_meta``: Robot metadata dictionary (required for LeRobot format).
  * ``instruction``: Task instruction dictionary.
  * ``use_videos``: Whether to save video recordings of episodes.
+
+```{note}
+The Dataset Manager handles structured training data. If you want debug or demo videos from a dedicated camera, use {class}`~envs.managers.record.record_camera_data` documented in {doc}`event_functors`.
+```
 
 The dataset manager is called automatically during {meth}`~envs.Env.step()`, ensuring all observation-action pairs are recorded without additional user code.
 

--- a/docs/source/overview/gym/event_functors.md
+++ b/docs/source/overview/gym/event_functors.md
@@ -294,6 +294,119 @@ This page lists all available event functors that can be used with the Event Man
     ```
 ```
 
+## Recording
+
+```{list-table} Recording Functors
+:header-rows: 1
+:widths: 25 75
+
+* - Functor Name
+  - Description
+* - {class}`~record.record_camera_data`
+  - Record RGB frames from a dedicated camera and save them as an MP4 video when an episode resets. This is useful for debugging, qualitative evaluation, and demo capture. The functor creates its own camera from the configured pose and intrinsics, captures frames during ``interval`` execution, and writes one video per episode.
+
+    ```json
+    {"func": "record_camera_data", "mode": "interval", "interval_step": 1,
+     "params": {"name": "debug_cam",
+                "resolution": [640, 480],
+                "eye": [1.0, 0.0, 1.2],
+                "target": [0.0, 0.0, 0.5],
+                "up": [0.0, 0.0, 1.0],
+                "save_path": "./outputs/videos"}}
+    ```
+* - {class}`~record.record_camera_data_async`
+  - Record RGB frames for several environments independently, then merge them into a single tiled MP4 once each tracked environment finishes an episode. This variant is useful when you want side-by-side qualitative comparison across vectorized environments.
+
+    ```json
+    {"func": "record_camera_data_async", "mode": "interval", "interval_step": 1,
+     "params": {"name": "overview_async_cam",
+                "resolution": [640, 480],
+                "eye": [1.0, 0.0, 1.2],
+                "target": [0.0, 0.0, 0.5],
+                "up": [0.0, 0.0, 1.0],
+                "save_path": "./outputs/videos"}}
+    ```
+```
+
+### record_camera_data
+
+The ``record_camera_data`` functor lives under the record manager module, but it is configured through the event pipeline because it runs periodically during stepping and flushes video output at episode reset.
+
+```{note}
+This is separate from {doc}`dataset_functors`. Use dataset functors when you need training data such as observations and actions. Use ``record_camera_data`` when you need human-viewable videos for debugging or demos.
+```
+
+#### Typical Usage
+
+- Set ``mode="interval"`` so the camera captures frames during stepping.
+- Use ``interval_step=1`` to record every environment step, or increase it to reduce file size.
+- Choose a fixed third-person camera pose with ``eye``, ``target``, and ``up``.
+- Save output videos with ``save_path``.
+
+#### Parameters
+
+```{list-table} record_camera_data Parameters
+:header-rows: 1
+:widths: 30 70
+
+* - Parameter
+  - Description
+* - ``name``
+  - Camera name used for the internally created sensor and output file naming. Default: ``"default"``.
+* - ``resolution``
+  - Output image size as ``[width, height]``. Default: ``[640, 480]``.
+* - ``eye``
+  - Camera position in world coordinates. Default: ``[0, 0, 2]``.
+* - ``target``
+  - Look-at target in world coordinates. Default: ``[0, 0, 0]``.
+* - ``up``
+  - Up vector for the camera pose. Default: ``[0, 0, 1]``.
+* - ``intrinsics``
+  - Camera intrinsics as ``[fx, fy, cx, cy]``. Defaults to values derived from the configured resolution.
+* - ``max_env_num``
+  - Maximum number of environments to tile into one frame when recording vectorized environments.
+* - ``save_path``
+  - Output directory for generated MP4 files. Default: ``./outputs/videos``.
+```
+
+#### Behavior Notes
+
+- In vectorized environments, frames from multiple environments are tiled into a single composite image before video encoding.
+- Videos are flushed during episode initialization for environments that are resetting, not by the Dataset Manager.
+- If the process exits without another reset, the final episode may not be flushed to disk.
+- This functor captures RGB imagery for visualization. It does not record actions, rewards, or structured training data.
+
+### record_camera_data_async
+
+The ``record_camera_data_async`` functor is the multi-environment variant of ``record_camera_data``. It tracks a small set of environments independently, waits until each one has completed an episode, and then writes a single tiled video that combines them.
+
+#### Typical Usage
+
+- Use this variant when you want one comparison video spanning multiple vectorized environments.
+- Configure it with ``mode="interval"`` just like ``record_camera_data``.
+- Keep the number of tracked environments modest; the current implementation records up to four environments.
+- Use the same camera pose parameters as the single-environment recorder.
+
+#### Parameters
+
+The async recorder accepts the same parameters as ``record_camera_data``:
+
+- ``name``
+- ``resolution``
+- ``eye``
+- ``target``
+- ``up``
+- ``intrinsics``
+- ``max_env_num``
+- ``save_path``
+
+#### Behavior Notes
+
+- Frames are buffered separately for each tracked environment and merged later into one tiled video.
+- The current implementation tracks at most four environments, even if ``num_envs`` is larger.
+- Output is written only after all tracked environments have completed an episode, so video generation may lag behind individual resets.
+- This variant is meant for qualitative inspection and comparison, not structured dataset export.
+
 ## Usage Example
 
 ```python

--- a/docs/source/overview/gym/index.rst
+++ b/docs/source/overview/gym/index.rst
@@ -165,17 +165,37 @@ For most new tasks, start from
 Choosing Where to Start
 -----------------------
 
+.. list-table::
+   :header-rows: 1
+   :widths: 34 66
+
+   * - If you want to...
+     - Start here
+   * - Understand the full ``EmbodiedEnv`` configuration surface
+     - :doc:`env`
+   * - Connect policy outputs to robot control terms
+     - :doc:`action_functors`
+   * - Randomize scenes, place objects, or capture debug/demo videos
+     - :doc:`event_functors`
+   * - Add task observations or transform existing observation entries
+     - :doc:`observation_functors`
+   * - Compose RL reward terms
+     - :doc:`reward_functors`
+   * - Save structured demonstrations or offline training datasets
+     - :doc:`dataset_functors`
+
 - Start with :doc:`env` for the full
   :class:`~embodichain.lab.gym.envs.embodied_env.EmbodiedEnv` configuration and
   custom task guide.
 - Use :doc:`action_functors` when connecting policy outputs to robot control.
 - Use :doc:`event_functors` for reset randomization, visual randomization, and
-  scene perturbations.
+  scene perturbations. This page also covers runtime camera-video capture via
+  ``record_camera_data``.
 - Use :doc:`observation_functors` to add task observations without changing base
   environment code.
 - Use :doc:`reward_functors` when composing RL reward terms.
 - Use :doc:`dataset_functors` when recording demonstrations or exporting
-  datasets.
+  datasets. Use this page for structured episode data, not debug video capture.
 
 Documentation Quality Notes
 ---------------------------

--- a/docs/source/overview/gym/observation_functors.md
+++ b/docs/source/overview/gym/observation_functors.md
@@ -5,6 +5,13 @@
 
 This page lists all available observation functors that can be used with the Observation Manager. Observation functors are configured using {class}`~cfg.ObservationCfg` and can operate in two modes: ``modify`` (update existing observations) or ``add`` (add new observations).
 
+## Quick Reference
+
+- Use ``mode="add"`` to create a new observation entry in the observation dictionary.
+- Use ``mode="modify"`` to update an existing observation entry in place.
+- Most returned tensors are batched over ``num_envs`` as the leading dimension.
+- Use hierarchical names such as ``"object/cup/pose"`` to keep custom observations organized.
+
 ````{tip}
 **Using an AI coding agent?** Use the **`/add-functor`** skill to scaffold a new observation functor with the correct signature (`env, obs, entity_cfg, ...`), module placement in `observations.py`, and `__all__` export. Use **`/add-test`** to generate mock-based tests.
 ````

--- a/docs/source/overview/gym/reward_functors.md
+++ b/docs/source/overview/gym/reward_functors.md
@@ -5,6 +5,13 @@
 
 This page lists all available reward functors that can be used with the Reward Manager. Reward functors are configured using {class}`~cfg.RewardCfg` and return scalar reward tensors that are weighted and summed to form the total environment reward.
 
+## Quick Reference
+
+- Use this page when composing scalar reward terms for RL tasks.
+- Reward functors are configured with {class}`~cfg.RewardCfg`.
+- Each reward functor returns a tensor of shape ``(num_envs,)`` before weighting.
+- Final rewards are the weighted sum of all configured reward terms.
+
 ````{tip}
 **Using an AI coding agent?** Use the **`/add-functor`** skill to scaffold a new reward functor with the correct signature (`env, obs, action, info, ...`), module placement in `rewards.py`, and `__all__` export. Use **`/add-test`** to generate mock-based tests.
 ````


### PR DESCRIPTION
## Description

This PR improves the Gym overview documentation for EmbodiedEnv managers and recording utilities.

It adds missing documentation for `record_camera_data` and `record_camera_data_async`, clarifies the difference between structured dataset export and debug/demo video capture, adds a compact end-to-end `EmbodiedEnvCfg` example, and introduces quick-reference/navigation sections across the Gym overview pages.

Motivation and context: the Gym overview pages did not document the recorder functors consistently, and the separation between dataset recording and visualization-oriented video recording was easy to miss.

Dependencies: None

Issue reference: None

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (existing functionality will not work without user modification)
- [x] Documentation update

## Screenshots

Not applicable.

## Checklist

- [ ] I have run the `black .` command to format the code base.
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Dependencies have been updated, if applicable.
