### PR TITLE
Add max_episodes CLI override for run_env

### DIFF
--- a/embodichain/lab/gym/utils/gym_utils.py
+++ b/embodichain/lab/gym/utils/gym_utils.py
@@ -819,6 +819,12 @@ def add_env_launcher_args_to_parser(parser: argparse.ArgumentParser) -> None:
         default=False,
         action="store_true",
     )
+    parser.add_argument(
+        "--max_episodes",
+        help="Override the max_episodes value from the gym config.",
+        default=None,
+        type=int,
+    )
 
 
 def merge_args_with_gym_config(args: argparse.Namespace, gym_config: dict) -> dict:
@@ -840,6 +846,8 @@ def merge_args_with_gym_config(args: argparse.Namespace, gym_config: dict) -> di
     merged_config["renderer"] = args.renderer
     merged_config["gpu_id"] = args.gpu_id
     merged_config["arena_space"] = args.arena_space
+    if args.max_episodes is not None:
+        merged_config["max_episodes"] = args.max_episodes
     return merged_config
 
 

--- a/tests/gym/utils/test_gym_utils.py
+++ b/tests/gym/utils/test_gym_utils.py
@@ -17,6 +17,8 @@
 
 from __future__ import annotations
 
+import argparse
+
 import pytest
 import torch
 
@@ -25,6 +27,7 @@ from tensordict import TensorDict
 from embodichain.lab.gym.utils.gym_utils import (
     config_to_cfg,
     DEFAULT_MANAGER_MODULES,
+    merge_args_with_gym_config,
     init_rollout_buffer_from_config,
 )
 from embodichain.utils.utility import load_config, save_config
@@ -252,92 +255,132 @@ class TestInitRolloutBufferFromConfig:
         assert "value" in buffer["obs"]["custom"]["group1"]
         assert buffer["obs"]["custom"]["group1"]["value"].shape == (4, 100, 4)
 
