### PR TITLE
Fix CUDA device index preservation in standardize_device_string

### DIFF
--- a/embodichain/utils/device_utils.py
+++ b/embodichain/utils/device_utils.py
@@ -33,7 +33,7 @@ def standardize_device_string(device: Union[str, torch.device]) -> str:
     else:
         device_str = str(device)
 
-    if device_str.startswith("cuda"):
+    if device_str == "cuda":
         device_str = "cuda:0"
 
     return device_str

--- a/tests/utils/test_device_utils.py
+++ b/tests/utils/test_device_utils.py
@@ -1,0 +1,48 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from embodichain.utils.device_utils import standardize_device_string
+
+
+class TestStandardizeDeviceString:
+    def test_cpu_string(self):
+        assert standardize_device_string("cpu") == "cpu"
+
+    def test_cpu_torch_device(self):
+        assert standardize_device_string(torch.device("cpu")) == "cpu"
+
+    def test_cuda_without_index(self):
+        assert standardize_device_string("cuda") == "cuda:0"
+
+    def test_cuda_without_index_torch_device(self):
+        assert standardize_device_string(torch.device("cuda")) == "cuda:0"
+
+    def test_cuda_zero(self):
+        assert standardize_device_string("cuda:0") == "cuda:0"
+
+    def test_cuda_zero_torch_device(self):
+        assert standardize_device_string(torch.device("cuda:0")) == "cuda:0"
+
+    def test_cuda_non_zero_index(self):
+        assert standardize_device_string("cuda:4") == "cuda:4"
+
+    def test_cuda_non_zero_index_torch_device(self):
+        assert standardize_device_string(torch.device("cuda:4")) == "cuda:4"


### PR DESCRIPTION
## Description

This PR fixes `standardize_device_string` so it preserves non-zero CUDA device indices instead of forcing every `cuda:X` to `cuda:0`.

Previously, when running with `--device cuda:4`, tensors were placed on `cuda:4` but Warp kernels were launched on `cuda:0`, causing a `RuntimeError` during environment reset in solvers such as OPW.

Dependencies: None

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (existing functionality will not work without user modification)
- [ ] Documentation update

## Screenshots

N/A

## Checklist

- [x] I have run the `black .` command to format the code base.
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Dependencies have been updated, if applicable.