### PR TITLE
Simplify atomic action tutorials

### DIFF
--- a/docs/source/overview/sim/atomic_actions/index.md
+++ b/docs/source/overview/sim/atomic_actions/index.md
@@ -30,7 +30,7 @@ the `next_state` of each action as the input state of the next, then concatenate
 trajectories into one contiguous sequence:
 
 ```
-GraspTarget(semantics) ──► AtomicAction.execute(target, state)
+GraspTarget(semantics, grasp_xpos=None) ──► AtomicAction.execute(target, state)
 EndEffectorPoseTarget(xpos)                │
 JointPositionTarget(qpos)                  ├─ IK solve when pose-based
 NamedJointPositionTarget(name)             ├─ Motion plan / interpolation
@@ -67,7 +67,7 @@ and every action declares the target type, or tuple of target types, it accepts 
 | `EndEffectorPoseTarget` | `EndEffectorPoseTarget(xpos, tcp_symmetry="none")` | `MoveEndEffector`, `Place`, `Press` |
 | `JointPositionTarget` | `JointPositionTarget(qpos)` | `MoveJoints` |
 | `NamedJointPositionTarget` | `NamedJointPositionTarget(name)` | `MoveJoints` |
-| `GraspTarget` | `GraspTarget(semantics)` | `PickUp` |
+| `GraspTarget` | `GraspTarget(semantics, grasp_xpos=None)` | `PickUp` |
 | `HeldObjectPoseTarget` | `HeldObjectPoseTarget(object_target_pose)` | `MoveHeldObject` |
 | `CoordinatedPickmentTarget` | `CoordinatedPickmentTarget(...)` | `CoordinatedPickment` |
 | `CoordinatedPlacementTarget` | `CoordinatedPlacementTarget(...)` | `CoordinatedPlacement` |
@@ -106,7 +106,7 @@ action's `TargetType` before calling `execute`:
 | `EndEffectorPoseTarget(xpos, tcp_symmetry="none")` | EEF pose tensor `(4,4)`, `(n_envs,4,4)` or `(n_envs, n_waypoint, 4, 4)`; `Place` may opt into TCP z-roll 180 equivalence | `MoveEndEffector`, `Place`, `Press` |
 | `JointPositionTarget(qpos)` | Control-part qpos tensor `(control_dof,)`, `(n_envs, control_dof)` or `(n_envs, n_waypoint, control_dof)` | `MoveJoints` |
 | `NamedJointPositionTarget(name)` | Name resolved from `MoveJointsCfg.named_joint_positions` | `MoveJoints` |
-| `GraspTarget(semantics)` | `ObjectSemantics` (affordance + entity) | `PickUp` |
+| `GraspTarget(semantics, grasp_xpos=None)` | `ObjectSemantics` plus an optional preselected TCP grasp pose | `PickUp` |
 | `HeldObjectPoseTarget(object_target_pose)` | Desired held-object pose tensor | `MoveHeldObject` |
 | `CoordinatedPickmentTarget(...)` | Shared object semantics plus left/right grasp transforms and target object pose | `CoordinatedPickment` |
 | `CoordinatedPlacementTarget(...)` | Two held-object states plus object-centric placing/support target poses | `CoordinatedPlacement` |

--- a/embodichain/lab/sim/atomic_actions/core.py
+++ b/embodichain/lab/sim/atomic_actions/core.py
@@ -122,9 +122,18 @@ class NamedJointPositionTarget:
 
 @dataclass(frozen=True)
 class GraspTarget:
-    """Pickup target. The grasp pose is solved from the affordance + entity at execute time."""
+    """Pickup target with an affordance-selected or explicitly supplied grasp pose."""
 
     semantics: ObjectSemantics
+
+    grasp_xpos: torch.Tensor | None = None
+    """Optional end-effector grasp pose.
+
+    When omitted, :class:`PickUp` selects a grasp from the target affordance.
+    Supplying a pose with shape ``(4, 4)`` or ``(n_envs, 4, 4)`` skips grasp
+    sampling, which is useful when perception or task geometry has already
+    selected a grasp.
+    """
 
 
 @dataclass(frozen=True)

--- a/embodichain/lab/sim/atomic_actions/primitives/pick_up.py
+++ b/embodichain/lab/sim/atomic_actions/primitives/pick_up.py
@@ -113,9 +113,11 @@ class PickUp(AtomicAction):
 
     def execute(self, target: GraspTarget, state: WorldState) -> ActionResult:
         sem = target.semantics
-        if not isinstance(sem.affordance, AntipodalAffordance):
+        if target.grasp_xpos is None and not isinstance(
+            sem.affordance, AntipodalAffordance
+        ):
             logger.log_error(
-                "PickUp requires an AntipodalAffordance on the target semantics.",
+                "PickUp requires an AntipodalAffordance when grasp_xpos is not set.",
                 ValueError,
             )
         if sem.entity is None:
@@ -128,7 +130,13 @@ class PickUp(AtomicAction):
             arm_dof=self.arm_dof,
             control_part=self.cfg.control_part,
         )
-        is_success, grasp_xpos = self._resolve_grasp_pose(sem, start_arm_qpos)
+        if target.grasp_xpos is None:
+            is_success, grasp_xpos = self._resolve_grasp_pose(sem, start_arm_qpos)
+        else:
+            grasp_xpos = self.builder.resolve_pose_target(
+                target.grasp_xpos, n_envs=self.n_envs
+            )
+            is_success = torch.ones(self.n_envs, dtype=torch.bool, device=self.device)
 
         # apply grasp yr rotation offset if specified
         if self.cfg.rotate_upright is not None:

--- a/scripts/tutorials/atomic_action/coordinated_pickment.py
+++ b/scripts/tutorials/atomic_action/coordinated_pickment.py
@@ -38,26 +38,23 @@ import numpy as np
 import torch
 
 from embodichain.lab.gym.utils.gym_utils import add_env_launcher_args_to_parser
-from embodichain.lab.sim import SimulationManager, SimulationManagerCfg
+from embodichain.lab.sim import SimulationManager
 from embodichain.lab.sim.atomic_actions import (
     Affordance,
+    AtomicActionEngine,
     CoordinatedPickment,
     CoordinatedPickmentCfg,
     CoordinatedPickmentTarget,
     ObjectSemantics,
-    WorldState,
 )
 from embodichain.lab.sim.cfg import (
     JointDrivePropertiesCfg,
-    LightCfg,
-    RenderCfg,
     RigidBodyAttributesCfg,
     RigidObjectCfg,
     RobotCfg,
     URDFCfg,
 )
 from embodichain.lab.sim.objects import RigidObject, Robot
-from embodichain.lab.sim.planners import MotionGenCfg, MotionGenerator, ToppraPlannerCfg
 from embodichain.lab.sim.shapes import CubeCfg, MeshCfg
 from embodichain.lab.sim.solvers import PytorchSolverCfg
 from embodichain.utils import logger
@@ -65,12 +62,11 @@ from embodichain.utils.math import matrix_from_euler
 from scripts.tutorials.atomic_action.tutorial_utils import (
     broadcast_pose_batch,
     clone_local_pose_from_first_env,
+    create_toppra_motion_generator,
+    create_tutorial_simulation,
     draw_axis_marker,
-    get_tutorial_window_size,
-    should_open_tutorial_window,
-    should_wait_for_tutorial_input,
-    start_auto_play_recording,
-    stop_auto_play_recording,
+    prepare_tutorial_scene,
+    replay_trajectory,
 )
 
 ARM_URDF_PATH = "UniversalRobots/UR5/UR5.urdf"
@@ -235,32 +231,6 @@ def make_transform(xyz: tuple[float, float, float], yaw: float) -> np.ndarray:
     transform[:3, :3] = rotation_z(yaw)
     transform[:3, 3] = np.asarray(xyz, dtype=np.float32)
     return transform
-
-
-def initialize_simulation(args: argparse.Namespace) -> SimulationManager:
-    """Create the simulation manager and a light."""
-    width, height = get_tutorial_window_size(args)
-    sim = SimulationManager(
-        SimulationManagerCfg(
-            width=width,
-            height=height,
-            headless=True,
-            num_envs=args.num_envs,
-            sim_device=args.device,
-            render_cfg=RenderCfg(renderer=args.renderer),
-            physics_dt=1.0 / 100.0,
-            arena_space=3.0,
-        )
-    )
-    sim.add_light(
-        cfg=LightCfg(
-            uid="main_light",
-            color=(0.6, 0.6, 0.6),
-            intensity=30.0,
-            init_pos=(0.0, -0.4, 3.0),
-        )
-    )
-    return sim
 
 
 def create_dual_ur5_robot(sim: SimulationManager) -> Robot:
@@ -670,24 +640,6 @@ def log_execution_state(
     )
 
 
-def execute_trajectory(
-    sim: SimulationManager,
-    robot: Robot,
-    traj: torch.Tensor,
-    obj: RigidObject,
-    debug_state: bool,
-) -> None:
-    """Play a planned trajectory in simulation."""
-    total_steps = traj.shape[1]
-    log_stride = max(1, total_steps // 10)
-    for i in range(total_steps):
-        robot.set_qpos(traj[:, i, :])
-        sim.update(step=TRAJECTORY_SIM_STEPS)
-        if debug_state and (i % log_stride == 0 or i == total_steps - 1):
-            log_execution_state(robot, obj, i, total_steps)
-        time.sleep(1e-2)
-
-
 def run_coordinated_pickment_demo(
     args: argparse.Namespace,
     sim: SimulationManager,
@@ -704,9 +656,7 @@ def run_coordinated_pickment_demo(
     n_envs = object_pose_batch.shape[0]
     object_vertices = get_local_vertices(obj)
     object_semantics = create_object_semantics(obj, preset.label)
-    motion_gen = MotionGenerator(
-        cfg=MotionGenCfg(planner_cfg=ToppraPlannerCfg(robot_uid=robot.uid))
-    )
+    motion_gen = create_toppra_motion_generator(robot)
 
     left_open, left_close = get_hand_open_close_qpos(
         robot, "left_hand", sim.device, preset.hand_close_qpos
@@ -734,6 +684,8 @@ def run_coordinated_pickment_demo(
             object_motion_keyframes=PICKMENT_OBJECT_MOTION_KEYFRAMES,
         ),
     )
+    engine = AtomicActionEngine(motion_generator=motion_gen)
+    engine.register(pickment_action)
 
     left_grasp_pose, right_grasp_pose = build_object_grasp_poses(
         object_pose,
@@ -779,24 +731,18 @@ def run_coordinated_pickment_demo(
         object_initial_pose=broadcast_pose_batch(object_pose, num_envs=n_envs),
     )
 
-    wait_for_user = should_wait_for_tutorial_input(args)
-    if should_open_tutorial_window(args):
-        sim.open_window()
-    if wait_for_user and not args.diagnose_plan:
-        input("Inspect the scene, then press Enter to plan pickment...")
+    wait_for_user = prepare_tutorial_scene(
+        sim, args, "Inspect the scene, then press Enter to plan pickment..."
+    )
 
     start_time = time.time()
-    result = pickment_action.execute(
-        pickment_target,
-        WorldState(last_qpos=robot.get_qpos().clone()),
-    )
+    success, traj, _ = engine.run([("coordinated_pickment", pickment_target)])
     logger.log_info(
         f"Plan coordinated pickment cost time: {time.time() - start_time:.2f} seconds"
     )
-    if not result.success:
+    if not success.all():
         logger.log_warning("Failed to plan coordinated pickment trajectory.")
         return
-    traj = result.trajectory
     joint_ids = list(range(robot.dof))
     log_action_plan(
         robot,
@@ -811,22 +757,24 @@ def run_coordinated_pickment_demo(
 
     if wait_for_user:
         input("Press Enter to execute coordinated pickment...")
-    recording_started = start_auto_play_recording(
+
+    def log_execution(step_idx: int, total_steps: int) -> None:
+        if args.debug_state and (
+            step_idx % max(1, total_steps // 10) == 0 or step_idx == total_steps - 1
+        ):
+            log_execution_state(robot, obj, step_idx, total_steps)
+
+    replay_trajectory(
         sim,
+        robot,
+        traj,
         args,
         video_prefix=f"coordinated_pickment_{args.object}_auto_play",
+        hold_steps=0,
+        trajectory_sim_steps=TRAJECTORY_SIM_STEPS,
+        on_trajectory_step=log_execution,
         look_at=PICKMENT_RECORD_LOOK_AT,
     )
-    try:
-        execute_trajectory(
-            sim,
-            robot,
-            traj,
-            obj,
-            args.debug_state,
-        )
-    finally:
-        stop_auto_play_recording(sim, recording_started)
     if wait_for_user:
         input("Press Enter to exit the simulation...")
 
@@ -834,7 +782,11 @@ def run_coordinated_pickment_demo(
 def main() -> None:
     """Run the coordinated pickment demo."""
     args = parse_arguments()
-    sim = initialize_simulation(args)
+    sim = create_tutorial_simulation(
+        args,
+        arena_space=3.0,
+        light_pos=(0.0, -0.4, 3.0),
+    )
     robot = create_dual_ur5_robot(sim)
     run_coordinated_pickment_demo(args, sim, robot)
 

--- a/scripts/tutorials/atomic_action/coordinated_placement.py
+++ b/scripts/tutorials/atomic_action/coordinated_placement.py
@@ -39,47 +39,40 @@ import torch
 from scipy.spatial.transform import Rotation as SciRotation
 
 from embodichain.lab.gym.utils.gym_utils import add_env_launcher_args_to_parser
-from embodichain.lab.sim import SimulationManager, SimulationManagerCfg
+from embodichain.lab.sim import SimulationManager
 from embodichain.lab.sim.atomic_actions import (
     Affordance,
+    AtomicActionEngine,
     CoordinatedPlacement,
     CoordinatedPlacementCfg,
     CoordinatedPlacementTarget,
+    GraspTarget,
     HeldObjectState,
     ObjectSemantics,
-    TrajectoryBuilder,
+    PickUp,
+    PickUpCfg,
     WorldState,
 )
 from embodichain.lab.sim.cfg import (
     JointDrivePropertiesCfg,
-    LightCfg,
-    RenderCfg,
     RigidBodyAttributesCfg,
     RigidObjectCfg,
     RobotCfg,
     URDFCfg,
 )
 from embodichain.lab.sim.objects import RigidObject, Robot
-from embodichain.lab.sim.planners import (
-    MotionGenCfg,
-    MotionGenerator,
-    MoveType,
-    PlanState,
-    ToppraPlannerCfg,
-)
 from embodichain.lab.sim.shapes import MeshCfg
 from embodichain.lab.sim.solvers import URSolverCfg
 from embodichain.utils import logger
 from scripts.tutorials.atomic_action.tutorial_utils import (
     broadcast_pose_batch,
     clone_local_pose_from_first_env,
+    create_toppra_motion_generator,
+    create_tutorial_simulation,
     draw_axis_marker,
-    get_tutorial_window_size,
     make_ur5_solver_cfg,
-    should_open_tutorial_window,
-    should_wait_for_tutorial_input,
-    start_auto_play_recording,
-    stop_auto_play_recording,
+    prepare_tutorial_scene,
+    replay_trajectory,
 )
 
 DEFAULT_MESH_FRAME_CORRECTION_EULER_DEG = (-90.0, 0.0, 0.0)
@@ -273,32 +266,6 @@ def make_transform(xyz: tuple[float, float, float], yaw: float) -> np.ndarray:
     transform[:3, :3] = rotation_z(yaw)
     transform[:3, 3] = np.asarray(xyz, dtype=np.float32)
     return transform
-
-
-def initialize_simulation(args: argparse.Namespace) -> SimulationManager:
-    """Create the simulation manager and a light."""
-    width, height = get_tutorial_window_size(args)
-    sim = SimulationManager(
-        SimulationManagerCfg(
-            width=width,
-            height=height,
-            headless=True,
-            num_envs=args.num_envs,
-            sim_device=args.device,
-            render_cfg=RenderCfg(renderer=args.renderer),
-            physics_dt=1.0 / 100.0,
-            arena_space=3.0,
-        )
-    )
-    sim.add_light(
-        cfg=LightCfg(
-            uid="main_light",
-            color=(0.6, 0.6, 0.6),
-            intensity=30.0,
-            init_pos=(0.0, -0.4, 3.0),
-        )
-    )
-    return sim
 
 
 def make_prefixed_ur5_solver_cfg(prefix: str) -> URSolverCfg:
@@ -716,116 +683,6 @@ def compute_actual_held_state(
     )
 
 
-def plan_manual_pick(
-    motion_gen: MotionGenerator,
-    robot: Robot,
-    *,
-    arm_control_part: str,
-    hand_control_part: str,
-    grasp_pose: torch.Tensor,
-    hand_open_qpos: torch.Tensor,
-    hand_close_qpos: torch.Tensor,
-    sample_interval: int,
-    hand_interp_steps: int,
-    pre_grasp_distance: float,
-    lift_height: float,
-    start_state: WorldState,
-) -> tuple[bool, torch.Tensor, WorldState]:
-    """Plan a demo-local pick trajectory from a hand-authored TCP grasp pose."""
-    builder = TrajectoryBuilder(motion_gen)
-    device = start_state.last_qpos.device
-    n_envs = robot.get_qpos().shape[0]
-    robot_dof = robot.dof
-    arm_joint_ids = robot.get_joint_ids(name=arm_control_part)
-    hand_joint_ids = robot.get_joint_ids(name=hand_control_part)
-    arm_dof = len(arm_joint_ids)
-
-    grasp_xpos = builder.resolve_pose_target(grasp_pose, n_envs=n_envs)
-    grasp_z = grasp_xpos[:, :3, 2]
-    pre_grasp_xpos = builder.apply_local_offset(
-        grasp_xpos, -grasp_z * pre_grasp_distance
-    )
-    lift_xpos = builder.apply_local_offset(
-        grasp_xpos,
-        torch.tensor([0.0, 0.0, lift_height], device=device),
-    )
-    start_arm_qpos = builder.resolve_start_qpos(
-        start_state.last_qpos[:, arm_joint_ids],
-        n_envs=n_envs,
-        arm_dof=arm_dof,
-        control_part=arm_control_part,
-    )
-    n_approach, n_close, n_lift = builder.split_three_phase(
-        sample_interval,
-        hand_interp_steps,
-        first_phase_name="approach",
-        third_phase_name="lift",
-    )
-
-    target_states_list = [
-        [
-            PlanState(xpos=pre_grasp_xpos[i], move_type=MoveType.EEF_MOVE),
-            PlanState(xpos=grasp_xpos[i], move_type=MoveType.EEF_MOVE),
-        ]
-        for i in range(n_envs)
-    ]
-    ok, approach_arm = builder.plan_arm_traj(
-        target_states_list,
-        start_arm_qpos,
-        n_approach,
-        control_part=arm_control_part,
-        arm_dof=arm_dof,
-    )
-    if not bool(torch.all(ok)):
-        logger.log_warning(f"Failed to plan {arm_control_part} manual pick approach.")
-        return (
-            False,
-            torch.empty((n_envs, 0, robot_dof), dtype=torch.float32, device=device),
-            start_state,
-        )
-
-    grasp_arm_qpos = approach_arm[:, -1, :]
-    target_states_list = [
-        [PlanState(xpos=lift_xpos[i], move_type=MoveType.EEF_MOVE)]
-        for i in range(n_envs)
-    ]
-    ok, lift_arm = builder.plan_arm_traj(
-        target_states_list,
-        grasp_arm_qpos,
-        n_lift,
-        control_part=arm_control_part,
-        arm_dof=arm_dof,
-    )
-    if not bool(torch.all(ok)):
-        logger.log_warning(f"Failed to plan {arm_control_part} manual pick lift.")
-        return (
-            False,
-            torch.empty((n_envs, 0, robot_dof), dtype=torch.float32, device=device),
-            start_state,
-        )
-
-    hand_open = builder.expand_hand_qpos(
-        hand_open_qpos, n_envs=n_envs, hand_dof=len(hand_joint_ids)
-    )
-    hand_close = builder.expand_hand_qpos(
-        hand_close_qpos, n_envs=n_envs, hand_dof=len(hand_joint_ids)
-    )
-    hand_close_path = builder.interpolate_hand_qpos(
-        hand_open, hand_close, n_waypoints=n_close
-    )
-
-    full = start_state.last_qpos.unsqueeze(1).repeat(1, sample_interval, 1).clone()
-    full[:, :n_approach, arm_joint_ids] = approach_arm
-    full[:, :n_approach, hand_joint_ids] = hand_open.unsqueeze(1)
-    full[:, n_approach : n_approach + n_close, arm_joint_ids] = (
-        grasp_arm_qpos.unsqueeze(1)
-    )
-    full[:, n_approach : n_approach + n_close, hand_joint_ids] = hand_close_path
-    full[:, n_approach + n_close :, arm_joint_ids] = lift_arm
-    full[:, n_approach + n_close :, hand_joint_ids] = hand_close.unsqueeze(1)
-    return True, full, WorldState(last_qpos=full[:, -1, :].clone(), held_object=None)
-
-
 def log_scene_targets(
     bread_pose: torch.Tensor,
     pan_pose: torch.Tensor,
@@ -906,26 +763,6 @@ def log_execution_state(
     )
 
 
-def execute_trajectory(
-    sim: SimulationManager,
-    robot: Robot,
-    traj: torch.Tensor,
-    joint_ids: list[int],
-    bread: RigidObject,
-    pan: RigidObject,
-    debug_state: bool,
-) -> None:
-    """Play a planned trajectory in simulation."""
-    total_steps = traj.shape[1]
-    log_stride = max(1, total_steps // 10)
-    for i in range(total_steps):
-        robot.set_qpos(traj[:, i, :], joint_ids=joint_ids)
-        sim.update(step=TRAJECTORY_SIM_STEPS)
-        if debug_state and (i % log_stride == 0 or i == total_steps - 1):
-            log_execution_state(robot, bread, pan, i, total_steps)
-        time.sleep(1e-2)
-
-
 def run_coordinated_placement_demo(
     args: argparse.Namespace, sim: SimulationManager, robot: Robot
 ) -> None:
@@ -948,14 +785,38 @@ def run_coordinated_placement_demo(
     log_scene_targets(bread_pose, pan_pose)
     bread_semantics = create_object_semantics(bread, BREAD_LABEL)
     pan_semantics = create_object_semantics(pan, PAN_LABEL)
-    motion_gen = MotionGenerator(
-        cfg=MotionGenCfg(planner_cfg=ToppraPlannerCfg(robot_uid=robot.uid))
-    )
+    motion_gen = create_toppra_motion_generator(robot)
 
     right_open, right_close = get_pan_handle_open_close_qpos(
         robot, "right_hand", sim.device
     )
     left_open, left_close = get_hand_open_close_qpos(robot, "left_hand", sim.device)
+    left_pick_action = PickUp(
+        motion_generator=motion_gen,
+        cfg=PickUpCfg(
+            control_part="left_arm",
+            hand_control_part="left_hand",
+            hand_open_qpos=left_open,
+            hand_close_qpos=left_close,
+            pre_grasp_distance=PICK_APPROACH_DISTANCE,
+            lift_height=0.12,
+            sample_interval=PICK_SAMPLE_INTERVAL,
+            hand_interp_steps=10,
+        ),
+    )
+    right_pick_action = PickUp(
+        motion_generator=motion_gen,
+        cfg=PickUpCfg(
+            control_part="right_arm",
+            hand_control_part="right_hand",
+            hand_open_qpos=right_open,
+            hand_close_qpos=right_close,
+            pre_grasp_distance=PICK_APPROACH_DISTANCE,
+            lift_height=0.10,
+            sample_interval=PAN_PICK_SAMPLE_INTERVAL,
+            hand_interp_steps=PAN_PICK_HAND_INTERP_STEPS,
+        ),
+    )
     coordinated_action = CoordinatedPlacement(
         motion_generator=motion_gen,
         cfg=CoordinatedPlacementCfg(
@@ -977,14 +838,14 @@ def run_coordinated_placement_demo(
             retreat_steps=18,
         ),
     )
+    engine = AtomicActionEngine(motion_generator=motion_gen)
+    engine.register(coordinated_action)
     full_joint_ids = list(range(robot.dof))
     state = WorldState(last_qpos=robot.get_qpos().clone())
 
-    wait_for_user = should_wait_for_tutorial_input(args)
-    if should_open_tutorial_window(args):
-        sim.open_window()
-    if wait_for_user and not args.diagnose_plan:
-        input("Inspect the scene, then press Enter to plan left pick-up...")
+    wait_for_user = prepare_tutorial_scene(
+        sim, args, "Inspect the scene, then press Enter to plan left pick-up..."
+    )
 
     bread_grasp_pose = build_flat_object_grasp_pose(
         bread_pose,
@@ -995,36 +856,25 @@ def run_coordinated_placement_demo(
         z_clearance=BREAD_GRASP_Z_CLEARANCE,
     )
     start_time = time.time()
-    left_pick_success, left_pick_traj, state = plan_manual_pick(
-        motion_gen,
-        robot,
-        arm_control_part="left_arm",
-        hand_control_part="left_hand",
-        grasp_pose=bread_grasp_pose,
-        hand_open_qpos=left_open,
-        hand_close_qpos=left_close,
-        sample_interval=PICK_SAMPLE_INTERVAL,
-        hand_interp_steps=10,
-        pre_grasp_distance=PICK_APPROACH_DISTANCE,
-        lift_height=0.12,
-        start_state=state,
+    left_pick_result = left_pick_action.execute(
+        GraspTarget(
+            semantics=bread_semantics,
+            grasp_xpos=broadcast_pose_batch(bread_grasp_pose, num_envs=n_envs),
+        ),
+        state,
     )
     logger.log_info(
         f"Plan left bread pick-up cost time: {time.time() - start_time:.2f} seconds"
     )
-    if not left_pick_success:
+    if not left_pick_result.success.all():
         logger.log_warning("Failed to plan left bread pick-up trajectory.")
         return
+    left_pick_traj = left_pick_result.trajectory
+    state = left_pick_result.next_state
+    bread_held_state = state.held_object
+    if bread_held_state is None:
+        raise RuntimeError("PickUp did not produce a held state for the bread.")
     log_action_plan(robot, "left_pick_up", left_pick_traj, full_joint_ids)
-    bread_object_to_eef = torch.bmm(
-        broadcast_pose_batch(invert_pose(bread_pose.unsqueeze(0)), num_envs=n_envs),
-        broadcast_pose_batch(bread_grasp_pose, num_envs=n_envs),
-    )
-    bread_held_state = HeldObjectState(
-        semantics=bread_semantics,
-        object_to_eef=bread_object_to_eef,
-        grasp_xpos=broadcast_pose_batch(bread_grasp_pose, num_envs=n_envs),
-    )
 
     pan_grasp_pose = build_pan_handle_grasp_pose(
         pan_pose,
@@ -1033,60 +883,62 @@ def run_coordinated_placement_demo(
         z_clearance=PAN_GRASP_Z_CLEARANCE,
     )
     start_time = time.time()
-    right_pick_success, right_pick_traj, state = plan_manual_pick(
-        motion_gen,
-        robot,
-        arm_control_part="right_arm",
-        hand_control_part="right_hand",
-        grasp_pose=pan_grasp_pose,
-        hand_open_qpos=right_open,
-        hand_close_qpos=right_close,
-        sample_interval=PAN_PICK_SAMPLE_INTERVAL,
-        hand_interp_steps=PAN_PICK_HAND_INTERP_STEPS,
-        pre_grasp_distance=PICK_APPROACH_DISTANCE,
-        lift_height=0.10,
-        start_state=state,
+    right_pick_result = right_pick_action.execute(
+        GraspTarget(
+            semantics=pan_semantics,
+            grasp_xpos=broadcast_pose_batch(pan_grasp_pose, num_envs=n_envs),
+        ),
+        state,
     )
     logger.log_info(
         f"Plan right pan pick-up cost time: {time.time() - start_time:.2f} seconds"
     )
-    if not right_pick_success:
+    if not right_pick_result.success.all():
         logger.log_warning("Failed to plan right pan pick-up trajectory.")
         return
+    right_pick_traj = right_pick_result.trajectory
+    state = right_pick_result.next_state
+    pan_held_state = state.held_object
+    if pan_held_state is None:
+        raise RuntimeError("PickUp did not produce a held state for the pan.")
     log_action_plan(robot, "right_pick_up", right_pick_traj, full_joint_ids)
-    pan_object_to_eef = torch.bmm(
-        broadcast_pose_batch(invert_pose(pan_pose.unsqueeze(0)), num_envs=n_envs),
-        broadcast_pose_batch(pan_grasp_pose, num_envs=n_envs),
-    )
-    pan_held_state = HeldObjectState(
-        semantics=pan_semantics,
-        object_to_eef=pan_object_to_eef,
-        grasp_xpos=broadcast_pose_batch(pan_grasp_pose, num_envs=n_envs),
-    )
 
     if args.diagnose_plan:
         robot.set_qpos(state.last_qpos, joint_ids=full_joint_ids)
     else:
         if wait_for_user:
             input("Press Enter to execute both pick-up trajectories...")
-        execute_trajectory(
+
+        def log_pick_execution(step_idx: int, total_steps: int) -> None:
+            if args.debug_state and (
+                step_idx % max(1, total_steps // 10) == 0 or step_idx == total_steps - 1
+            ):
+                log_execution_state(robot, bread, pan, step_idx, total_steps)
+
+        replay_trajectory(
             sim,
             robot,
             left_pick_traj,
-            full_joint_ids,
-            bread,
-            pan,
-            args.debug_state,
+            args,
+            video_prefix="",
+            hold_steps=0,
+            trajectory_sim_steps=TRAJECTORY_SIM_STEPS,
+            joint_ids=full_joint_ids,
+            on_trajectory_step=log_pick_execution,
+            record=False,
         )
         bread.clear_dynamics()
-        execute_trajectory(
+        replay_trajectory(
             sim,
             robot,
             right_pick_traj,
-            full_joint_ids,
-            bread,
-            pan,
-            args.debug_state,
+            args,
+            video_prefix="",
+            hold_steps=0,
+            trajectory_sim_steps=TRAJECTORY_SIM_STEPS,
+            joint_ids=full_joint_ids,
+            on_trajectory_step=log_pick_execution,
+            record=False,
         )
         pan.clear_dynamics()
         bread_pose_batch = clone_local_pose_from_first_env(bread).to(
@@ -1148,15 +1000,14 @@ def run_coordinated_placement_demo(
         release=True,
     )
     start_time = time.time()
-    coordinated_result = coordinated_action.execute(coordinated_target, state)
-    coordinated_success = coordinated_result.success
-    coordinated_traj = coordinated_result.trajectory
-    state = coordinated_result.next_state
+    coordinated_success, coordinated_traj, state = engine.run(
+        [("coordinated_placement", coordinated_target)], state
+    )
     logger.log_info(
         "Plan coordinated placement cost time: "
         f"{time.time() - start_time:.2f} seconds"
     )
-    if not coordinated_success:
+    if not coordinated_success.all():
         logger.log_warning("Failed to plan coordinated placement trajectory.")
         return
     log_action_plan(
@@ -1170,41 +1021,38 @@ def run_coordinated_placement_demo(
     if args.diagnose_plan:
         return
 
-    recording_started = start_auto_play_recording(
+    if args.auto_play and not args.no_vis_eef_axis:
+        draw_coordinated_axes(
+            sim,
+            support_target_pose,
+            placing_target_pose,
+            num_envs=n_envs,
+        )
+    if wait_for_user:
+        input("Press Enter to execute coordinated placement...")
+
+    def log_execution(step_idx: int, total_steps: int) -> None:
+        if args.debug_state and (
+            step_idx % max(1, total_steps // 10) == 0 or step_idx == total_steps - 1
+        ):
+            log_execution_state(robot, bread, pan, step_idx, total_steps)
+
+    replay_trajectory(
         sim,
+        robot,
+        coordinated_traj,
         args,
         video_prefix="coordinated_placement_auto_play",
+        hold_steps=80,
+        trajectory_sim_steps=TRAJECTORY_SIM_STEPS,
+        joint_ids=full_joint_ids,
+        on_trajectory_step=log_execution,
         look_at=(
             (-0.25, 0.0, 2.5),
             (-0.05, 0.0, 0.72),
             (0.0, 0.0, 1.0),
         ),
     )
-    try:
-        if args.auto_play and not args.no_vis_eef_axis:
-            draw_coordinated_axes(
-                sim,
-                support_target_pose,
-                placing_target_pose,
-                num_envs=n_envs,
-            )
-        if wait_for_user:
-            input("Press Enter to execute coordinated placement...")
-        execute_trajectory(
-            sim,
-            robot,
-            coordinated_traj,
-            full_joint_ids,
-            bread,
-            pan,
-            args.debug_state,
-        )
-        for _ in range(80):
-            robot.set_qpos(state.last_qpos, joint_ids=full_joint_ids)
-            sim.update(step=2)
-            time.sleep(1e-2)
-    finally:
-        stop_auto_play_recording(sim, recording_started)
     if wait_for_user:
         input("Press Enter to exit the simulation...")
 
@@ -1212,7 +1060,11 @@ def run_coordinated_placement_demo(
 def main() -> None:
     """Run the coordinated placement demo."""
     args = parse_arguments()
-    sim = initialize_simulation(args)
+    sim = create_tutorial_simulation(
+        args,
+        arena_space=3.0,
+        light_pos=(0.0, -0.4, 3.0),
+    )
     robot = create_dual_ur5_robot(sim)
     run_coordinated_placement_demo(args, sim, robot)
 

--- a/scripts/tutorials/atomic_action/move_end_effector.py
+++ b/scripts/tutorials/atomic_action/move_end_effector.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import argparse
 import sys
-import time
 from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -30,25 +29,23 @@ if str(_REPO_ROOT) not in sys.path:
 import torch
 
 from embodichain.lab.gym.utils.gym_utils import add_env_launcher_args_to_parser
-from embodichain.lab.sim import SimulationManager, SimulationManagerCfg
 from embodichain.lab.sim.atomic_actions import (
     AtomicActionEngine,
     EndEffectorPoseTarget,
     MoveEndEffector,
     MoveEndEffectorCfg,
 )
-from embodichain.lab.sim.cfg import LightCfg, RenderCfg
-from embodichain.lab.sim.objects import Robot
-from embodichain.lab.sim.planners import MotionGenerator, MotionGenCfg, ToppraPlannerCfg
 from embodichain.utils import logger
 from scripts.tutorials.atomic_action.tutorial_utils import (
+    add_ur5_gripper_robot,
     broadcast_pose_batch,
     broadcast_waypoint_pose_batch,
-    create_ur5_gripper_robot_cfg,
+    create_toppra_motion_generator,
+    create_tutorial_simulation,
     draw_axis_marker,
-    get_tutorial_window_size,
-    start_auto_play_recording,
-    stop_auto_play_recording,
+    make_top_down_eef_pose,
+    prepare_tutorial_scene,
+    replay_trajectory,
 )
 
 MOVE_SAMPLE_INTERVAL = 80
@@ -56,190 +53,74 @@ POST_TRAJECTORY_STEPS = 120
 
 
 def parse_arguments() -> argparse.Namespace:
+    """Parse command-line arguments for the MoveEndEffector tutorial."""
     parser = argparse.ArgumentParser(
         description="Demonstrate MoveEndEffector with a multi-waypoint pose trajectory."
     )
     add_env_launcher_args_to_parser(parser)
-    parser.add_argument(
-        "--auto_play",
-        action="store_true",
-        help="Run the viewer demo without waiting for keyboard input.",
-    )
-    parser.add_argument(
-        "--no_vis_eef_axis",
-        action="store_true",
-        help="Do not draw the current end-effector/TCP coordinate frame before planning.",
-    )
+    parser.add_argument("--auto_play", action="store_true")
+    parser.add_argument("--no_vis_eef_axis", action="store_true")
     return parser.parse_args()
 
 
-def initialize_simulation(args: argparse.Namespace) -> SimulationManager:
-    width, height = get_tutorial_window_size(args)
-    cfg = SimulationManagerCfg(
-        width=width,
-        height=height,
-        headless=True,
-        num_envs=args.num_envs,
-        sim_device=args.device,
-        render_cfg=RenderCfg(renderer=args.renderer),
-        physics_dt=1.0 / 100.0,
-        arena_space=2.5,
-    )
-    sim = SimulationManager(cfg)
-    sim.add_light(
-        cfg=LightCfg(
-            uid="main_light",
-            color=(0.6, 0.6, 0.6),
-            intensity=30.0,
-            init_pos=(1.0, 0.0, 3.0),
-        )
-    )
-    return sim
-
-
-def create_robot(sim: SimulationManager, position=(0.0, 0.0, 0.0)) -> Robot:
-    cfg = create_ur5_gripper_robot_cfg(init_pos=position)
-    return sim.add_robot(cfg=cfg)
-
-
-def make_top_down_eef_pose(device: torch.device) -> torch.Tensor:
-    pose = torch.eye(4, dtype=torch.float32, device=device)
-    pose[:3, :3] = torch.tensor(
-        [
-            [-0.0539, -0.9985, -0.0022],
-            [-0.9977, 0.0540, -0.0401],
-            [0.0401, 0.0000, -0.9992],
-        ],
-        dtype=torch.float32,
-        device=device,
-    )
-    pose[:3, 3] = torch.tensor([0.30, -0.20, 0.36], dtype=torch.float32, device=device)
-    return pose
-
-
-def make_side_eef_pose(device: torch.device) -> torch.Tensor:
-    """A second waypoint offset from the top-down pose for the multi-waypoint demo."""
-    pose = torch.eye(4, dtype=torch.float32, device=device)
-    pose[:3, :3] = torch.tensor(
-        [
-            [-0.0539, -0.9985, -0.0022],
-            [-0.9977, 0.0540, -0.0401],
-            [0.0401, 0.0000, -0.9992],
-        ],
-        dtype=torch.float32,
-        device=device,
-    )
-    pose[:3, 3] = torch.tensor([0.45, 0.10, 0.30], dtype=torch.float32, device=device)
-    return pose
-
-
-def format_tensor(tensor: torch.Tensor) -> str:
-    rounded = (tensor.detach().cpu() * 10000.0).round() / 10000.0
-    return str(rounded.tolist())
-
-
 def main() -> None:
-    """Move the robot end effector through a multi-waypoint pose trajectory."""
+    """Move the robot end effector through two pose waypoints."""
     args = parse_arguments()
+    sim = create_tutorial_simulation(args)
+    robot = add_ur5_gripper_robot(sim)
+    motion_gen = create_toppra_motion_generator(robot)
 
-    # ------------------------------------------------------------------ #
-    # Step 1: Set up simulation and robot                                 #
-    # ------------------------------------------------------------------ #
-    sim = initialize_simulation(args)
-    robot = create_robot(sim)
+    engine = AtomicActionEngine(motion_generator=motion_gen)
+    engine.register(
+        MoveEndEffector(
+            motion_gen,
+            cfg=MoveEndEffectorCfg(sample_interval=MOVE_SAMPLE_INTERVAL),
+        )
+    )
+
+    poses = torch.stack(
+        [
+            make_top_down_eef_pose(
+                torch.tensor([0.30, -0.20, 0.36], device=sim.device)
+            ),
+            make_top_down_eef_pose(torch.tensor([0.45, 0.10, 0.30], device=sim.device)),
+        ]
+    )
     n_envs = robot.get_qpos().shape[0]
-
-    # ------------------------------------------------------------------ #
-    # Step 2: Create a MotionGenerator for the robot                      #
-    # ------------------------------------------------------------------ #
-    motion_gen = MotionGenerator(
-        cfg=MotionGenCfg(planner_cfg=ToppraPlannerCfg(robot_uid=robot.uid))
-    )
-
-    # ------------------------------------------------------------------ #
-    # Step 3: Configure the MoveEndEffector atomic action                 #
-    # ------------------------------------------------------------------ #
-    move_cfg = MoveEndEffectorCfg(
-        control_part="arm",
-        sample_interval=MOVE_SAMPLE_INTERVAL,
-    )
-
-    # ------------------------------------------------------------------ #
-    # Step 4: Build the AtomicActionEngine                                #
-    # ------------------------------------------------------------------ #
-    atomic_engine = AtomicActionEngine(motion_generator=motion_gen)
-    atomic_engine.register(MoveEndEffector(motion_gen, cfg=move_cfg))
-
-    # ------------------------------------------------------------------ #
-    # Step 5: Define and visualize the end-effector target                #
-    # ------------------------------------------------------------------ #
-    target_pose = make_top_down_eef_pose(sim.device)
-    side_pose = make_side_eef_pose(sim.device)
-    if not args.headless:
-        sim.open_window()
     if not args.no_vis_eef_axis:
-        draw_axis_marker(
-            sim,
-            "move_end_effector_target_axis",
-            broadcast_pose_batch(target_pose, num_envs=n_envs),
-        )
-        draw_axis_marker(
-            sim,
-            "move_end_effector_side_axis",
-            broadcast_pose_batch(side_pose, num_envs=n_envs),
-        )
-    if not args.auto_play:
-        input("Inspect the robot, then press Enter to plan MoveEndEffector...")
+        for name, pose in zip(("target", "side"), poses, strict=True):
+            draw_axis_marker(
+                sim,
+                f"move_end_effector_{name}_axis",
+                broadcast_pose_batch(pose, num_envs=n_envs),
+            )
+    wait_for_user = prepare_tutorial_scene(
+        sim, args, "Inspect the robot, then press Enter to plan MoveEndEffector..."
+    )
 
-    # ------------------------------------------------------------------ #
-    # Step 6: Plan the declared (name, typed_target) sequence             #
-    # ------------------------------------------------------------------ #
-    # Pass a multi-waypoint trajectory (n_envs, n_waypoint, 4, 4): the
-    # end-effector visits `target_pose` then `side_pose` in a single plan.
-    multi_waypoint_xpos = broadcast_waypoint_pose_batch(
-        torch.stack([target_pose, side_pose], dim=0), num_envs=n_envs
-    )
-    logger.log_info(
-        "Planning MoveEndEffector through multi-waypoint trajectory: "
-        f"xpos0={format_tensor(target_pose[:3, 3])} -> "
-        f"xpos1={format_tensor(side_pose[:3, 3])}"
-    )
-    is_success, traj, _ = atomic_engine.run(
-        steps=[
+    success, trajectory, _ = engine.run(
+        [
             (
                 "move_end_effector",
-                EndEffectorPoseTarget(xpos=multi_waypoint_xpos),
+                EndEffectorPoseTarget(broadcast_waypoint_pose_batch(poses, n_envs)),
             )
         ]
     )
-    if not is_success.all():
+    if not success.all():
         logger.log_warning("Failed to plan MoveEndEffector demo trajectory.")
         return
 
-    if not args.auto_play:
+    if wait_for_user:
         input("Press Enter to replay the MoveEndEffector demo...")
-
-    # ------------------------------------------------------------------ #
-    # Step 7: Replay the planned trajectory                               #
-    # ------------------------------------------------------------------ #
-    recording_started = start_auto_play_recording(
-        sim, args, video_prefix="move_end_effector_auto_play"
+    replay_trajectory(
+        sim,
+        robot,
+        trajectory,
+        args,
+        video_prefix="move_end_effector_auto_play",
+        hold_steps=POST_TRAJECTORY_STEPS,
     )
-    try:
-        for i in range(traj.shape[1]):
-            robot.set_qpos(traj[:, i, :])
-            sim.update(step=4)
-            time.sleep(1e-2)
-
-        final_qpos = traj[:, -1, :]
-        for _ in range(POST_TRAJECTORY_STEPS):
-            robot.set_qpos(final_qpos)
-            sim.update(step=2)
-            time.sleep(1e-2)
-    finally:
-        stop_auto_play_recording(sim, recording_started)
-
-    if not args.auto_play:
+    if wait_for_user:
         input("Press Enter to exit the simulation...")
 
 

--- a/scripts/tutorials/atomic_action/move_held_object.py
+++ b/scripts/tutorials/atomic_action/move_held_object.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import argparse
 import sys
-import time
 from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -31,9 +30,7 @@ import torch
 
 from embodichain.data import get_data_path
 from embodichain.lab.gym.utils.gym_utils import add_env_launcher_args_to_parser
-from embodichain.lab.sim import SimulationManager, SimulationManagerCfg
 from embodichain.lab.sim.atomic_actions import (
-    AntipodalAffordance,
     AtomicActionEngine,
     EndEffectorPoseTarget,
     GraspTarget,
@@ -42,52 +39,29 @@ from embodichain.lab.sim.atomic_actions import (
     MoveEndEffectorCfg,
     MoveHeldObject,
     MoveHeldObjectCfg,
-    ObjectSemantics,
     PickUp,
     PickUpCfg,
 )
-from embodichain.lab.sim.cfg import (
-    LightCfg,
-    RenderCfg,
-    RigidBodyAttributesCfg,
-    RigidObjectCfg,
-)
-from embodichain.lab.sim.objects import RigidObject, Robot
-from embodichain.lab.sim.planners import MotionGenerator, MotionGenCfg, ToppraPlannerCfg
+from embodichain.lab.sim.cfg import RigidBodyAttributesCfg, RigidObjectCfg
+from embodichain.lab.sim.objects import RigidObject
 from embodichain.lab.sim.shapes import MeshCfg
-from embodichain.toolkits.graspkit.pg_grasp.antipodal_generator import (
-    AntipodalSamplerCfg,
-    GraspGeneratorCfg,
-)
-from embodichain.toolkits.graspkit.pg_grasp.gripper_collision_checker import (
-    GripperCollisionCfg,
-)
 from embodichain.utils import logger
 from scripts.tutorials.atomic_action.tutorial_utils import (
+    add_ur5_gripper_robot,
     broadcast_pose_batch,
     clone_local_pose_from_first_env,
-    create_ur5_gripper_robot_cfg,
+    create_antipodal_semantics,
+    create_toppra_motion_generator,
+    create_tutorial_simulation,
     draw_axis_marker,
-    get_tutorial_window_size,
-    start_auto_play_recording,
-    stop_auto_play_recording,
+    get_hand_open_close_qpos,
+    make_eef_pose_at,
+    prepare_tutorial_scene,
+    replay_trajectory,
 )
 
-GRIPPER_MAX_OPEN_WIDTH = 0.080
-GRIPPER_FINGER_LENGTH = 0.088
-GRIPPER_ROOT_Z_WIDTH = 0.096
-GRIPPER_Y_THICKNESS = 0.040
-
-OBJECT_LABEL = "paper_cup"
 OBJECT_MESH_PATH = "PaperCup/paper_cup.ply"
 OBJECT_XY = (-0.42, -0.08)
-OBJECT_APPROACH_DIRECTION = (0.0, 0.0, -1.0)
-OBJECT_MIN_HAND_CLOSE_QPOS = 0.024
-OBJECT_INIT_ROT = (0.0, 0.0, 0.0)
-OBJECT_BODY_SCALE = (0.75, 0.75, 1.0)
-OBJECT_MASS = 0.01
-OBJECT_USE_USD_PROPERTIES = False
-
 MOVE_SAMPLE_INTERVAL = 60
 PICK_SAMPLE_INTERVAL = 120
 MOVE_HELD_OBJECT_SAMPLE_INTERVAL = 120
@@ -96,308 +70,143 @@ POST_TRAJECTORY_STEPS = 240
 
 
 def parse_arguments() -> argparse.Namespace:
+    """Parse command-line arguments for the MoveHeldObject tutorial."""
     parser = argparse.ArgumentParser(
-        description="Demonstrate MoveHeldObject holding a paper cup in the gripper."
+        description="Pick up a paper cup and move it by object pose."
     )
     add_env_launcher_args_to_parser(parser)
-    parser.add_argument(
-        "--n_sample",
-        type=int,
-        default=10000,
-        help="Number of samples for antipodal grasp generation.",
-    )
-    parser.add_argument(
-        "--force_reannotate",
-        action="store_true",
-        help="Force grasp region re-annotation instead of using cached data.",
-    )
-    parser.add_argument(
-        "--auto_play",
-        action="store_true",
-        help="Run the viewer demo without waiting for keyboard input.",
-    )
-    parser.add_argument(
-        "--no_vis_eef_axis",
-        action="store_true",
-        help="Do not draw the current end-effector/TCP coordinate frame before planning.",
-    )
+    parser.add_argument("--n_sample", type=int, default=10000)
+    parser.add_argument("--force_reannotate", action="store_true")
+    parser.add_argument("--auto_play", action="store_true")
+    parser.add_argument("--no_vis_eef_axis", action="store_true")
     return parser.parse_args()
 
 
-def initialize_simulation(args: argparse.Namespace) -> SimulationManager:
-    width, height = get_tutorial_window_size(args)
-    cfg = SimulationManagerCfg(
-        width=width,
-        height=height,
-        headless=True,
-        num_envs=args.num_envs,
-        sim_device=args.device,
-        render_cfg=RenderCfg(renderer=args.renderer),
-        physics_dt=1.0 / 100.0,
-        arena_space=2.5,
-    )
-    sim = SimulationManager(cfg)
-    sim.add_light(
-        cfg=LightCfg(
-            uid="main_light",
-            color=(0.6, 0.6, 0.6),
-            intensity=30.0,
-            init_pos=(1.0, 0.0, 3.0),
+def create_pick_object(sim) -> RigidObject:
+    """Create and settle the paper cup used by the tutorial."""
+    obj = sim.add_rigid_object(
+        cfg=RigidObjectCfg(
+            uid="paper_cup",
+            shape=MeshCfg(fpath=get_data_path(OBJECT_MESH_PATH)),
+            attrs=RigidBodyAttributesCfg(
+                mass=0.01,
+                dynamic_friction=0.97,
+                static_friction=0.99,
+            ),
+            max_convex_hull_num=16,
+            init_pos=[*OBJECT_XY, 0.0],
+            body_scale=(0.75, 0.75, 1.0),
         )
     )
-    return sim
-
-
-def create_robot(sim: SimulationManager, position=(0.0, 0.0, 0.0)) -> Robot:
-    cfg = create_ur5_gripper_robot_cfg(init_pos=position)
-    return sim.add_robot(cfg=cfg)
-
-
-def create_pick_object(sim: SimulationManager) -> RigidObject:
-    cfg = RigidObjectCfg(
-        uid=OBJECT_LABEL,
-        shape=MeshCfg(fpath=get_data_path(OBJECT_MESH_PATH)),
-        attrs=RigidBodyAttributesCfg(
-            mass=OBJECT_MASS,
-            dynamic_friction=0.97,
-            static_friction=0.99,
-        ),
-        max_convex_hull_num=16,
-        init_pos=[OBJECT_XY[0], OBJECT_XY[1], 0.0],
-        init_rot=OBJECT_INIT_ROT,
-        body_scale=OBJECT_BODY_SCALE,
-        use_usd_properties=OBJECT_USE_USD_PROPERTIES,
-    )
-    obj = sim.add_rigid_object(cfg=cfg)
-
-    sim.update(
-        step=10
-    )  # Settle the object to ensure it is resting on the ground before planning
+    sim.update(step=10)
     clone_local_pose_from_first_env(obj)
     obj.clear_dynamics()
     return obj
 
 
-def build_grasp_generator_cfg(args: argparse.Namespace) -> GraspGeneratorCfg:
-    return GraspGeneratorCfg(
-        viser_port=11801,
-        antipodal_sampler_cfg=AntipodalSamplerCfg(
-            n_sample=args.n_sample,
-            max_length=GRIPPER_MAX_OPEN_WIDTH,
-            min_length=0.003,
-        ),
-        is_partial_annotate=False,
-        is_filter_ground_collision=False,
-    )
-
-
-def build_gripper_collision_cfg() -> GripperCollisionCfg:
-    return GripperCollisionCfg(
-        max_open_length=GRIPPER_MAX_OPEN_WIDTH,
-        finger_length=GRIPPER_FINGER_LENGTH,
-        y_thickness=GRIPPER_Y_THICKNESS,
-        root_z_width=GRIPPER_ROOT_Z_WIDTH,
-        open_check_margin=0.002,
-        point_sample_dense=0.012,
-    )
-
-
-def create_object_semantics(
-    obj: RigidObject, args: argparse.Namespace
-) -> ObjectSemantics:
-    return ObjectSemantics(
-        label=OBJECT_LABEL,
-        geometry={
-            "mesh_vertices": obj.get_vertices(env_ids=[0], scale=True)[0],
-            "mesh_triangles": obj.get_triangles(env_ids=[0])[0],
-        },
-        affordance=AntipodalAffordance(
-            mesh_vertices=obj.get_vertices(env_ids=[0], scale=True)[0],
-            mesh_triangles=obj.get_triangles(env_ids=[0])[0],
-            gripper_collision_cfg=build_gripper_collision_cfg(),
-            generator_cfg=build_grasp_generator_cfg(args),
-            force_reannotate=args.force_reannotate,
-        ),
-        entity=obj,
-    )
-
-
-def get_hand_open_close_qpos(
-    robot: Robot, device: torch.device
-) -> tuple[torch.Tensor, torch.Tensor]:
-    hand_limits = robot.get_qpos_limits(name="hand")[0].to(
-        device=device, dtype=torch.float32
-    )
-    hand_open = hand_limits[:, 0]
-    hand_close_limit = hand_limits[:, 1]
-    hand_close = torch.minimum(
-        hand_close_limit,
-        torch.full_like(hand_close_limit, OBJECT_MIN_HAND_CLOSE_QPOS),
-    )
-    return hand_open, hand_close
-
-
-def make_pre_pick_eef_pose(robot: Robot, position: torch.Tensor) -> torch.Tensor:
-    pose = robot.compute_fk(
-        qpos=robot.get_qpos(name="arm"),
-        name="arm",
-        to_matrix=True,
-    )[0].clone()
-    pose[:3, 3] = position
-    return pose
-
-
 def make_object_target_pose(device: torch.device) -> torch.Tensor:
+    """Build the desired final paper-cup pose in the object frame."""
     pose = torch.eye(4, dtype=torch.float32, device=device)
     pose[:3, :3] = torch.tensor(
-        [
-            [0.0, 0.0, -1.0],
-            [0.0, 1.0, 0.0],
-            [1.0, 0.0, 0.0],
-        ],
+        [[0.0, 0.0, -1.0], [0.0, 1.0, 0.0], [1.0, 0.0, 0.0]],
         dtype=torch.float32,
         device=device,
     )
-    pose[:3, 3] = torch.tensor([-0.3, -0.3, 0.5], dtype=torch.float32, device=device)
+    pose[:3, 3] = torch.tensor([-0.3, -0.3, 0.5], device=device)
     return pose
 
 
-def compute_pick_close_end_step() -> int:
-    motion_waypoints = PICK_SAMPLE_INTERVAL - HAND_INTERP_STEPS
-    n_approach = int(round(motion_waypoints) * 0.6)
-    return MOVE_SAMPLE_INTERVAL + n_approach + HAND_INTERP_STEPS
-
-
 def main() -> None:
-    """Pick up an object and move the held object to an object-frame target."""
+    """Plan MoveEndEffector -> PickUp -> MoveHeldObject."""
     args = parse_arguments()
-
-    # ------------------------------------------------------------------ #
-    # Step 1: Set up simulation, robot, and object                 #
-    # ------------------------------------------------------------------ #
-    sim = initialize_simulation(args)
-    robot = create_robot(sim)
+    sim = create_tutorial_simulation(args)
+    robot = add_ur5_gripper_robot(sim)
     obj = create_pick_object(sim)
+    motion_gen = create_toppra_motion_generator(robot)
+    hand_open, hand_close = get_hand_open_close_qpos(robot)
 
-    if not args.headless:
-        sim.open_window()
-
-    # ------------------------------------------------------------------ #
-    # Step 2: Create a MotionGenerator for the robot                      #
-    # ------------------------------------------------------------------ #
-    motion_gen = MotionGenerator(
-        cfg=MotionGenCfg(planner_cfg=ToppraPlannerCfg(robot_uid=robot.uid))
+    engine = AtomicActionEngine(motion_generator=motion_gen)
+    engine.register(
+        MoveEndEffector(
+            motion_gen, MoveEndEffectorCfg(sample_interval=MOVE_SAMPLE_INTERVAL)
+        )
+    )
+    engine.register(
+        PickUp(
+            motion_gen,
+            PickUpCfg(
+                hand_open_qpos=hand_open,
+                hand_close_qpos=hand_close,
+                pre_grasp_distance=0.15,
+                lift_height=0.16,
+                sample_interval=PICK_SAMPLE_INTERVAL,
+                hand_interp_steps=HAND_INTERP_STEPS,
+            ),
+        )
+    )
+    engine.register(
+        MoveHeldObject(
+            motion_gen,
+            MoveHeldObjectCfg(
+                hand_close_qpos=hand_close,
+                sample_interval=MOVE_HELD_OBJECT_SAMPLE_INTERVAL,
+            ),
+        )
     )
 
-    # ------------------------------------------------------------------ #
-    # Step 3: Configure the three atomic actions                          #
-    # ------------------------------------------------------------------ #
-    hand_open, hand_close = get_hand_open_close_qpos(robot, sim.device)
-    move_cfg = MoveEndEffectorCfg(
-        control_part="arm",
-        sample_interval=MOVE_SAMPLE_INTERVAL,
+    semantics = create_antipodal_semantics(
+        obj,
+        label="paper_cup",
+        n_sample=args.n_sample,
+        force_reannotate=args.force_reannotate,
     )
-    pickup_cfg = PickUpCfg(
-        control_part="arm",
-        hand_control_part="hand",
-        hand_open_qpos=hand_open,
-        hand_close_qpos=hand_close,
-        approach_direction=torch.tensor(
-            OBJECT_APPROACH_DIRECTION, dtype=torch.float32, device=sim.device
-        ),
-        pre_grasp_distance=0.15,
-        lift_height=0.16,
-        sample_interval=PICK_SAMPLE_INTERVAL,
-        hand_interp_steps=HAND_INTERP_STEPS,
-    )
-    move_held_object_cfg = MoveHeldObjectCfg(
-        control_part="arm",
-        hand_control_part="hand",
-        hand_close_qpos=hand_close,
-        sample_interval=MOVE_HELD_OBJECT_SAMPLE_INTERVAL,
-    )
-
-    # ------------------------------------------------------------------ #
-    # Step 4: Build the AtomicActionEngine                                #
-    # ------------------------------------------------------------------ #
-    atomic_engine = AtomicActionEngine(motion_generator=motion_gen)
-    atomic_engine.register(MoveEndEffector(motion_gen, cfg=move_cfg))
-    atomic_engine.register(PickUp(motion_gen, cfg=pickup_cfg))
-    atomic_engine.register(MoveHeldObject(motion_gen, cfg=move_held_object_cfg))
-
-    # ------------------------------------------------------------------ #
-    # Step 5: Describe the object and define the motion targets           #
-    # ------------------------------------------------------------------ #
-    semantics = create_object_semantics(obj, args)
-    obj_pose = obj.get_local_pose(to_matrix=True)
-    move_position = obj_pose[0, :3, 3].clone()
+    move_position = obj.get_local_pose(to_matrix=True)[0, :3, 3].clone()
     move_position[2] = 0.36
     n_envs = robot.get_qpos().shape[0]
-    move_target = broadcast_pose_batch(
-        make_pre_pick_eef_pose(robot, move_position), num_envs=n_envs
-    )
-    object_target_pose = broadcast_pose_batch(
-        make_object_target_pose(sim.device), num_envs=n_envs
-    )
-    move_held_object_target = HeldObjectPoseTarget(
-        object_target_pose=object_target_pose
-    )
-
+    move_target = broadcast_pose_batch(make_eef_pose_at(robot, move_position), n_envs)
+    object_target = broadcast_pose_batch(make_object_target_pose(sim.device), n_envs)
     if not args.no_vis_eef_axis:
-        draw_axis_marker(sim, "move_held_object_target_axis", object_target_pose)
-    if not args.auto_play:
-        input("Inspect the paper cup, then press Enter to plan...")
+        draw_axis_marker(sim, "move_held_object_target_axis", object_target)
+    wait_for_user = prepare_tutorial_scene(
+        sim, args, "Inspect the paper cup, then press Enter to plan..."
+    )
 
-    # ------------------------------------------------------------------ #
-    # Step 6: Plan the declared (name, typed_target) sequence             #
-    # ------------------------------------------------------------------ #
-    logger.log_info("Planning move_end_effector -> pick_up -> move_held_object")
-    start_time = time.time()
-    is_success, traj, _ = atomic_engine.run(
-        steps=[
-            ("move_end_effector", EndEffectorPoseTarget(xpos=move_target)),
-            ("pick_up", GraspTarget(semantics=semantics)),
-            ("move_held_object", move_held_object_target),
+    success, trajectory, _ = engine.run(
+        [
+            ("move_end_effector", EndEffectorPoseTarget(move_target)),
+            ("pick_up", GraspTarget(semantics)),
+            ("move_held_object", HeldObjectPoseTarget(object_target)),
         ]
     )
-    cost_time = time.time() - start_time
-    logger.log_info(f"Plan trajectory cost time: {cost_time:.2f} seconds")
-    if not is_success.all():
-        logger.log_warning("Failed to plan move_held_object demo trajectory.")
+    if not success.all():
+        logger.log_warning("Failed to plan MoveHeldObject demo trajectory.")
         return
 
-    if not args.auto_play:
-        input("Press Enter to replay the move_held_object demo...")
-
-    # ------------------------------------------------------------------ #
-    # Step 7: Replay the planned trajectory                               #
-    # ------------------------------------------------------------------ #
-    recording_started = start_auto_play_recording(
-        sim, args, video_prefix="move_held_object_auto_play"
+    if wait_for_user:
+        input("Press Enter to replay the MoveHeldObject demo...")
+    clear_after_step = (
+        MOVE_SAMPLE_INTERVAL
+        + round((PICK_SAMPLE_INTERVAL - HAND_INTERP_STEPS) * 0.6)
+        + HAND_INTERP_STEPS
     )
-    try:
-        post_grasp_clear_step = compute_pick_close_end_step()
-        should_clear_object_dynamics = True
-        for i in range(traj.shape[1]):
-            robot.set_qpos(traj[:, i, :])
-            sim.update(step=4)
-            if should_clear_object_dynamics and i + 1 >= post_grasp_clear_step:
-                obj.clear_dynamics()
-                should_clear_object_dynamics = False
-                logger.log_info(f"Object dynamics cleared after grasp at step={i}")
-            time.sleep(1e-2)
+    dynamics_cleared = False
 
-        logger.log_info("MoveHeldObject keeps the paper cup suspended in the gripper.")
+    def clear_object_dynamics(step_idx: int, _: int) -> None:
+        nonlocal dynamics_cleared
+        if not dynamics_cleared and step_idx + 1 >= clear_after_step:
+            obj.clear_dynamics()
+            dynamics_cleared = True
 
-        final_qpos = traj[:, -1, :]
-        for i in range(POST_TRAJECTORY_STEPS):
-            robot.set_qpos(final_qpos)
-            sim.update(step=2)
-            time.sleep(1e-2)
-    finally:
-        stop_auto_play_recording(sim, recording_started)
-
-    if not args.auto_play:
+    replay_trajectory(
+        sim,
+        robot,
+        trajectory,
+        args,
+        video_prefix="move_held_object_auto_play",
+        hold_steps=POST_TRAJECTORY_STEPS,
+        on_trajectory_step=clear_object_dynamics,
+    )
+    if wait_for_user:
         input("Press Enter to exit the simulation...")
 
 

--- a/scripts/tutorials/atomic_action/move_joints.py
+++ b/scripts/tutorials/atomic_action/move_joints.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import argparse
 import sys
-import time
 from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -30,7 +29,6 @@ if str(_REPO_ROOT) not in sys.path:
 import torch
 
 from embodichain.lab.gym.utils.gym_utils import add_env_launcher_args_to_parser
-from embodichain.lab.sim import SimulationManager, SimulationManagerCfg
 from embodichain.lab.sim.atomic_actions import (
     AtomicActionEngine,
     JointPositionTarget,
@@ -38,16 +36,14 @@ from embodichain.lab.sim.atomic_actions import (
     MoveJointsCfg,
     NamedJointPositionTarget,
 )
-from embodichain.lab.sim.cfg import LightCfg, RenderCfg
-from embodichain.lab.sim.objects import Robot
-from embodichain.lab.sim.planners import MotionGenerator, MotionGenCfg, ToppraPlannerCfg
 from embodichain.utils import logger
 from scripts.tutorials.atomic_action.tutorial_utils import (
-    create_ur5_gripper_robot_cfg,
+    add_ur5_gripper_robot,
+    create_toppra_motion_generator,
+    create_tutorial_simulation,
     draw_axis_marker,
-    get_tutorial_window_size,
-    start_auto_play_recording,
-    stop_auto_play_recording,
+    prepare_tutorial_scene,
+    replay_trajectory,
 )
 
 MOVE_JOINTS_SAMPLE_INTERVAL = 80
@@ -55,158 +51,76 @@ POST_TRAJECTORY_STEPS = 120
 
 
 def parse_arguments() -> argparse.Namespace:
+    """Parse command-line arguments for the MoveJoints tutorial."""
     parser = argparse.ArgumentParser(
         description="Demonstrate MoveJoints with named and explicit qpos targets."
     )
     add_env_launcher_args_to_parser(parser)
-    parser.add_argument(
-        "--auto_play",
-        action="store_true",
-        help="Run the viewer demo without waiting for keyboard input.",
-    )
-    parser.add_argument(
-        "--no_vis_eef_axis",
-        action="store_true",
-        help="Do not draw the current end-effector/TCP coordinate frame before planning.",
-    )
+    parser.add_argument("--auto_play", action="store_true")
+    parser.add_argument("--no_vis_eef_axis", action="store_true")
     return parser.parse_args()
 
 
-def initialize_simulation(args: argparse.Namespace) -> SimulationManager:
-    width, height = get_tutorial_window_size(args)
-    cfg = SimulationManagerCfg(
-        width=width,
-        height=height,
-        headless=True,
-        num_envs=args.num_envs,
-        sim_device=args.device,
-        render_cfg=RenderCfg(renderer=args.renderer),
-        physics_dt=1.0 / 100.0,
-        arena_space=2.5,
-    )
-    sim = SimulationManager(cfg)
-    sim.add_light(
-        cfg=LightCfg(
-            uid="main_light",
-            color=(0.6, 0.6, 0.6),
-            intensity=30.0,
-            init_pos=(1.0, 0.0, 3.0),
+def main() -> None:
+    """Move the robot arm through a named target and two explicit waypoints."""
+    args = parse_arguments()
+    sim = create_tutorial_simulation(args)
+    robot = add_ur5_gripper_robot(sim)
+    motion_gen = create_toppra_motion_generator(robot)
+
+    ready, mid, home = (
+        torch.tensor(qpos, dtype=torch.float32, device=sim.device)
+        for qpos in (
+            [0.35, -1.20, 1.30, -1.65, -1.57, 0.20],
+            [0.15, -1.40, 1.45, -1.60, -1.57, 0.10],
+            [0.0, -1.57, 1.57, -1.57, -1.57, 0.0],
         )
     )
-    return sim
-
-
-def create_robot(sim: SimulationManager, position=(0.0, 0.0, 0.0)) -> Robot:
-    cfg = create_ur5_gripper_robot_cfg(init_pos=position)
-    return sim.add_robot(cfg=cfg)
-
-
-def make_arm_qpos(values: list[float], device: torch.device) -> torch.Tensor:
-    return torch.tensor(values, dtype=torch.float32, device=device)
-
-
-def draw_start_eef_axis(sim: SimulationManager, robot: Robot) -> None:
-    eef_pose = robot.compute_fk(
-        qpos=robot.get_qpos(name="arm"),
-        name="arm",
-        to_matrix=True,
-    )
-    draw_axis_marker(sim, "move_joints_start_eef_axis", eef_pose)
-
-
-def main() -> None:
-    """Move the robot arm through named and explicit joint targets."""
-    args = parse_arguments()
-
-    # ------------------------------------------------------------------ #
-    # Step 1: Set up simulation and robot                                 #
-    # ------------------------------------------------------------------ #
-    sim = initialize_simulation(args)
-    robot = create_robot(sim)
-
-    # ------------------------------------------------------------------ #
-    # Step 2: Create a MotionGenerator for the robot                      #
-    # ------------------------------------------------------------------ #
-    motion_gen = MotionGenerator(
-        cfg=MotionGenCfg(planner_cfg=ToppraPlannerCfg(robot_uid=robot.uid))
+    engine = AtomicActionEngine(motion_generator=motion_gen)
+    engine.register(
+        MoveJoints(
+            motion_gen,
+            cfg=MoveJointsCfg(
+                sample_interval=MOVE_JOINTS_SAMPLE_INTERVAL,
+                named_joint_positions={"ready": ready},
+            ),
+        )
     )
 
-    # ------------------------------------------------------------------ #
-    # Step 3: Configure the MoveJoints atomic action                      #
-    # ------------------------------------------------------------------ #
-    ready_qpos = make_arm_qpos([0.35, -1.20, 1.30, -1.65, -1.57, 0.20], sim.device)
-    mid_qpos = make_arm_qpos([0.15, -1.40, 1.45, -1.60, -1.57, 0.10], sim.device)
-    home_qpos = make_arm_qpos([0.0, -1.57, 1.57, -1.57, -1.57, 0.0], sim.device)
-    move_joints_cfg = MoveJointsCfg(
-        control_part="arm",
-        sample_interval=MOVE_JOINTS_SAMPLE_INTERVAL,
-        named_joint_positions={"ready": ready_qpos},
-    )
-
-    # ------------------------------------------------------------------ #
-    # Step 4: Build the AtomicActionEngine                                #
-    # ------------------------------------------------------------------ #
-    atomic_engine = AtomicActionEngine(motion_generator=motion_gen)
-    atomic_engine.register(MoveJoints(motion_gen, cfg=move_joints_cfg))
-
-    # ------------------------------------------------------------------ #
-    # Step 5: Open the viewer and show the starting end-effector frame    #
-    # ------------------------------------------------------------------ #
-    if not args.headless:
-        sim.open_window()
     if not args.no_vis_eef_axis:
-        draw_start_eef_axis(sim, robot)
-    if not args.auto_play:
-        input("Inspect the robot, then press Enter to plan MoveJoints...")
+        draw_axis_marker(
+            sim,
+            "move_joints_start_eef_axis",
+            robot.compute_fk(robot.get_qpos(name="arm"), name="arm", to_matrix=True),
+        )
+    wait_for_user = prepare_tutorial_scene(
+        sim, args, "Inspect the robot, then press Enter to plan MoveJoints..."
+    )
 
-    # ------------------------------------------------------------------ #
-    # Step 6: Plan the declared (name, typed_target) sequence             #
-    # ------------------------------------------------------------------ #
-    # The second MoveJoints step passes a multi-waypoint trajectory
-    # (n_envs, n_waypoint, control_dof): the arm visits `mid_qpos` then
-    # `home_qpos` in a single planned trajectory.
-    n_envs = robot.get_qpos().shape[0]
-    multi_waypoint_qpos = (
-        torch.stack([mid_qpos, home_qpos], dim=0).unsqueeze(0).repeat(n_envs, 1, 1)
+    waypoints = (
+        torch.stack([mid, home]).unsqueeze(0).repeat(robot.get_qpos().shape[0], 1, 1)
     )
-    logger.log_info(
-        "Planning MoveJoints: NamedJointPositionTarget('ready') -> "
-        "multi-waypoint trajectory (mid -> home)"
-    )
-    is_success, traj, _ = atomic_engine.run(
-        steps=[
-            ("move_joints", NamedJointPositionTarget(name="ready")),
-            ("move_joints", JointPositionTarget(qpos=multi_waypoint_qpos)),
+    success, trajectory, _ = engine.run(
+        [
+            ("move_joints", NamedJointPositionTarget("ready")),
+            ("move_joints", JointPositionTarget(waypoints)),
         ]
     )
-    if not is_success.all():
+    if not success.all():
         logger.log_warning("Failed to plan MoveJoints demo trajectory.")
         return
 
-    if not args.auto_play:
+    if wait_for_user:
         input("Press Enter to replay the MoveJoints demo...")
-
-    # ------------------------------------------------------------------ #
-    # Step 7: Replay the planned trajectory                               #
-    # ------------------------------------------------------------------ #
-    recording_started = start_auto_play_recording(
-        sim, args, video_prefix="move_joints_auto_play"
+    replay_trajectory(
+        sim,
+        robot,
+        trajectory,
+        args,
+        video_prefix="move_joints_auto_play",
+        hold_steps=POST_TRAJECTORY_STEPS,
     )
-    try:
-        for i in range(traj.shape[1]):
-            robot.set_qpos(traj[:, i, :])
-            sim.update(step=4)
-            time.sleep(1e-2)
-
-        final_qpos = traj[:, -1, :]
-        for _ in range(POST_TRAJECTORY_STEPS):
-            robot.set_qpos(final_qpos)
-            sim.update(step=2)
-            time.sleep(1e-2)
-    finally:
-        stop_auto_play_recording(sim, recording_started)
-
-    if not args.auto_play:
+    if wait_for_user:
         input("Press Enter to exit the simulation...")
 
 

--- a/scripts/tutorials/atomic_action/pickup.py
+++ b/scripts/tutorials/atomic_action/pickup.py
@@ -14,13 +14,12 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
-"""Demonstrate PickUp on an upright object with configurable approach."""
+"""Demonstrate PickUp on a cube with a configurable approach direction."""
 
 from __future__ import annotations
 
 import argparse
 import sys
-import time
 from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -30,65 +29,34 @@ if str(_REPO_ROOT) not in sys.path:
 import torch
 
 from embodichain.lab.gym.utils.gym_utils import add_env_launcher_args_to_parser
-from embodichain.lab.sim import SimulationManager, SimulationManagerCfg
 from embodichain.lab.sim.atomic_actions import (
-    AntipodalAffordance,
     AtomicActionEngine,
     GraspTarget,
-    ObjectSemantics,
     PickUp,
     PickUpCfg,
 )
-from embodichain.lab.sim.cfg import (
-    LightCfg,
-    RenderCfg,
-    RigidBodyAttributesCfg,
-    RigidObjectCfg,
-)
-from embodichain.lab.sim.objects import RigidObject, Robot
-from embodichain.lab.sim.planners import MotionGenerator, MotionGenCfg, ToppraPlannerCfg
+from embodichain.lab.sim.cfg import RigidBodyAttributesCfg, RigidObjectCfg
+from embodichain.lab.sim.objects import RigidObject
 from embodichain.lab.sim.shapes import CubeCfg
-from embodichain.toolkits.graspkit.pg_grasp.antipodal_generator import (
-    AntipodalSamplerCfg,
-    GraspGeneratorCfg,
-)
-from embodichain.toolkits.graspkit.pg_grasp.gripper_collision_checker import (
-    GripperCollisionCfg,
-)
 from embodichain.utils import logger
 from scripts.tutorials.atomic_action.tutorial_utils import (
+    add_ur5_gripper_robot,
     clone_local_pose_from_first_env,
-    create_ur5_gripper_robot_cfg,
+    create_antipodal_semantics,
+    create_toppra_motion_generator,
+    create_tutorial_simulation,
     draw_axis_marker,
-    get_tutorial_window_size,
-    start_auto_play_recording,
-    stop_auto_play_recording,
+    get_hand_open_close_qpos,
+    initialize_pre_pick_robot_pose,
+    prepare_tutorial_scene,
+    replay_trajectory,
 )
 
-GRIPPER_MAX_OPEN_WIDTH = 0.080
-GRIPPER_FINGER_LENGTH = 0.088
-GRIPPER_ROOT_Z_WIDTH = 0.096
-GRIPPER_Y_THICKNESS = 0.040
-
-OBJECT_MIN_HAND_CLOSE_QPOS = 0.024
+OBJECT_SIZE = (0.05, 0.05, 0.05)
 OBJECT_XY = (-0.42, -0.08)
-
-OBJECT_PRESETS = {
-    "cube": {
-        "label": "cube",
-        "cube_size": (0.05, 0.05, 0.05),
-        "init_z": 0.05,
-        "init_rot": (0.0, 0.0, 0.0),
-        "body_scale": (1.0, 1.0, 1.0),
-        "mass": 0.05,
-        "use_usd_properties": False,
-    },
-}
-
 PICK_SAMPLE_INTERVAL = 120
 HAND_INTERP_STEPS = 12
 POST_TRAJECTORY_STEPS = 240
-
 APPROACH_DIRECTIONS = {
     "top": (0.0, 0.0, -1.0),
     "side": (0.0, 1.0, 0.0),
@@ -97,346 +65,125 @@ APPROACH_DIRECTIONS = {
 
 
 def parse_arguments() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(
-        description="Demonstrate PickUp on an upright object."
-    )
+    """Parse command-line arguments for the PickUp tutorial."""
+    parser = argparse.ArgumentParser(description="Demonstrate PickUp on a cube.")
     add_env_launcher_args_to_parser(parser)
+    parser.add_argument("--n_sample", type=int, default=10000)
+    parser.add_argument("--force_reannotate", action="store_true")
+    parser.add_argument("--auto_play", action="store_true")
     parser.add_argument(
-        "--object",
-        choices=sorted(OBJECT_PRESETS.keys()),
-        default="cube",
-        help="Object preset to pick.",
+        "--approach", choices=[*APPROACH_DIRECTIONS, "custom"], default="top"
     )
-    parser.add_argument(
-        "--n_sample",
-        type=int,
-        default=10000,
-        help="Number of samples for antipodal grasp generation.",
-    )
-    parser.add_argument(
-        "--force_reannotate",
-        action="store_true",
-        help="Force grasp region re-annotation instead of using cached data.",
-    )
-    parser.add_argument(
-        "--auto_play",
-        action="store_true",
-        help="Run the viewer demo without waiting for keyboard input.",
-    )
-    parser.add_argument(
-        "--approach",
-        choices=["top", "side", "side_y", "custom"],
-        default="top",
-        help="Pick approach direction preset.",
-    )
-    parser.add_argument(
-        "--custom_approach_direction",
-        type=float,
-        nargs=3,
-        default=None,
-        metavar=("X", "Y", "Z"),
-        help="World-frame approach direction used when --approach custom.",
-    )
-    parser.add_argument(
-        "--no_vis_eef_axis",
-        action="store_true",
-        help="Do not draw the current end-effector/TCP coordinate frame before planning.",
-    )
+    parser.add_argument("--custom_approach_direction", type=float, nargs=3)
+    parser.add_argument("--no_vis_eef_axis", action="store_true")
     return parser.parse_args()
 
 
-def initialize_simulation(args: argparse.Namespace) -> SimulationManager:
-    width, height = get_tutorial_window_size(args)
-    cfg = SimulationManagerCfg(
-        width=width,
-        height=height,
-        headless=True,
-        num_envs=args.num_envs,
-        sim_device=args.device,
-        render_cfg=RenderCfg(renderer=args.renderer),
-        physics_dt=1.0 / 100.0,
-        arena_space=2.5,
-    )
-    sim = SimulationManager(cfg)
-    sim.add_light(
-        cfg=LightCfg(
-            uid="main_light",
-            color=(0.6, 0.6, 0.6),
-            intensity=30.0,
-            init_pos=(1.0, 0.0, 3.0),
+def create_pick_object(sim) -> RigidObject:
+    """Create a settled cube for antipodal grasp planning."""
+    obj = sim.add_rigid_object(
+        cfg=RigidObjectCfg(
+            uid="cube",
+            shape=CubeCfg(size=list(OBJECT_SIZE)),
+            attrs=RigidBodyAttributesCfg(
+                mass=0.05,
+                dynamic_friction=0.97,
+                static_friction=0.99,
+            ),
+            max_convex_hull_num=16,
+            init_pos=[*OBJECT_XY, OBJECT_SIZE[2]],
         )
     )
-    return sim
-
-
-def create_robot(sim: SimulationManager, position=(0.0, 0.0, 0.0)) -> Robot:
-    cfg = create_ur5_gripper_robot_cfg(init_pos=position)
-    return sim.add_robot(cfg=cfg)
-
-
-def create_pick_object(sim: SimulationManager, object_name: str) -> RigidObject:
-    preset = OBJECT_PRESETS[object_name]
-    cfg = RigidObjectCfg(
-        uid=preset["label"],
-        shape=CubeCfg(size=list(preset["cube_size"])),
-        attrs=RigidBodyAttributesCfg(
-            mass=preset["mass"],
-            dynamic_friction=0.97,
-            static_friction=0.99,
-        ),
-        max_convex_hull_num=16,
-        init_pos=[OBJECT_XY[0], OBJECT_XY[1], preset["init_z"]],
-        init_rot=preset["init_rot"],
-        body_scale=preset["body_scale"],
-        use_usd_properties=preset["use_usd_properties"],
-    )
-    obj = sim.add_rigid_object(cfg=cfg)
-
-    # Settle the object to ensure it is resting on the ground before planning
     sim.update(step=10)
     clone_local_pose_from_first_env(obj)
     obj.clear_dynamics()
     return obj
 
 
-def build_grasp_generator_cfg(args: argparse.Namespace) -> GraspGeneratorCfg:
-    return GraspGeneratorCfg(
-        viser_port=11801,
-        antipodal_sampler_cfg=AntipodalSamplerCfg(
-            n_sample=args.n_sample,
-            max_length=GRIPPER_MAX_OPEN_WIDTH,
-            min_length=0.003,
-        ),
-        is_partial_annotate=False,
-        is_filter_ground_collision=False,
-    )
-
-
-def build_gripper_collision_cfg() -> GripperCollisionCfg:
-    return GripperCollisionCfg(
-        max_open_length=GRIPPER_MAX_OPEN_WIDTH,
-        finger_length=GRIPPER_FINGER_LENGTH,
-        y_thickness=GRIPPER_Y_THICKNESS,
-        root_z_width=GRIPPER_ROOT_Z_WIDTH,
-        open_check_margin=0.002,
-        point_sample_dense=0.012,
-    )
-
-
-def create_object_semantics(
-    obj: RigidObject, args: argparse.Namespace
-) -> ObjectSemantics:
-    label = OBJECT_PRESETS[args.object]["label"]
-    return ObjectSemantics(
-        label=label,
-        geometry={
-            "mesh_vertices": obj.get_vertices(env_ids=[0], scale=True)[0],
-            "mesh_triangles": obj.get_triangles(env_ids=[0])[0],
-        },
-        affordance=AntipodalAffordance(
-            mesh_vertices=obj.get_vertices(env_ids=[0], scale=True)[0],
-            mesh_triangles=obj.get_triangles(env_ids=[0])[0],
-            gripper_collision_cfg=build_gripper_collision_cfg(),
-            generator_cfg=build_grasp_generator_cfg(args),
-            force_reannotate=args.force_reannotate,
-        ),
-        entity=obj,
-    )
-
-
-def get_hand_open_close_qpos(
-    robot: Robot, device: torch.device
-) -> tuple[torch.Tensor, torch.Tensor]:
-    hand_limits = robot.get_qpos_limits(name="hand")[0].to(
-        device=device, dtype=torch.float32
-    )
-    hand_open = hand_limits[:, 0]
-    hand_close_limit = hand_limits[:, 1]
-    hand_close = torch.minimum(
-        hand_close_limit,
-        torch.full_like(hand_close_limit, OBJECT_MIN_HAND_CLOSE_QPOS),
-    )
-    return hand_open, hand_close
-
-
 def resolve_approach_direction(
     args: argparse.Namespace, device: torch.device
 ) -> torch.Tensor:
-    if args.approach == "custom":
-        if args.custom_approach_direction is None:
-            raise ValueError(
-                "--custom_approach_direction is required when --approach custom."
-            )
-        direction = args.custom_approach_direction
-    else:
-        direction = APPROACH_DIRECTIONS[args.approach]
-
-    approach_direction = torch.tensor(direction, dtype=torch.float32, device=device)
-    norm = torch.linalg.norm(approach_direction)
-    if norm < 1e-6:
+    """Resolve and validate a normalized approach direction."""
+    direction = (
+        args.custom_approach_direction
+        if args.approach == "custom"
+        else APPROACH_DIRECTIONS[args.approach]
+    )
+    if direction is None:
+        raise ValueError(
+            "--custom_approach_direction is required for --approach custom."
+        )
+    approach = torch.tensor(direction, dtype=torch.float32, device=device)
+    if torch.linalg.norm(approach) < 1e-6:
         raise ValueError("approach_direction must be non-zero.")
-    return approach_direction / norm
-
-
-def make_pre_pick_eef_pose(robot: Robot, position: torch.Tensor) -> torch.Tensor:
-    pose = robot.compute_fk(
-        qpos=robot.get_qpos(name="arm"),
-        name="arm",
-        to_matrix=True,
-    ).clone()
-    pose[:, :3, 3] = position
-    return pose
-
-
-def initialize_pre_pick_robot_pose(
-    robot: Robot,
-    obj: RigidObject,
-    hand_open: torch.Tensor,
-) -> None:
-    obj_pose = obj.get_local_pose(to_matrix=True)
-    move_position = obj_pose[:, :3, 3].clone()
-    move_position[:, 2] = 0.36
-    pre_pick_pose = make_pre_pick_eef_pose(robot, move_position)
-    ik_success, arm_qpos = robot.compute_ik(
-        pose=pre_pick_pose,
-        joint_seed=robot.get_qpos(name="arm"),
-        name="arm",
-    )
-    if not torch.all(ik_success):
-        raise RuntimeError("Failed to initialize the robot at the pre-pick pose.")
-
-    n_envs = robot.get_qpos().shape[0]
-    hand_qpos = hand_open.unsqueeze(0).repeat(n_envs, 1)
-    for target in (False, True):
-        robot.set_qpos(arm_qpos, name="arm", target=target)
-        robot.set_qpos(hand_qpos, name="hand", target=target)
-    robot.clear_dynamics()
-
-
-def compute_pick_close_end_step() -> int:
-    motion_waypoints = PICK_SAMPLE_INTERVAL - HAND_INTERP_STEPS
-    n_approach = int(round(motion_waypoints) * 0.6)
-    return n_approach + HAND_INTERP_STEPS
-
-
-def format_tensor(tensor: torch.Tensor) -> str:
-    rounded = (tensor.detach().cpu() * 10000.0).round() / 10000.0
-    return str(rounded.tolist())
-
-
-def draw_pick_object_axis(sim: SimulationManager, obj: RigidObject) -> None:
-    draw_axis_marker(
-        sim,
-        "pickup_object_axis",
-        obj.get_local_pose(to_matrix=True),
-    )
+    return torch.nn.functional.normalize(approach, dim=0)
 
 
 def main() -> None:
-    """Pick up an object using an antipodal grasp affordance."""
+    """Plan and replay a sampled antipodal PickUp trajectory."""
     args = parse_arguments()
-
-    # ------------------------------------------------------------------ #
-    # Step 1: Set up simulation, robot, and object                 #
-    # ------------------------------------------------------------------ #
-    sim = initialize_simulation(args)
-    robot = create_robot(sim)
-    obj = create_pick_object(sim, args.object)
-
-    # ------------------------------------------------------------------ #
-    # Step 2: Create a MotionGenerator for the robot                      #
-    # ------------------------------------------------------------------ #
-    motion_gen = MotionGenerator(
-        cfg=MotionGenCfg(planner_cfg=ToppraPlannerCfg(robot_uid=robot.uid))
-    )
-
-    # ------------------------------------------------------------------ #
-    # Step 3: Configure the PickUp atomic action                          #
-    # ------------------------------------------------------------------ #
-    hand_open, hand_close = get_hand_open_close_qpos(robot, sim.device)
-    approach_direction = resolve_approach_direction(args, sim.device)
+    sim = create_tutorial_simulation(args)
+    robot = add_ur5_gripper_robot(sim)
+    obj = create_pick_object(sim)
+    hand_open, hand_close = get_hand_open_close_qpos(robot)
     initialize_pre_pick_robot_pose(robot, obj, hand_open)
-    pickup_cfg = PickUpCfg(
-        control_part="arm",
-        hand_control_part="hand",
-        hand_open_qpos=hand_open,
-        hand_close_qpos=hand_close,
-        approach_direction=approach_direction,
-        pre_grasp_distance=0.15,
-        lift_height=0.16,
-        sample_interval=PICK_SAMPLE_INTERVAL,
-        hand_interp_steps=HAND_INTERP_STEPS,
+    motion_gen = create_toppra_motion_generator(robot)
+
+    engine = AtomicActionEngine(motion_generator=motion_gen)
+    engine.register(
+        PickUp(
+            motion_gen,
+            cfg=PickUpCfg(
+                hand_open_qpos=hand_open,
+                hand_close_qpos=hand_close,
+                approach_direction=resolve_approach_direction(args, sim.device),
+                pre_grasp_distance=0.15,
+                lift_height=0.16,
+                sample_interval=PICK_SAMPLE_INTERVAL,
+                hand_interp_steps=HAND_INTERP_STEPS,
+            ),
+        )
     )
-
-    # ------------------------------------------------------------------ #
-    # Step 4: Build the AtomicActionEngine                                #
-    # ------------------------------------------------------------------ #
-    atomic_engine = AtomicActionEngine(motion_generator=motion_gen)
-    atomic_engine.register(PickUp(motion_gen, cfg=pickup_cfg))
-
-    # ------------------------------------------------------------------ #
-    # Step 5: Describe the object with ObjectSemantics                    #
-    # ------------------------------------------------------------------ #
-    semantics = create_object_semantics(obj, args)
-
-    if not args.headless:
-        sim.open_window()
+    semantics = create_antipodal_semantics(
+        obj,
+        label="cube",
+        n_sample=args.n_sample,
+        force_reannotate=args.force_reannotate,
+    )
     if not args.no_vis_eef_axis:
-        draw_pick_object_axis(sim, obj)
-    if not args.auto_play:
-        input(f"Inspect the upright {args.object}, then press Enter to plan...")
+        draw_axis_marker(sim, "pickup_object_axis", obj.get_local_pose(to_matrix=True))
+    wait_for_user = prepare_tutorial_scene(
+        sim, args, "Inspect the cube, then press Enter to plan PickUp..."
+    )
 
-    # ------------------------------------------------------------------ #
-    # Step 6: Plan the declared (name, typed_target) sequence             #
-    # ------------------------------------------------------------------ #
-    logger.log_info(
-        f"Planning pick_up for {args.object} with "
-        f"approach_direction={format_tensor(approach_direction)}"
-    )
-    start_time = time.time()
-    is_success, traj, _ = atomic_engine.run(
-        steps=[("pick_up", GraspTarget(semantics=semantics))]
-    )
-    cost_time = time.time() - start_time
-    logger.log_info(f"Plan trajectory cost time: {cost_time:.2f} seconds")
-    if not is_success.all():
-        logger.log_warning("Failed to plan pickup demo trajectory.")
+    success, trajectory, _ = engine.run([("pick_up", GraspTarget(semantics))])
+    if not success.all():
+        logger.log_warning("Failed to plan PickUp demo trajectory.")
         return
 
-    if not args.auto_play:
-        input("Press Enter to replay the pickup demo...")
-
-    # ------------------------------------------------------------------ #
-    # Step 7: Replay the planned trajectory                               #
-    # ------------------------------------------------------------------ #
-    recording_started = start_auto_play_recording(
-        sim, args, video_prefix=f"pickup_{args.object}_auto_play"
+    if wait_for_user:
+        input("Press Enter to replay the PickUp demo...")
+    clear_after_step = (
+        round((PICK_SAMPLE_INTERVAL - HAND_INTERP_STEPS) * 0.6) + HAND_INTERP_STEPS
     )
-    try:
-        post_grasp_clear_step = compute_pick_close_end_step()
-        should_clear_object_dynamics = True
-        for i in range(traj.shape[1]):
-            robot.set_qpos(traj[:, i, :])
-            sim.update(step=4)
-            if should_clear_object_dynamics and i + 1 >= post_grasp_clear_step:
-                obj.clear_dynamics()
-                should_clear_object_dynamics = False
-                logger.log_info(f"Object dynamics cleared after grasp at step={i}")
-            time.sleep(1e-2)
+    dynamics_cleared = False
 
-        logger.log_info(
-            f"PickUp keeps the upright {args.object} suspended in the gripper."
-        )
+    def clear_object_dynamics(step_idx: int, _: int) -> None:
+        nonlocal dynamics_cleared
+        if not dynamics_cleared and step_idx + 1 >= clear_after_step:
+            obj.clear_dynamics()
+            dynamics_cleared = True
 
-        final_qpos = traj[:, -1, :]
-        for i in range(POST_TRAJECTORY_STEPS):
-            robot.set_qpos(final_qpos)
-            sim.update(step=2)
-            time.sleep(1e-2)
-    finally:
-        stop_auto_play_recording(sim, recording_started)
-
-    if not args.auto_play:
+    replay_trajectory(
+        sim,
+        robot,
+        trajectory,
+        args,
+        video_prefix="pickup_cube_auto_play",
+        hold_steps=POST_TRAJECTORY_STEPS,
+        on_trajectory_step=clear_object_dynamics,
+    )
+    if wait_for_user:
         input("Press Enter to exit the simulation...")
 
 

--- a/scripts/tutorials/atomic_action/place.py
+++ b/scripts/tutorials/atomic_action/place.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import argparse
 import sys
-import time
 from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -30,61 +29,36 @@ if str(_REPO_ROOT) not in sys.path:
 import torch
 
 from embodichain.lab.gym.utils.gym_utils import add_env_launcher_args_to_parser
-from embodichain.lab.sim import SimulationManager, SimulationManagerCfg
 from embodichain.lab.sim.atomic_actions import (
-    AntipodalAffordance,
     AtomicActionEngine,
     EndEffectorPoseTarget,
     GraspTarget,
-    ObjectSemantics,
     PickUp,
     PickUpCfg,
     Place,
     PlaceCfg,
 )
-from embodichain.lab.sim.cfg import (
-    LightCfg,
-    RenderCfg,
-    RigidBodyAttributesCfg,
-    RigidObjectCfg,
-)
-from embodichain.lab.sim.objects import RigidObject, Robot
-from embodichain.lab.sim.planners import MotionGenerator, MotionGenCfg, ToppraPlannerCfg
+from embodichain.lab.sim.cfg import RigidBodyAttributesCfg, RigidObjectCfg
+from embodichain.lab.sim.objects import RigidObject
 from embodichain.lab.sim.shapes import CubeCfg
-from embodichain.toolkits.graspkit.pg_grasp.antipodal_generator import (
-    AntipodalSamplerCfg,
-    GraspGeneratorCfg,
-)
-from embodichain.toolkits.graspkit.pg_grasp.gripper_collision_checker import (
-    GripperCollisionCfg,
-)
 from embodichain.utils import logger
 from scripts.tutorials.atomic_action.tutorial_utils import (
+    add_ur5_gripper_robot,
     broadcast_pose_batch,
     broadcast_waypoint_pose_batch,
     clone_local_pose_from_first_env,
-    create_ur5_gripper_robot_cfg,
+    create_antipodal_semantics,
+    create_toppra_motion_generator,
+    create_tutorial_simulation,
     draw_axis_marker,
-    get_tutorial_window_size,
-    start_auto_play_recording,
-    stop_auto_play_recording,
+    get_hand_open_close_qpos,
+    initialize_pre_pick_robot_pose,
+    prepare_tutorial_scene,
+    replay_trajectory,
 )
 
-GRIPPER_MAX_OPEN_WIDTH = 0.080
-GRIPPER_FINGER_LENGTH = 0.088
-GRIPPER_ROOT_Z_WIDTH = 0.096
-GRIPPER_Y_THICKNESS = 0.040
-
-OBJECT_LABEL = "cube"
 OBJECT_SIZE = (0.05, 0.05, 0.05)
 OBJECT_XY = (-0.42, -0.08)
-OBJECT_MIN_HAND_CLOSE_QPOS = 0.024
-OBJECT_APPROACH_DIRECTION = (0.0, 0.0, -1.0)
-OBJECT_INIT_ROT = (0.0, 0.0, 0.0)
-OBJECT_BODY_SCALE = (1.0, 1.0, 1.0)
-OBJECT_MASS = 0.05
-OBJECT_USE_USD_PROPERTIES = False
-
 PICK_SAMPLE_INTERVAL = 120
 PLACE_SAMPLE_INTERVAL = 120
 HAND_INTERP_STEPS = 12
@@ -93,342 +67,153 @@ PLACE_LIFT_HEIGHT = 0.14
 
 
 def parse_arguments() -> argparse.Namespace:
+    """Parse command-line arguments for the Place tutorial."""
     parser = argparse.ArgumentParser(
-        description="Demonstrate Place by picking an object and releasing it at a target pose."
+        description="Pick up a cube and place it at a target pose."
     )
     add_env_launcher_args_to_parser(parser)
-    parser.add_argument(
-        "--n_sample",
-        type=int,
-        default=10000,
-        help="Number of samples for antipodal grasp generation.",
-    )
-    parser.add_argument(
-        "--force_reannotate",
-        action="store_true",
-        help="Force grasp region re-annotation instead of using cached data.",
-    )
-    parser.add_argument(
-        "--auto_play",
-        action="store_true",
-        help="Run the viewer demo without waiting for keyboard input.",
-    )
-    parser.add_argument(
-        "--no_vis_eef_axis",
-        action="store_true",
-        help="Do not draw the current end-effector/TCP coordinate frame before planning.",
-    )
+    parser.add_argument("--n_sample", type=int, default=10000)
+    parser.add_argument("--force_reannotate", action="store_true")
+    parser.add_argument("--auto_play", action="store_true")
+    parser.add_argument("--no_vis_eef_axis", action="store_true")
     return parser.parse_args()
 
 
-def initialize_simulation(args: argparse.Namespace) -> SimulationManager:
-    width, height = get_tutorial_window_size(args)
-    cfg = SimulationManagerCfg(
-        width=width,
-        height=height,
-        headless=True,
-        num_envs=args.num_envs,
-        sim_device=args.device,
-        render_cfg=RenderCfg(renderer=args.renderer),
-        physics_dt=1.0 / 100.0,
-        arena_space=2.5,
-    )
-    sim = SimulationManager(cfg)
-    sim.add_light(
-        cfg=LightCfg(
-            uid="main_light",
-            color=(0.6, 0.6, 0.6),
-            intensity=30.0,
-            init_pos=(1.0, 0.0, 3.0),
+def create_pick_object(sim) -> RigidObject:
+    """Create a settled cube for the PickUp and Place sequence."""
+    obj = sim.add_rigid_object(
+        cfg=RigidObjectCfg(
+            uid="cube",
+            shape=CubeCfg(size=list(OBJECT_SIZE)),
+            attrs=RigidBodyAttributesCfg(
+                mass=0.05,
+                dynamic_friction=0.97,
+                static_friction=0.99,
+                enable_ccd=True,
+            ),
+            max_convex_hull_num=16,
+            init_pos=[*OBJECT_XY, 0.5 * OBJECT_SIZE[2]],
         )
     )
-    return sim
-
-
-def create_robot(sim: SimulationManager, position=(0.0, 0.0, 0.0)) -> Robot:
-    cfg = create_ur5_gripper_robot_cfg(init_pos=position)
-    return sim.add_robot(cfg=cfg)
-
-
-def create_pick_object(sim: SimulationManager) -> RigidObject:
-    cfg = RigidObjectCfg(
-        uid=OBJECT_LABEL,
-        shape=CubeCfg(size=list(OBJECT_SIZE)),
-        attrs=RigidBodyAttributesCfg(
-            mass=OBJECT_MASS,
-            dynamic_friction=0.97,
-            static_friction=0.99,
-            enable_ccd=True,
-        ),
-        max_convex_hull_num=16,
-        init_pos=[OBJECT_XY[0], OBJECT_XY[1], 0.5 * OBJECT_SIZE[2]],
-        init_rot=OBJECT_INIT_ROT,
-        body_scale=OBJECT_BODY_SCALE,
-        use_usd_properties=OBJECT_USE_USD_PROPERTIES,
-    )
-    obj = sim.add_rigid_object(cfg=cfg)
-
-    # Set the object to a stable pose on the ground by simulating a few steps.
     sim.update(step=10)
     clone_local_pose_from_first_env(obj)
     obj.clear_dynamics()
     return obj
 
 
-def get_hand_open_close_qpos(
-    robot: Robot, device: torch.device
-) -> tuple[torch.Tensor, torch.Tensor]:
-    hand_limits = robot.get_qpos_limits(name="hand")[0].to(
-        device=device, dtype=torch.float32
-    )
-    hand_open = hand_limits[:, 0]
-    hand_close_limit = hand_limits[:, 1]
-    hand_close = torch.minimum(
-        hand_close_limit,
-        torch.full_like(hand_close_limit, OBJECT_MIN_HAND_CLOSE_QPOS),
-    )
-    return hand_open, hand_close
-
-
-def build_grasp_generator_cfg(args: argparse.Namespace) -> GraspGeneratorCfg:
-    return GraspGeneratorCfg(
-        viser_port=11801,
-        antipodal_sampler_cfg=AntipodalSamplerCfg(
-            n_sample=args.n_sample,
-            max_length=GRIPPER_MAX_OPEN_WIDTH,
-            min_length=0.003,
-        ),
-        is_partial_annotate=False,
-        is_filter_ground_collision=False,
-    )
-
-
-def build_gripper_collision_cfg() -> GripperCollisionCfg:
-    return GripperCollisionCfg(
-        max_open_length=GRIPPER_MAX_OPEN_WIDTH,
-        finger_length=GRIPPER_FINGER_LENGTH,
-        y_thickness=GRIPPER_Y_THICKNESS,
-        root_z_width=GRIPPER_ROOT_Z_WIDTH,
-        open_check_margin=0.002,
-        point_sample_dense=0.012,
-    )
-
-
-def create_object_semantics(
-    obj: RigidObject, args: argparse.Namespace
-) -> ObjectSemantics:
-    return ObjectSemantics(
-        label=OBJECT_LABEL,
-        geometry={
-            "mesh_vertices": obj.get_vertices(env_ids=[0], scale=True)[0],
-            "mesh_triangles": obj.get_triangles(env_ids=[0])[0],
-        },
-        affordance=AntipodalAffordance(
-            mesh_vertices=obj.get_vertices(env_ids=[0], scale=True)[0],
-            mesh_triangles=obj.get_triangles(env_ids=[0])[0],
-            gripper_collision_cfg=build_gripper_collision_cfg(),
-            generator_cfg=build_grasp_generator_cfg(args),
-            force_reannotate=args.force_reannotate,
-        ),
-        entity=obj,
-    )
-
-
-def make_pre_pick_eef_pose(robot: Robot, position: torch.Tensor) -> torch.Tensor:
-    pose = robot.compute_fk(
-        qpos=robot.get_qpos(name="arm"),
-        name="arm",
-        to_matrix=True,
-    ).clone()
-    pose[:, :3, 3] = position
-    return pose
-
-
-def initialize_pre_pick_robot_pose(
-    robot: Robot,
-    obj: RigidObject,
-    hand_open: torch.Tensor,
-) -> None:
-    obj_pose = obj.get_local_pose(to_matrix=True)
-    move_position = obj_pose[:, :3, 3].clone()
-    move_position[:, 2] = 0.36
-    pre_pick_pose = make_pre_pick_eef_pose(robot, move_position)
-    ik_success, arm_qpos = robot.compute_ik(
-        pose=pre_pick_pose,
-        joint_seed=robot.get_qpos(name="arm"),
-        name="arm",
-    )
-    if not torch.all(ik_success):
-        raise RuntimeError("Failed to initialize the robot at the pre-pick pose.")
-
-    n_envs = robot.get_qpos().shape[0]
-    hand_qpos = hand_open.unsqueeze(0).repeat(n_envs, 1)
-    for target in (False, True):
-        robot.set_qpos(arm_qpos, name="arm", target=target)
-        robot.set_qpos(hand_qpos, name="hand", target=target)
-    robot.clear_dynamics()
-
-
 def make_place_eef_poses(device: torch.device) -> torch.Tensor:
-    """Build a multi-waypoint place trajectory ``(n_waypoint, 4, 4)``.
-
-    Two waypoints are returned: a higher hover pose and the final release pose.
-    ``Place`` approaches from above the first waypoint, descends through each
-    waypoint in order, opens the gripper at the last, and retracts — so this
-    exercises the multi-waypoint descent path.
-    """
+    """Build hover and release waypoints for the multi-waypoint Place target."""
     rotation = torch.tensor(
         [
             [0.0539, 0.9985, -0.0022],
             [0.9977, -0.0540, -0.0401],
-            [-0.0401, -0.0000, -0.9992],
+            [-0.0401, 0.0, -0.9992],
         ],
         dtype=torch.float32,
         device=device,
     )
-    hover_pose = torch.eye(4, dtype=torch.float32, device=device)
-    hover_pose[:3, :3] = rotation
-    hover_pose[:3, 3] = torch.tensor(
-        [-0.40, 0.48, 0.20], dtype=torch.float32, device=device
-    )
-    place_pose = torch.eye(4, dtype=torch.float32, device=device)
-    place_pose[:3, :3] = rotation
-    place_pose[:3, 3] = torch.tensor(
-        [-0.40, 0.48, 0.10], dtype=torch.float32, device=device
-    )
-    return torch.stack([hover_pose, place_pose], dim=0)
-
-
-def compute_pick_close_end_step() -> int:
-    motion_waypoints = PICK_SAMPLE_INTERVAL - HAND_INTERP_STEPS
-    n_approach = int(round(motion_waypoints) * 0.6)
-    return n_approach + HAND_INTERP_STEPS
+    poses = []
+    for position in ((-0.40, 0.48, 0.20), (-0.40, 0.48, 0.10)):
+        pose = torch.eye(4, dtype=torch.float32, device=device)
+        pose[:3, :3], pose[:3, 3] = rotation, torch.tensor(position, device=device)
+        poses.append(pose)
+    return torch.stack(poses)
 
 
 def main() -> None:
-    """Pick up an object and place it at a target end-effector pose."""
+    """Plan and replay PickUp followed by a multi-waypoint Place."""
     args = parse_arguments()
-
-    # ------------------------------------------------------------------ #
-    # Step 1: Set up simulation, robot, and object                 #
-    # ------------------------------------------------------------------ #
-    sim = initialize_simulation(args)
-    robot = create_robot(sim)
+    sim = create_tutorial_simulation(args)
+    robot = add_ur5_gripper_robot(sim)
     obj = create_pick_object(sim)
-
-    if not args.headless:
-        sim.open_window()
-
-    # ------------------------------------------------------------------ #
-    # Step 2: Create a MotionGenerator for the robot                      #
-    # ------------------------------------------------------------------ #
-    motion_gen = MotionGenerator(
-        cfg=MotionGenCfg(planner_cfg=ToppraPlannerCfg(robot_uid=robot.uid))
-    )
-
-    # ------------------------------------------------------------------ #
-    # Step 3: Configure the PickUp and Place atomic actions               #
-    # ------------------------------------------------------------------ #
-    hand_open, hand_close = get_hand_open_close_qpos(robot, sim.device)
+    motion_gen = create_toppra_motion_generator(robot)
+    hand_open, hand_close = get_hand_open_close_qpos(robot)
     initialize_pre_pick_robot_pose(robot, obj, hand_open)
-    pickup_cfg = PickUpCfg(
-        control_part="arm",
-        hand_control_part="hand",
-        hand_open_qpos=hand_open,
-        hand_close_qpos=hand_close,
-        approach_direction=torch.tensor(
-            OBJECT_APPROACH_DIRECTION, dtype=torch.float32, device=sim.device
-        ),
-        pre_grasp_distance=0.15,
-        lift_height=0.16,
-        sample_interval=PICK_SAMPLE_INTERVAL,
-        hand_interp_steps=HAND_INTERP_STEPS,
+
+    engine = AtomicActionEngine(motion_generator=motion_gen)
+    engine.register(
+        PickUp(
+            motion_gen,
+            cfg=PickUpCfg(
+                hand_open_qpos=hand_open,
+                hand_close_qpos=hand_close,
+                pre_grasp_distance=0.15,
+                lift_height=0.16,
+                sample_interval=PICK_SAMPLE_INTERVAL,
+                hand_interp_steps=HAND_INTERP_STEPS,
+            ),
+        )
     )
-    place_cfg = PlaceCfg(
-        control_part="arm",
-        hand_control_part="hand",
-        hand_open_qpos=hand_open,
-        hand_close_qpos=hand_close,
-        lift_height=PLACE_LIFT_HEIGHT,
-        sample_interval=PLACE_SAMPLE_INTERVAL,
-        hand_interp_steps=HAND_INTERP_STEPS,
+    engine.register(
+        Place(
+            motion_gen,
+            cfg=PlaceCfg(
+                hand_open_qpos=hand_open,
+                hand_close_qpos=hand_close,
+                lift_height=PLACE_LIFT_HEIGHT,
+                sample_interval=PLACE_SAMPLE_INTERVAL,
+                hand_interp_steps=HAND_INTERP_STEPS,
+            ),
+        )
     )
 
-    # ------------------------------------------------------------------ #
-    # Step 4: Build the AtomicActionEngine                                #
-    # ------------------------------------------------------------------ #
-    atomic_engine = AtomicActionEngine(motion_generator=motion_gen)
-    atomic_engine.register(PickUp(motion_gen, cfg=pickup_cfg))
-    atomic_engine.register(Place(motion_gen, cfg=place_cfg))
-
-    # ------------------------------------------------------------------ #
-    # Step 5: Describe the object and define the place target             #
-    # ------------------------------------------------------------------ #
-    semantics = create_object_semantics(obj, args)
-    place_eef_poses = make_place_eef_poses(sim.device)
-    n_envs = robot.get_qpos().shape[0]
-
+    semantics = create_antipodal_semantics(
+        obj,
+        label="cube",
+        n_sample=args.n_sample,
+        force_reannotate=args.force_reannotate,
+    )
+    place_poses = make_place_eef_poses(sim.device)
     if not args.no_vis_eef_axis:
         draw_axis_marker(
             sim,
             "place_target_axis",
-            broadcast_pose_batch(place_eef_poses[-1], num_envs=n_envs),
+            broadcast_pose_batch(place_poses[-1], robot.get_qpos().shape[0]),
         )
-    if not args.auto_play:
-        input("Inspect the object, then press Enter to plan PickUp -> Place...")
-
-    # ------------------------------------------------------------------ #
-    # Step 6: Plan the declared (name, typed_target) sequence             #
-    # ------------------------------------------------------------------ #
-    # Pass a multi-waypoint trajectory (n_envs, n_waypoint, 4, 4): Place
-    # approaches from above the first waypoint, descends through each
-    # waypoint in order, opens the gripper at the last, and retracts.
-    multi_waypoint_xpos = broadcast_waypoint_pose_batch(
-        place_eef_poses, num_envs=n_envs
+    wait_for_user = prepare_tutorial_scene(
+        sim, args, "Inspect the cube, then press Enter to plan PickUp -> Place..."
     )
-    place_target = EndEffectorPoseTarget(xpos=multi_waypoint_xpos)
-    logger.log_info("Planning PickUp precondition -> Place release trajectory")
-    is_success, traj, _ = atomic_engine.run(
-        steps=[
-            ("pick_up", GraspTarget(semantics=semantics)),
-            ("place", place_target),
+
+    success, trajectory, _ = engine.run(
+        [
+            ("pick_up", GraspTarget(semantics)),
+            (
+                "place",
+                EndEffectorPoseTarget(
+                    broadcast_waypoint_pose_batch(
+                        place_poses, robot.get_qpos().shape[0]
+                    )
+                ),
+            ),
         ]
     )
-    if not is_success.all():
+    if not success.all():
         logger.log_warning("Failed to plan Place demo trajectory.")
         return
 
-    if not args.auto_play:
+    if wait_for_user:
         input("Press Enter to replay the Place demo...")
-
-    # ------------------------------------------------------------------ #
-    # Step 7: Replay the planned trajectory                               #
-    # ------------------------------------------------------------------ #
-    recording_started = start_auto_play_recording(
-        sim, args, video_prefix="place_auto_play"
+    clear_after_step = (
+        round((PICK_SAMPLE_INTERVAL - HAND_INTERP_STEPS) * 0.6) + HAND_INTERP_STEPS
     )
-    try:
-        post_grasp_clear_step = compute_pick_close_end_step()
-        should_clear_object_dynamics = True
-        for i in range(traj.shape[1]):
-            robot.set_qpos(traj[:, i, :])
-            sim.update(step=4)
-            if should_clear_object_dynamics and i + 1 >= post_grasp_clear_step:
-                obj.clear_dynamics()
-                should_clear_object_dynamics = False
-                logger.log_info(f"Object dynamics cleared after grasp at step={i}")
-            time.sleep(1e-2)
+    dynamics_cleared = False
 
-        logger.log_info("Place opens the gripper and clears WorldState.held_object.")
-        final_qpos = traj[:, -1, :]
-        for i in range(POST_TRAJECTORY_STEPS):
-            robot.set_qpos(final_qpos)
-            sim.update(step=2)
-            time.sleep(1e-2)
-    finally:
-        stop_auto_play_recording(sim, recording_started)
+    def clear_object_dynamics(step_idx: int, _: int) -> None:
+        nonlocal dynamics_cleared
+        if not dynamics_cleared and step_idx + 1 >= clear_after_step:
+            obj.clear_dynamics()
+            dynamics_cleared = True
 
-    if not args.auto_play:
+    replay_trajectory(
+        sim,
+        robot,
+        trajectory,
+        args,
+        video_prefix="place_auto_play",
+        hold_steps=POST_TRAJECTORY_STEPS,
+        on_trajectory_step=clear_object_dynamics,
+    )
+    if wait_for_user:
         input("Press Enter to exit the simulation...")
 
 

--- a/scripts/tutorials/atomic_action/press.py
+++ b/scripts/tutorials/atomic_action/press.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import argparse
 import sys
-import time
 from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -30,7 +29,6 @@ if str(_REPO_ROOT) not in sys.path:
 import torch
 
 from embodichain.lab.gym.utils.gym_utils import add_env_launcher_args_to_parser
-from embodichain.lab.sim import SimulationManager, SimulationManagerCfg
 from embodichain.lab.sim.atomic_actions import (
     AtomicActionEngine,
     EndEffectorPoseTarget,
@@ -40,260 +38,136 @@ from embodichain.lab.sim.atomic_actions import (
     PressCfg,
 )
 from embodichain.lab.sim.cfg import (
-    LightCfg,
-    RenderCfg,
     RigidBodyAttributesCfg,
     RigidObjectCfg,
 )
 from embodichain.lab.sim.material import VisualMaterialCfg
-from embodichain.lab.sim.objects import RigidObject, Robot
-from embodichain.lab.sim.planners import MotionGenerator, MotionGenCfg, ToppraPlannerCfg
+from embodichain.lab.sim.objects import RigidObject
 from embodichain.lab.sim.shapes import CubeCfg
 from embodichain.utils import logger
 from scripts.tutorials.atomic_action.tutorial_utils import (
+    add_ur5_gripper_robot,
     broadcast_pose_batch,
-    clone_local_pose_from_first_env,
-    create_ur5_gripper_robot_cfg,
+    create_toppra_motion_generator,
+    create_tutorial_simulation,
     draw_axis_marker,
-    get_tutorial_window_size,
-    should_open_tutorial_window,
-    should_wait_for_tutorial_input,
-    start_auto_play_recording,
-    stop_auto_play_recording,
+    format_tensor,
+    get_hand_open_close_qpos,
+    make_top_down_eef_pose,
+    prepare_tutorial_scene,
+    replay_trajectory,
 )
 
 MOVE_SAMPLE_INTERVAL = 60
 PRESS_SAMPLE_INTERVAL = 90
 HAND_INTERP_STEPS = 12
 POST_TRAJECTORY_STEPS = 180
-BLOCK_SIZE = [0.12, 0.12, 0.06]
-SUPPORT_SURFACE_Z = 0.0
-BLOCK_CENTER = [-0.30, -0.12, SUPPORT_SURFACE_Z + 0.5 * BLOCK_SIZE[2]]
+BLOCK_SIZE = (0.12, 0.12, 0.06)
 PRESS_CLEARANCE = 0.13
 PRESS_SURFACE_OFFSET = 0.003
 DEFAULT_PRESS_TOLERANCE = 0.01
 
 
 def parse_arguments() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(
-        description="Demonstrate Press on the center of a regular wooden block."
-    )
+    """Parse command-line arguments for the Press tutorial."""
+    parser = argparse.ArgumentParser(description="Demonstrate Press on a wooden block.")
     add_env_launcher_args_to_parser(parser)
+    parser.add_argument("--auto_play", action="store_true")
+    parser.add_argument("--debug_state", action="store_true")
     parser.add_argument(
-        "--auto_play",
-        action="store_true",
-        help="Run the viewer demo without waiting for keyboard input.",
+        "--press_tolerance", type=float, default=DEFAULT_PRESS_TOLERANCE
     )
-    parser.add_argument(
-        "--debug_state",
-        action="store_true",
-        help="Log the block pose during replay.",
-    )
-    parser.add_argument(
-        "--press_tolerance",
-        type=float,
-        default=DEFAULT_PRESS_TOLERANCE,
-        help="XY tolerance in meters for checking whether press reaches block center.",
-    )
-    parser.add_argument(
-        "--block_pos",
-        type=float,
-        nargs=2,
-        default=BLOCK_CENTER[:2],
-        metavar=("X", "Y"),
-        help="Initial XY position of the wooden block center.",
-    )
-    parser.add_argument(
-        "--no_vis_eef_axis",
-        action="store_true",
-        help="Do not draw the press target coordinate frame before planning.",
-    )
+    parser.add_argument("--block_pos", type=float, nargs=2, default=(-0.30, -0.12))
+    parser.add_argument("--no_vis_eef_axis", action="store_true")
     return parser.parse_args()
 
 
-def initialize_simulation(args: argparse.Namespace) -> SimulationManager:
-    width, height = get_tutorial_window_size(args)
-    cfg = SimulationManagerCfg(
-        width=width,
-        height=height,
-        headless=True,
-        num_envs=args.num_envs,
-        sim_device=args.device,
-        render_cfg=RenderCfg(renderer=args.renderer),
-        physics_dt=1.0 / 100.0,
-        arena_space=2.5,
-    )
-    sim = SimulationManager(cfg)
-    sim.add_light(
-        cfg=LightCfg(
-            uid="main_light",
-            color=(0.6, 0.6, 0.6),
-            intensity=30.0,
-            init_pos=(1.0, 0.0, 3.0),
+def create_wooden_block(sim, center: list[float]) -> RigidObject:
+    """Create the static block used as a press target."""
+    return sim.add_rigid_object(
+        cfg=RigidObjectCfg(
+            uid="wooden_block",
+            shape=CubeCfg(
+                size=list(BLOCK_SIZE),
+                visual_material=VisualMaterialCfg(
+                    uid="wooden_block_mat",
+                    base_color=[0.58, 0.32, 0.14, 1.0],
+                    roughness=0.85,
+                ),
+            ),
+            body_type="static",
+            attrs=RigidBodyAttributesCfg(dynamic_friction=0.8, static_friction=0.9),
+            init_pos=center,
         )
     )
-    return sim
-
-
-def create_robot(sim: SimulationManager, position=(0.0, 0.0, 0.0)) -> Robot:
-    return sim.add_robot(cfg=create_ur5_gripper_robot_cfg(init_pos=position))
-
-
-def create_wooden_block(
-    sim: SimulationManager,
-    block_center: list[float],
-) -> RigidObject:
-    cfg = RigidObjectCfg(
-        uid="wooden_block",
-        shape=CubeCfg(
-            size=BLOCK_SIZE,
-            visual_material=VisualMaterialCfg(
-                uid="wooden_block_mat",
-                base_color=[0.58, 0.32, 0.14, 1.0],
-                roughness=0.85,
-            ),
-        ),
-        body_type="static",
-        attrs=RigidBodyAttributesCfg(
-            dynamic_friction=0.8,
-            static_friction=0.9,
-        ),
-        init_pos=block_center,
-    )
-    return sim.add_rigid_object(cfg=cfg)
-
-
-def settle_object(sim: SimulationManager, obj: RigidObject, step: int = 5) -> None:
-    if sim.device.type == "cuda":
-        sim.init_gpu_physics()
-    obj.reset()
-    sim.update(step=step)
-    obj.clear_dynamics()
-
-
-def get_hand_close_qpos(robot: Robot, device: torch.device) -> torch.Tensor:
-    hand_limits = robot.get_qpos_limits(name="hand")[0].to(
-        device=device, dtype=torch.float32
-    )
-    return hand_limits[:, 1]
-
-
-def make_top_down_eef_pose(position: torch.Tensor) -> torch.Tensor:
-    pose = torch.eye(4, dtype=torch.float32, device=position.device)
-    pose[:3, :3] = torch.tensor(
-        [
-            [-0.0539, -0.9985, -0.0022],
-            [-0.9977, 0.0540, -0.0401],
-            [0.0401, 0.0000, -0.9992],
-        ],
-        dtype=torch.float32,
-        device=position.device,
-    )
-    pose[:3, 3] = position
-    return pose
-
-
-def format_tensor(tensor: torch.Tensor) -> str:
-    rounded = (tensor.detach().cpu() * 10000.0).round() / 10000.0
-    return str(rounded.tolist())
-
-
-def log_block_state(block: RigidObject, label: str) -> None:
-    block_pose = block.get_local_pose(to_matrix=True)
-    logger.log_info(
-        f"{label}: pos={format_tensor(block_pose[0, :3, 3])}, "
-        f"z_axis={format_tensor(block_pose[0, :3, 2])}"
-    )
-
-
-def draw_press_target_axis(sim: SimulationManager, press_target: torch.Tensor) -> None:
-    draw_axis_marker(sim, "press_target_axis", press_target)
 
 
 def compute_press_center_check(
-    robot: Robot,
-    traj: torch.Tensor,
+    robot,
+    trajectory: torch.Tensor,
     block: RigidObject,
     tolerance: float,
 ) -> tuple[bool, float, int, torch.Tensor, torch.Tensor]:
+    """Return whether the press trajectory reaches the block center tolerance."""
     arm_joint_ids = robot.get_joint_ids(name="arm")
-    press_segment_start = MOVE_SAMPLE_INTERVAL + HAND_INTERP_STEPS
-    press_segment_end = MOVE_SAMPLE_INTERVAL + PRESS_SAMPLE_INTERVAL
-    arm_traj = traj[:, press_segment_start:press_segment_end, arm_joint_ids]
-    n_envs, n_steps, _ = arm_traj.shape
+    start = MOVE_SAMPLE_INTERVAL + HAND_INTERP_STEPS
+    arm_traj = trajectory[
+        :, start : MOVE_SAMPLE_INTERVAL + PRESS_SAMPLE_INTERVAL, arm_joint_ids
+    ]
     fk_pose = torch.stack(
         [
-            robot.compute_fk(
-                qpos=arm_traj[:, step_idx, :],
-                name="arm",
-                to_matrix=True,
-            )
-            for step_idx in range(n_steps)
+            robot.compute_fk(qpos=qpos, name="arm", to_matrix=True)
+            for qpos in arm_traj.unbind(dim=1)
         ],
         dim=1,
     )
-
-    block_pose = block.get_local_pose(to_matrix=True)
-    block_center = block_pose[:, :3, 3]
-    block_top_z = block_center[:, 2] + 0.5 * BLOCK_SIZE[2]
-    target_xy = block_center[:, :2]
-    target_z = block_top_z + PRESS_SURFACE_OFFSET
-
-    xy_error = torch.linalg.norm(fk_pose[:, :, :2, 3] - target_xy.unsqueeze(1), dim=2)
-    z_error = torch.abs(fk_pose[:, :, 2, 3] - target_z.unsqueeze(1))
-    combined_error = xy_error + z_error
-    best_idx = torch.argmin(combined_error, dim=1)
-    env_indices = torch.arange(n_envs, device=traj.device)
-    best_pos = fk_pose[env_indices, best_idx, :3, 3]
-    center_error = torch.linalg.norm(best_pos[:, :2] - target_xy, dim=1)
-    worst_env = int(torch.argmax(center_error).item())
+    block_center = block.get_local_pose(to_matrix=True)[:, :3, 3]
+    target_z = block_center[:, 2] + 0.5 * BLOCK_SIZE[2] + PRESS_SURFACE_OFFSET
+    xy_error = torch.linalg.norm(
+        fk_pose[:, :, :2, 3] - block_center[:, None, :2], dim=2
+    )
+    z_error = torch.abs(fk_pose[:, :, 2, 3] - target_z[:, None])
+    best_idx = (xy_error + z_error).argmin(dim=1)
+    env_idx = torch.arange(trajectory.shape[0], device=trajectory.device)
+    best_pos = fk_pose[env_idx, best_idx, :3, 3]
+    center_error = torch.linalg.norm(best_pos[:, :2] - block_center[:, :2], dim=1)
+    worst_env = int(center_error.argmax().item())
+    expected = torch.stack(
+        [block_center[worst_env, 0], block_center[worst_env, 1], target_z[worst_env]]
+    )
     return (
         bool(torch.all(center_error <= tolerance)),
         float(center_error[worst_env].item()),
-        press_segment_start + int(best_idx[worst_env].item()),
+        start + int(best_idx[worst_env].item()),
         best_pos[worst_env],
-        torch.tensor(
-            [target_xy[worst_env, 0], target_xy[worst_env, 1], target_z[worst_env]],
-            dtype=torch.float32,
-            device=traj.device,
-        ),
+        expected,
     )
 
 
-def run_press_demo(args: argparse.Namespace) -> None:
-    sim = initialize_simulation(args)
-    robot = create_robot(sim)
-    block_center = [
-        args.block_pos[0],
-        args.block_pos[1],
-        SUPPORT_SURFACE_Z + 0.5 * BLOCK_SIZE[2],
-    ]
-    block = create_wooden_block(sim, block_center)
-
-    settle_object(sim, block, step=5)
-    clone_local_pose_from_first_env(block)
+def main() -> None:
+    """Plan, verify, and replay MoveEndEffector followed by Press."""
+    args = parse_arguments()
+    sim = create_tutorial_simulation(args)
+    robot = add_ur5_gripper_robot(sim)
+    block = create_wooden_block(sim, [*args.block_pos, 0.5 * BLOCK_SIZE[2]])
+    if sim.device.type == "cuda":
+        sim.init_gpu_physics()
+    block.reset()
+    sim.update(step=5)
     block.clear_dynamics()
-    motion_gen = MotionGenerator(
-        cfg=MotionGenCfg(planner_cfg=ToppraPlannerCfg(robot_uid=robot.uid))
-    )
-    hand_close = get_hand_close_qpos(robot, sim.device)
 
-    atomic_engine = AtomicActionEngine(motion_generator=motion_gen)
-    atomic_engine.register(
+    motion_gen = create_toppra_motion_generator(robot)
+    hand_close = get_hand_open_close_qpos(robot)[1]
+    engine = AtomicActionEngine(motion_generator=motion_gen)
+    engine.register(
         MoveEndEffector(
-            motion_gen,
-            cfg=MoveEndEffectorCfg(
-                control_part="arm",
-                sample_interval=MOVE_SAMPLE_INTERVAL,
-            ),
+            motion_gen, MoveEndEffectorCfg(sample_interval=MOVE_SAMPLE_INTERVAL)
         )
     )
-    atomic_engine.register(
+    engine.register(
         Press(
             motion_gen,
-            cfg=PressCfg(
-                control_part="arm",
-                hand_control_part="hand",
+            PressCfg(
                 hand_close_qpos=hand_close,
                 sample_interval=PRESS_SAMPLE_INTERVAL,
                 hand_interp_steps=HAND_INTERP_STEPS,
@@ -301,99 +175,66 @@ def run_press_demo(args: argparse.Namespace) -> None:
         )
     )
 
-    wait_for_user = should_wait_for_tutorial_input(args)
-    if should_open_tutorial_window(args):
-        sim.open_window()
-    if wait_for_user:
-        input("Inspect the wooden block, then press Enter to plan...")
-
-    block_pose = block.get_local_pose(to_matrix=True)
-    block_top_z = block_pose[0, 2, 3] + 0.5 * BLOCK_SIZE[2]
-    press_position = block_pose[0, :3, 3].clone()
-    press_position[2] = block_top_z + PRESS_SURFACE_OFFSET
+    block_center = block.get_local_pose(to_matrix=True)[0, :3, 3]
+    press_position = block_center.clone()
+    press_position[2] += 0.5 * BLOCK_SIZE[2] + PRESS_SURFACE_OFFSET
     move_position = press_position.clone()
-    move_position[2] = block_top_z + PRESS_CLEARANCE
-
+    move_position[2] += PRESS_CLEARANCE - PRESS_SURFACE_OFFSET
     n_envs = robot.get_qpos().shape[0]
-    move_target = broadcast_pose_batch(
-        make_top_down_eef_pose(move_position), num_envs=n_envs
-    )
-    press_target = broadcast_pose_batch(
-        make_top_down_eef_pose(press_position), num_envs=n_envs
-    )
+    move_target = broadcast_pose_batch(make_top_down_eef_pose(move_position), n_envs)
+    press_target = broadcast_pose_batch(make_top_down_eef_pose(press_position), n_envs)
     if not args.no_vis_eef_axis:
-        draw_press_target_axis(sim, press_target)
+        draw_axis_marker(sim, "press_target_axis", press_target)
+    wait_for_user = prepare_tutorial_scene(
+        sim, args, "Inspect the wooden block, then press Enter to plan..."
+    )
 
-    logger.log_info("Planning MoveEndEffector -> Press")
-    start_time = time.time()
-    is_success, traj, _ = atomic_engine.run(
-        steps=[
-            ("move_end_effector", EndEffectorPoseTarget(xpos=move_target)),
-            ("press", EndEffectorPoseTarget(xpos=press_target)),
+    success, trajectory, _ = engine.run(
+        [
+            ("move_end_effector", EndEffectorPoseTarget(move_target)),
+            ("press", EndEffectorPoseTarget(press_target)),
         ]
     )
-    cost_time = time.time() - start_time
-    logger.log_info(f"Plan trajectory cost time: {cost_time:.2f} seconds")
-    if not is_success.all():
+    if not success.all():
         logger.log_warning("Failed to plan Press demo trajectory.")
         return
-
     is_center_hit, center_error, hit_step, hit_pos, expected_pos = (
-        compute_press_center_check(
-            robot=robot,
-            traj=traj,
-            block=block,
-            tolerance=args.press_tolerance,
-        )
+        compute_press_center_check(robot, trajectory, block, args.press_tolerance)
     )
     logger.log_info(
         "Press center check: "
-        f"success={is_center_hit}, "
-        f"xy_error={center_error:.4f} m, "
-        f"hit_step={hit_step}, "
-        f"hit_pos={format_tensor(hit_pos)}, "
-        f"expected={format_tensor(expected_pos)}"
+        f"success={is_center_hit}, xy_error={center_error:.4f} m, hit_step={hit_step}, "
+        f"hit_pos={format_tensor(hit_pos)}, expected={format_tensor(expected_pos)}"
     )
     if not is_center_hit:
         logger.log_warning(
-            "Press planned trajectory did not reach the block center within "
-            f"{args.press_tolerance:.4f} m."
+            "Press trajectory did not reach the block center within tolerance."
         )
         return
 
     if wait_for_user:
         input("Press Enter to replay the Press demo...")
 
-    recording_started = start_auto_play_recording(
-        sim, args, video_prefix="press_auto_play"
+    def log_state(step_idx: int, total_steps: int) -> None:
+        if args.debug_state and (
+            step_idx % max(1, total_steps // 10) == 0 or step_idx == total_steps - 1
+        ):
+            logger.log_info(
+                f"replay step {step_idx}/{total_steps - 1}: "
+                f"pos={format_tensor(block.get_local_pose(to_matrix=True)[0, :3, 3])}"
+            )
+
+    replay_trajectory(
+        sim,
+        robot,
+        trajectory,
+        args,
+        video_prefix="press_auto_play",
+        hold_steps=POST_TRAJECTORY_STEPS,
+        on_trajectory_step=log_state,
     )
-    try:
-        log_stride = max(1, traj.shape[1] // 10)
-        for i in range(traj.shape[1]):
-            robot.set_qpos(traj[:, i, :])
-            sim.update(step=4)
-            if args.debug_state and (i % log_stride == 0 or i == traj.shape[1] - 1):
-                log_block_state(block, f"replay step {i}/{traj.shape[1] - 1}")
-            time.sleep(1e-2)
-
-        logger.log_info("Press returned the end-effector to the starting pose.")
-        final_qpos = traj[:, -1, :]
-        for i in range(POST_TRAJECTORY_STEPS):
-            robot.set_qpos(final_qpos)
-            sim.update(step=2)
-            if args.debug_state and i % max(1, POST_TRAJECTORY_STEPS // 5) == 0:
-                log_block_state(block, f"post step {i}/{POST_TRAJECTORY_STEPS - 1}")
-            time.sleep(1e-2)
-    finally:
-        stop_auto_play_recording(sim, recording_started)
-
     if wait_for_user:
         input("Press Enter to exit the simulation...")
-
-
-def main() -> None:
-    args = parse_arguments()
-    run_press_demo(args)
 
 
 if __name__ == "__main__":

--- a/scripts/tutorials/atomic_action/tutorial_utils.py
+++ b/scripts/tutorials/atomic_action/tutorial_utils.py
@@ -19,15 +19,29 @@
 from __future__ import annotations
 
 import argparse
-from collections.abc import Sequence
+import time
+from collections.abc import Callable, Sequence
 
 import torch
 
 from embodichain.data import get_data_path
-from embodichain.lab.sim import SimulationManager
-from embodichain.lab.sim.cfg import MarkerCfg, RobotCfg
+from embodichain.lab.sim import SimulationManager, SimulationManagerCfg
+from embodichain.lab.sim.atomic_actions import (
+    AntipodalAffordance,
+    ObjectSemantics,
+)
+from embodichain.lab.sim.cfg import LightCfg, MarkerCfg, RenderCfg, RobotCfg
+from embodichain.lab.sim.objects import RigidObject, Robot
+from embodichain.lab.sim.planners import MotionGenCfg, MotionGenerator, ToppraPlannerCfg
 from embodichain.lab.sim.robots import URRobotCfg
 from embodichain.lab.sim.solvers import URSolverCfg
+from embodichain.toolkits.graspkit.pg_grasp.antipodal_generator import (
+    AntipodalSamplerCfg,
+    GraspGeneratorCfg,
+)
+from embodichain.toolkits.graspkit.pg_grasp.gripper_collision_checker import (
+    GripperCollisionCfg,
+)
 
 RECORD_WIDTH = 640
 RECORD_HEIGHT = 480
@@ -46,6 +60,17 @@ DEFAULT_AXIS_SIZE = 0.003
 GRIPPER_URDF_PATH = "DH_PGI_140_80/DH_PGI_140_80.urdf"
 GRIPPER_HAND_JOINT_PATTERN = "gripper_finger1_joint_1"
 GRIPPER_TCP_Z = 0.15
+GRIPPER_MAX_OPEN_WIDTH = 0.080
+GRIPPER_FINGER_LENGTH = 0.088
+GRIPPER_ROOT_Z_WIDTH = 0.096
+GRIPPER_Y_THICKNESS = 0.040
+DEFAULT_GRIPPER_CLOSE_QPOS = 0.024
+DEFAULT_TUTORIAL_LIGHT_POS = (1.0, 0.0, 3.0)
+TOP_DOWN_EEF_ROTATION = (
+    (-0.0539, -0.9985, -0.0022),
+    (-0.9977, 0.0540, -0.0401),
+    (0.0401, 0.0000, -0.9992),
+)
 
 
 def make_ur5_solver_cfg(tcp_z: float) -> URSolverCfg:
@@ -63,6 +88,325 @@ def make_ur5_solver_cfg(tcp_z: float) -> URSolverCfg:
     )
     cfg.urdf_path = None
     return cfg
+
+
+def create_tutorial_simulation(
+    args: argparse.Namespace,
+    *,
+    arena_space: float = 2.5,
+    light_pos: Sequence[float] = DEFAULT_TUTORIAL_LIGHT_POS,
+) -> SimulationManager:
+    """Create the shared simulation setup used by atomic-action tutorials.
+
+    Args:
+        args: Parsed launcher arguments containing environment count, device,
+            and renderer selections.
+        arena_space: Spacing between parallel simulation arenas in meters.
+        light_pos: Position of the scene's key light.
+
+    Returns:
+        A simulation manager with the tutorial key light configured.
+    """
+    width, height = get_tutorial_window_size(args)
+    sim = SimulationManager(
+        SimulationManagerCfg(
+            width=width,
+            height=height,
+            headless=True,
+            num_envs=args.num_envs,
+            sim_device=args.device,
+            render_cfg=RenderCfg(renderer=args.renderer),
+            physics_dt=1.0 / 100.0,
+            arena_space=arena_space,
+        )
+    )
+    sim.add_light(
+        cfg=LightCfg(
+            uid="main_light",
+            color=(0.6, 0.6, 0.6),
+            intensity=30.0,
+            init_pos=list(light_pos),
+        )
+    )
+    return sim
+
+
+def add_ur5_gripper_robot(
+    sim: SimulationManager,
+    init_pos: Sequence[float] = (0.0, 0.0, 0.0),
+) -> Robot:
+    """Add the standard UR5 plus PGI gripper tutorial robot.
+
+    Args:
+        sim: Simulation manager that owns the robot.
+        init_pos: Root position of the robot in its arena.
+
+    Returns:
+        The added robot instance.
+    """
+    return sim.add_robot(cfg=create_ur5_gripper_robot_cfg(init_pos=init_pos))
+
+
+def create_toppra_motion_generator(robot: Robot) -> MotionGenerator:
+    """Create the standard TOPPRA motion generator for a tutorial robot.
+
+    Args:
+        robot: Robot whose trajectories will be planned.
+
+    Returns:
+        The configured motion generator.
+    """
+    return MotionGenerator(
+        cfg=MotionGenCfg(planner_cfg=ToppraPlannerCfg(robot_uid=robot.uid))
+    )
+
+
+def get_hand_open_close_qpos(
+    robot: Robot,
+    *,
+    hand_control_part: str = "hand",
+    close_qpos: float = DEFAULT_GRIPPER_CLOSE_QPOS,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return the open limit and a safe closed position for a gripper.
+
+    Args:
+        robot: Robot containing the gripper control part.
+        hand_control_part: Name of the gripper control part.
+        close_qpos: Desired per-joint closed position, clamped to joint limits.
+
+    Returns:
+        Open and closed joint-position tensors on the robot device.
+    """
+    hand_limits = robot.get_qpos_limits(name=hand_control_part)[0].to(
+        device=robot.device, dtype=torch.float32
+    )
+    return hand_limits[:, 0], torch.minimum(
+        hand_limits[:, 1], torch.full_like(hand_limits[:, 1], close_qpos)
+    )
+
+
+def create_antipodal_semantics(
+    obj: RigidObject,
+    *,
+    label: str,
+    n_sample: int,
+    force_reannotate: bool,
+) -> ObjectSemantics:
+    """Describe a rigid object using the standard PGI antipodal-grasp setup.
+
+    Args:
+        obj: Rigid object that will be grasped.
+        label: Human-readable object category.
+        n_sample: Number of grasp-pair samples to generate.
+        force_reannotate: Whether to ignore cached grasp annotations.
+
+    Returns:
+        Object semantics with mesh data stored only on its affordance.
+    """
+    vertices = obj.get_vertices(env_ids=[0], scale=True)[0]
+    triangles = obj.get_triangles(env_ids=[0])[0]
+    return ObjectSemantics(
+        label=label,
+        geometry={},
+        affordance=AntipodalAffordance(
+            mesh_vertices=vertices,
+            mesh_triangles=triangles,
+            gripper_collision_cfg=GripperCollisionCfg(
+                max_open_length=GRIPPER_MAX_OPEN_WIDTH,
+                finger_length=GRIPPER_FINGER_LENGTH,
+                y_thickness=GRIPPER_Y_THICKNESS,
+                root_z_width=GRIPPER_ROOT_Z_WIDTH,
+                open_check_margin=0.002,
+                point_sample_dense=0.012,
+            ),
+            generator_cfg=GraspGeneratorCfg(
+                viser_port=11801,
+                antipodal_sampler_cfg=AntipodalSamplerCfg(
+                    n_sample=n_sample,
+                    max_length=GRIPPER_MAX_OPEN_WIDTH,
+                    min_length=0.003,
+                ),
+                is_partial_annotate=False,
+                is_filter_ground_collision=False,
+            ),
+            force_reannotate=force_reannotate,
+        ),
+        entity=obj,
+    )
+
+
+def make_top_down_eef_pose(position: torch.Tensor) -> torch.Tensor:
+    """Build the standard downward-facing TCP pose at ``position``.
+
+    Args:
+        position: Three-dimensional position for the tool center point.
+
+    Returns:
+        A homogeneous end-effector pose.
+    """
+    pose = torch.eye(4, dtype=torch.float32, device=position.device)
+    pose[:3, :3] = torch.tensor(
+        TOP_DOWN_EEF_ROTATION,
+        dtype=torch.float32,
+        device=position.device,
+    )
+    pose[:3, 3] = position
+    return pose
+
+
+def format_tensor(tensor: torch.Tensor) -> str:
+    """Format a tensor compactly for tutorial log messages.
+
+    Args:
+        tensor: Tensor to render for a human-readable log message.
+
+    Returns:
+        A rounded Python-list representation.
+    """
+    rounded = (tensor.detach().cpu() * 10000.0).round() / 10000.0
+    return str(rounded.tolist())
+
+
+def make_eef_pose_at(robot: Robot, position: torch.Tensor) -> torch.Tensor:
+    """Reuse the current TCP orientation at a requested position.
+
+    Args:
+        robot: Robot whose current arm pose supplies the orientation.
+        position: Position tensor with shape ``(3,)`` or ``(n_envs, 3)``.
+
+    Returns:
+        A single or batched homogeneous pose matching ``position``.
+    """
+    pose = robot.compute_fk(
+        qpos=robot.get_qpos(name="arm"), name="arm", to_matrix=True
+    ).clone()
+    if position.dim() == 1:
+        pose = pose[0]
+    pose[..., :3, 3] = position
+    return pose
+
+
+def initialize_pre_pick_robot_pose(
+    robot: Robot,
+    obj: RigidObject,
+    hand_open: torch.Tensor,
+    *,
+    height: float = 0.36,
+) -> None:
+    """Set a UR5 at a deterministic open-gripper pose above an object.
+
+    Args:
+        robot: Robot to initialize.
+        obj: Object below the pre-pick TCP pose.
+        hand_open: Open gripper joint positions.
+        height: World-Z coordinate for the pre-pick TCP pose.
+
+    Raises:
+        RuntimeError: If the pre-pick pose is unreachable.
+    """
+    position = obj.get_local_pose(to_matrix=True)[:, :3, 3].clone()
+    position[:, 2] = height
+    ik_success, arm_qpos = robot.compute_ik(
+        pose=make_eef_pose_at(robot, position),
+        joint_seed=robot.get_qpos(name="arm"),
+        name="arm",
+    )
+    if not torch.all(ik_success):
+        raise RuntimeError("Failed to initialize the robot at the pre-pick pose.")
+
+    hand_qpos = hand_open.unsqueeze(0).repeat(robot.get_qpos().shape[0], 1)
+    for target in (False, True):
+        robot.set_qpos(arm_qpos, name="arm", target=target)
+        robot.set_qpos(hand_qpos, name="hand", target=target)
+    robot.clear_dynamics()
+
+
+def prepare_tutorial_scene(
+    sim: SimulationManager,
+    args: argparse.Namespace,
+    prompt: str,
+) -> bool:
+    """Open an interactive scene and optionally wait before planning.
+
+    Args:
+        sim: Simulation manager used by the tutorial.
+        args: Parsed tutorial arguments.
+        prompt: Prompt displayed for interactive runs.
+
+    Returns:
+        Whether the caller should retain later interactive pauses.
+    """
+    wait_for_user = should_wait_for_tutorial_input(args)
+    if should_open_tutorial_window(args):
+        sim.open_window()
+    if wait_for_user:
+        input(prompt)
+    return wait_for_user
+
+
+def replay_trajectory(
+    sim: SimulationManager,
+    robot: Robot,
+    trajectory: torch.Tensor,
+    args: argparse.Namespace,
+    *,
+    video_prefix: str,
+    hold_steps: int,
+    trajectory_sim_steps: int = 4,
+    hold_sim_steps: int = 2,
+    joint_ids: list[int] | None = None,
+    on_trajectory_step: Callable[[int, int], None] | None = None,
+    look_at: tuple[Sequence[float], Sequence[float], Sequence[float]] | None = None,
+    record: bool = True,
+) -> None:
+    """Replay a trajectory, optionally record it, and hold its final pose.
+
+    Args:
+        sim: Simulation manager to step and record.
+        robot: Robot receiving full-DOF trajectory positions.
+        trajectory: Full robot trajectory with shape ``(n_envs, n_steps, dof)``.
+        args: Parsed tutorial arguments controlling auto-play recording.
+        video_prefix: Output video filename prefix.
+        hold_steps: Number of final-pose simulation updates after the trajectory.
+        trajectory_sim_steps: Physics steps for each trajectory waypoint.
+        hold_sim_steps: Physics steps for each final-pose update.
+        joint_ids: Optional joint IDs when controlling a robot subset.
+        on_trajectory_step: Optional callback run after each trajectory update.
+        look_at: Optional recorder camera pose for auto-play videos.
+        record: Whether to start auto-play recording for this replay.
+    """
+    recording_started = (
+        start_auto_play_recording(
+            sim,
+            args,
+            video_prefix=video_prefix,
+            look_at=DEFAULT_AUTO_PLAY_LOOK_AT if look_at is None else look_at,
+        )
+        if record
+        else False
+    )
+    try:
+        total_steps = trajectory.shape[1]
+        for step_idx in range(total_steps):
+            if joint_ids is None:
+                robot.set_qpos(trajectory[:, step_idx, :])
+            else:
+                robot.set_qpos(trajectory[:, step_idx, :], joint_ids=joint_ids)
+            sim.update(step=trajectory_sim_steps)
+            if on_trajectory_step is not None:
+                on_trajectory_step(step_idx, total_steps)
+            time.sleep(1e-2)
+
+        final_qpos = trajectory[:, -1, :]
+        for _ in range(hold_steps):
+            if joint_ids is None:
+                robot.set_qpos(final_qpos)
+            else:
+                robot.set_qpos(final_qpos, joint_ids=joint_ids)
+            sim.update(step=hold_sim_steps)
+            time.sleep(1e-2)
+    finally:
+        stop_auto_play_recording(sim, recording_started)
 
 
 def get_tutorial_window_size(args: argparse.Namespace) -> tuple[int, int]:
@@ -286,15 +630,29 @@ __all__ = [
     "DEFAULT_AUTO_PLAY_LOOK_AT",
     "DEFAULT_AXIS_LEN",
     "DEFAULT_AXIS_SIZE",
+    "DEFAULT_GRIPPER_CLOSE_QPOS",
+    "DEFAULT_TUTORIAL_LIGHT_POS",
     "GRIPPER_HAND_JOINT_PATTERN",
     "GRIPPER_TCP_Z",
     "GRIPPER_URDF_PATH",
+    "TOP_DOWN_EEF_ROTATION",
+    "add_ur5_gripper_robot",
     "broadcast_pose_batch",
     "broadcast_waypoint_pose_batch",
     "clone_local_pose_from_first_env",
+    "create_antipodal_semantics",
+    "create_toppra_motion_generator",
+    "create_tutorial_simulation",
     "create_ur5_gripper_robot_cfg",
+    "format_tensor",
+    "get_hand_open_close_qpos",
+    "initialize_pre_pick_robot_pose",
     "make_ur5_solver_cfg",
+    "make_eef_pose_at",
+    "make_top_down_eef_pose",
     "get_tutorial_window_size",
+    "prepare_tutorial_scene",
+    "replay_trajectory",
     "should_open_tutorial_window",
     "should_wait_for_tutorial_input",
     "start_auto_play_recording",

--- a/tests/sim/atomic_actions/test_actions.py
+++ b/tests/sim/atomic_actions/test_actions.py
@@ -441,6 +441,47 @@ class TestPickUpAction:
         assert isinstance(result.next_state.held_object, HeldObjectState)
         assert result.next_state.held_object.semantics is sem
 
+    def test_execute_accepts_an_explicit_grasp_pose(self):
+        action = PickUp(
+            self.mg,
+            PickUpCfg(
+                hand_open_qpos=_hand_open(),
+                hand_close_qpos=_hand_close(),
+                sample_interval=12,
+                hand_interp_steps=4,
+            ),
+        )
+        entity = Mock()
+        entity.get_local_pose.return_value = (
+            torch.eye(4).unsqueeze(0).repeat(NUM_ENVS, 1, 1)
+        )
+        affordance = Mock()
+        grasp_xpos = torch.eye(4)
+
+        with patch(
+            "embodichain.lab.sim.atomic_actions.trajectory.interpolate_with_distance",
+            return_value=torch.zeros(NUM_ENVS, 4, ARM_DOF),
+        ):
+            result = action.execute(
+                GraspTarget(
+                    semantics=ObjectSemantics(
+                        affordance=affordance,
+                        geometry={},
+                        entity=entity,
+                    ),
+                    grasp_xpos=grasp_xpos,
+                ),
+                WorldState(last_qpos=torch.zeros(NUM_ENVS, TOTAL_DOF)),
+            )
+
+        assert result.success.all()
+        assert result.next_state.held_object is not None
+        assert torch.allclose(
+            result.next_state.held_object.grasp_xpos,
+            grasp_xpos.unsqueeze(0).repeat(NUM_ENVS, 1, 1),
+        )
+        affordance.get_valid_grasp_poses.assert_not_called()
+
     def test_execute_chooses_symmetric_grasp_variant_closest_to_start_pose(self):
         cfg = PickUpCfg(
             hand_open_qpos=_hand_open(),

--- a/tests/sim/atomic_actions/test_tutorial_utils.py
+++ b/tests/sim/atomic_actions/test_tutorial_utils.py
@@ -28,6 +28,7 @@ from scripts.tutorials.atomic_action.tutorial_utils import (
     broadcast_pose_batch,
     broadcast_waypoint_pose_batch,
     clone_local_pose_from_first_env,
+    create_antipodal_semantics,
     should_wait_for_tutorial_input,
 )
 
@@ -112,6 +113,29 @@ def test_clone_local_pose_from_first_env_sets_shared_pose() -> None:
     assert torch.allclose(shared, expected)
     entity.set_local_pose.assert_called_once()
     assert torch.allclose(entity.set_local_pose.call_args.args[0], expected)
+
+
+def test_create_antipodal_semantics_keeps_mesh_data_on_affordance() -> None:
+    vertices = torch.tensor([[0.0, 0.0, 0.0], [0.1, 0.0, 0.0]])
+    triangles = torch.tensor([[0, 1, 1]])
+    obj = MagicMock()
+    obj.get_vertices.return_value = vertices.unsqueeze(0)
+    obj.get_triangles.return_value = triangles.unsqueeze(0)
+
+    semantics = create_antipodal_semantics(
+        obj,
+        label="cube",
+        n_sample=64,
+        force_reannotate=True,
+    )
+
+    assert semantics.entity is obj
+    assert semantics.label == "cube"
+    assert semantics.geometry == {}
+    assert torch.equal(semantics.affordance.mesh_vertices, vertices)
+    assert torch.equal(semantics.affordance.mesh_triangles, triangles)
+    assert semantics.affordance.force_reannotate is True
+    assert semantics.affordance.generator_cfg.antipodal_sampler_cfg.n_sample == 64
 
 
 def test_broadcast_pose_batch_rejects_wrong_env_count() -> None:


### PR DESCRIPTION
## Description

This PR simplifies the atomic-action tutorials while preserving the action configuration and typed-target flow that the examples are intended to teach.

It adds an optional explicit TCP grasp pose to `GraspTarget`, allowing `PickUp` to consume geometry- or perception-selected grasps without duplicating pickup trajectory construction. Shared tutorial setup, antipodal semantics, recording, and replay helpers remove repeated simulation boilerplate. The coordinated demos now execute through `AtomicActionEngine`, and coordinated placement reuses `PickUp` instead of a tutorial-local planner.

Dependencies: None.
Issue reference: N/A.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which improves an existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (existing functionality will not work without user modification)
- [ ] Documentation update

## Screenshots

Headless `--auto_play` runs generated MP4 recordings for all eight atomic-action tutorials.

## Checklist

- [x] I have run Black formatting checks.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove the explicit-grasp and tutorial-helper changes work.
- [x] Dependencies have not changed.