-    def test_sensor_and_extra_obs_together(self):
-        """Test that both sensors and extra observations work together."""
-        config = {
-            "sensor": [
-                {
-                    "uid": "camera",
-                    "width": 320,
-                    "height": 240,
-                    "enable_mask": True,
+
+def test_merge_args_with_gym_config_overrides_max_episodes():
+    """Test that CLI max_episodes overrides the gym config value."""
+    args = argparse.Namespace(
+        num_envs=1,
+        device="cpu",
+        headless=False,
+        renderer="auto",
+        gpu_id=0,
+        arena_space=5.0,
+        max_episodes=12,
+    )
+    gym_config = {"max_episodes": 3, "id": "Dummy-v0"}
+
+    merged_config = merge_args_with_gym_config(args, gym_config)
+
+    assert merged_config["max_episodes"] == 12
+    assert gym_config["max_episodes"] == 3
+
+
+def test_merge_args_with_gym_config_keeps_default_max_episodes():
+    """Test that gym config max_episodes is preserved when CLI omits it."""
+    args = argparse.Namespace(
+        num_envs=1,
+        device="cpu",
+        headless=False,
+        renderer="auto",
+        gpu_id=0,
+        arena_space=5.0,
+        max_episodes=None,
+    )
+    gym_config = {"max_episodes": 3, "id": "Dummy-v0"}
+
+    merged_config = merge_args_with_gym_config(args, gym_config)
+
+    assert merged_config["max_episodes"] == 3
+
+
+def test_sensor_and_extra_obs_together():
+    """Test that both sensors and extra observations work together."""
+    config = {
+        "sensor": [
+            {
+                "uid": "camera",
+                "width": 320,
+                "height": 240,
+                "enable_mask": True,
+            }
+        ],
+        "env": {
+            "observations": {
+                "extra_vec": {
+                    "mode": "add",
+                    "extra": {"shape": [10]},
                 }
-            ],
-            "env": {
-                "observations": {
-                    "extra_vec": {
-                        "mode": "add",
-                        "extra": {"shape": [10]},
-                    }
+            }
+        },
+    }
+
+    buffer = init_rollout_buffer_from_config(
+        config=config,
+        max_episode_steps=100,
+        batch_size=4,
+        state_dim=7,
+        device="cpu",
+    )
+
+    # Check sensor is present
+    assert "sensor" in buffer["obs"]
+    assert "camera" in buffer["obs"]["sensor"]
+    assert buffer["obs"]["sensor"]["camera"]["color"].shape == (4, 100, 240, 320, 4)
+    assert buffer["obs"]["sensor"]["camera"]["mask"].shape == (4, 100, 240, 320)
+
+    # Check extra obs is present
+    assert "extra_vec" in buffer["obs"]
+    assert buffer["obs"]["extra_vec"].shape == (4, 100, 10)
+
+
+def test_different_batch_sizes():
+    """Test that batch_size correctly affects extra observations."""
+    config = {
+        "sensor": [],
+        "env": {
+            "observations": {
+                "extra_data": {
+                    "mode": "add",
+                    "extra": {"shape": [5]},
                 }
-            },
-        }
+            }
+        },
+    }
 
-        buffer = init_rollout_buffer_from_config(
-            config=config,
-            max_episode_steps=100,
-            batch_size=4,
-            state_dim=7,
-            device="cpu",
-        )
+    buffer = init_rollout_buffer_from_config(
+        config=config,
+        max_episode_steps=50,
+        batch_size=8,
+        state_dim=7,
+        device="cpu",
+    )
 
-        # Check sensor is present
-        assert "sensor" in buffer["obs"]
-        assert "camera" in buffer["obs"]["sensor"]
-        assert buffer["obs"]["sensor"]["camera"]["color"].shape == (4, 100, 240, 320, 4)
-        assert buffer["obs"]["sensor"]["camera"]["mask"].shape == (4, 100, 240, 320)
+    assert buffer["obs"]["extra_data"].shape == (8, 50, 5)
 
-        # Check extra obs is present
-        assert "extra_vec" in buffer["obs"]
-        assert buffer["obs"]["extra_vec"].shape == (4, 100, 10)
 
-    def test_different_batch_sizes(self):
-        """Test that batch_size correctly affects extra observations."""
-        config = {
-            "sensor": [],
-            "env": {
-                "observations": {
-                    "extra_data": {
-                        "mode": "add",
-                        "extra": {"shape": [5]},
-                    }
+def test_different_max_episode_steps():
+    """Test that max_episode_steps correctly affects extra observations."""
+    config = {
+        "sensor": [],
+        "env": {
+            "observations": {
+                "extra_data": {
+                    "mode": "add",
+                    "extra": {"shape": [2]},
                 }
-            },
-        }
+            }
+        },
+    }
 
-        buffer = init_rollout_buffer_from_config(
-            config=config,
-            max_episode_steps=50,
-            batch_size=8,
-            state_dim=7,
-            device="cpu",
-        )
+    buffer = init_rollout_buffer_from_config(
+        config=config,
+        max_episode_steps=200,
+        batch_size=4,
+        state_dim=7,
+        device="cpu",
+    )
 
-        assert buffer["obs"]["extra_data"].shape == (8, 50, 5)
-
-    def test_different_max_episode_steps(self):
-        """Test that max_episode_steps correctly affects extra observations."""
-        config = {
-            "sensor": [],
-            "env": {
-                "observations": {
-                    "extra_data": {
-                        "mode": "add",
-                        "extra": {"shape": [2]},
-                    }
-                }
-            },
-        }
-
-        buffer = init_rollout_buffer_from_config(
-            config=config,
-            max_episode_steps=200,
-            batch_size=4,
-            state_dim=7,
-            device="cpu",
-        )
-
-        assert buffer["obs"]["extra_data"].shape == (4, 200, 2)
+    assert buffer["obs"]["extra_data"].shape == (4, 200, 2)
 
 
 class TestConfigToCfgFromYaml:


### PR DESCRIPTION
## Description

This PR adds a `--max_episodes` CLI override for `run_env.py` by merging the flag into the loaded gym config before environment construction.

This keeps the behavior centralized in the shared launcher config path and avoids adding script-specific branching in `run_env.py`.

Dependencies: none

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (existing functionality will not work without user modification)
- [ ] Documentation update

## Screenshots

N/A

## Checklist

- [x] I have run the `black .` command to format the code base.
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Dependencies have been updated, if applicable.
