### PR TITLE
Reset dataset manager and add head drive properties

### DIFF
--- a/embodichain/lab/gym/envs/embodied_env.py
+++ b/embodichain/lab/gym/envs/embodied_env.py
@@ -566,6 +566,9 @@ class EmbodiedEnv(BaseEnv):
         if self.cfg.rewards:
             self.reward_manager.reset(env_ids=env_ids)
 
+        if self.cfg.dataset:
+            self.dataset_manager.reset(env_ids=env_ids)
+
     def _infer_rollout_buffer_mode(self, rollout_buffer: TensorDict) -> str:
         """Infer whether the rollout buffer is expert recording or RL training data."""
         if {

--- a/embodichain/lab/sim/robots/dexforce_w1/cfg.py
+++ b/embodichain/lab/sim/robots/dexforce_w1/cfg.py
@@ -242,7 +242,11 @@ class DexforceW1Cfg(RobotCfg):
         HEAD_JOINTS = "(NECK1|NECK2)"
 
         joint_params = {
-            "stiffness": {ARM_JOINTS: 1e4, BODY_JOINTS: 1e7, HEAD_JOINTS: 1e4,},
+            "stiffness": {
+                ARM_JOINTS: 1e4,
+                BODY_JOINTS: 1e7,
+                HEAD_JOINTS: 1e4,
+            },
             "damping": {ARM_JOINTS: 1e3, BODY_JOINTS: 1e4, HEAD_JOINTS: 1e3},
             "max_effort": {ARM_JOINTS: 1e5, BODY_JOINTS: 1e10, HEAD_JOINTS: 1e5},
         }

--- a/embodichain/lab/sim/robots/dexforce_w1/cfg.py
+++ b/embodichain/lab/sim/robots/dexforce_w1/cfg.py
@@ -239,11 +239,12 @@ class DexforceW1Cfg(RobotCfg):
         DEFAULT_EEF_GRIPPER_JOINT_NAMES = "(LEFT|RIGHT)_FINGER[1-2]"
         ARM_JOINTS = "(RIGHT|LEFT)_J[0-9]"
         BODY_JOINTS = "(ANKLE|KNEE|BUTTOCK|WAIST)"
+        HEAD_JOINTS = "(NECK1|NECK2)"
 
         joint_params = {
-            "stiffness": {ARM_JOINTS: 1e4, BODY_JOINTS: 1e7},
-            "damping": {ARM_JOINTS: 1e3, BODY_JOINTS: 1e4},
-            "max_effort": {ARM_JOINTS: 1e5, BODY_JOINTS: 1e10},
+            "stiffness": {ARM_JOINTS: 1e4, BODY_JOINTS: 1e7, HEAD_JOINTS: 1e4,},
+            "damping": {ARM_JOINTS: 1e3, BODY_JOINTS: 1e4, HEAD_JOINTS: 1e3},
+            "max_effort": {ARM_JOINTS: 1e5, BODY_JOINTS: 1e10, HEAD_JOINTS: 1e5},
         }
         drive_pros = JointDrivePropertiesCfg(**joint_params)
 


### PR DESCRIPTION
# Description

This PR resets the dataset manager during environment reset and adds default drive properties for the head joints.

The dataset manager reset keeps dataset-related state consistent across episodes.  
The head drive properties make the DexforceW1 head joints use explicit default stiffness, damping, and effort settings.

No new dependencies are required for this change.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Enhancement (non-breaking change which improves an existing functionality)

## Screenshots

Not applicable.

## Checklist

- [ ] I have run the `black .` command to format the code base.
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Dependencies have been updated, if applicable.