### PR TITLE
fix(sim): propagate max_linear_velocity and max_angular_velocity in RigidBodyAttributesCfg

### DIFF
--- a/embodichain/lab/sim/cfg.py
+++ b/embodichain/lab/sim/cfg.py
@@ -300,6 +300,8 @@ class RigidBodyAttributesCfg:
         attr.sleep_threshold = self.sleep_threshold
         attr.restitution = self.restitution
         attr.enable_ccd = self.enable_ccd
+        attr.max_linear_velocity = self.max_linear_velocity
+        attr.max_angular_velocity = self.max_angular_velocity
         attr.max_depenetration_velocity = self.max_depenetration_velocity
         attr.min_position_iters = self.min_position_iters
         attr.min_velocity_iters = self.min_velocity_iters


### PR DESCRIPTION
## Description

This PR fixes a bug where `max_linear_velocity` and `max_angular_velocity` fields were defined in `RigidBodyAttributesCfg` but never assigned to the underlying physics rigid body attributes. This caused the velocity limits to be silently ignored when creating rigid bodies.

**Root cause**: The `RigidBodyAttributesCfg.to_physx_rigid_body_attr()` method was missing the two assignment lines for `max_linear_velocity` and `max_angular_velocity`.

**Fix**: Added the two missing attribute assignments.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (existing functionality will not work without user modification)
- [ ] Documentation update

## Checklist

- [x] I have run the `black .` command to format the code base.
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Dependencies have been updated, if applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)