### PR TITLE
Improve resource-aware test execution

### DIFF
--- a/.agents/skills/add-test/SKILL.md
+++ b/.agents/skills/add-test/SKILL.md
@@ -105,9 +105,11 @@ class TestMySimComponent:
 Use the narrowest test type that proves the behavior:
 
 - Prefer mocks or CPU-only inputs for pure logic and shape validation.
-- Mark a test `@pytest.mark.gpu` only when it executes CUDA code or validates a CUDA-specific contract.
-- Mark long end-to-end tests `@pytest.mark.slow`.
-- Mark explicit real-simulation integration tests `@pytest.mark.requires_sim` when the module does not import `SimulationManager` at module scope.
+- `tests/conftest.py` automatically classifies conventional CUDA, renderer, and
+  real-simulation tests. Add `@pytest.mark.gpu`, `@pytest.mark.slow`, or
+  `@pytest.mark.requires_sim` explicitly only when the test's node id/source
+  cannot reveal that requirement (for example, a hidden CUDA helper or an
+  end-to-end toolkit test).
 
 GPU tests are skipped by default to keep normal test runs within the shared VRAM budget. Run them explicitly and serially:
 

--- a/.agents/skills/add-test/SKILL.md
+++ b/.agents/skills/add-test/SKILL.md
@@ -111,14 +111,15 @@ Use the narrowest test type that proves the behavior:
   cannot reveal that requirement (for example, a hidden CUDA helper or an
   end-to-end toolkit test).
 
-GPU tests are skipped by default to keep normal test runs within the shared VRAM budget. Run them explicitly and serially:
+The full suite includes GPU tests by default. Use a marker expression only when
+you intentionally need a lower-resource local run:
 
 ```bash
-# Default suite: GPU-marked tests are skipped.
+# Full suite, including GPU tests.
 pytest tests/
 
-# Dedicated GPU suite. Do not add -n unless pytest-xdist is installed.
-pytest tests/ --run-gpu -m gpu
+# Optional lower-resource local suite.
+pytest tests/ -m "not gpu"
 ```
 
 For backend/device matrices, run the complete contract on one representative
@@ -227,7 +228,7 @@ pytest tests/<subpath>/test_<module>.py -v
 pytest tests/<subpath>/test_<module>.py::test_expected_output -v
 
 # GPU-specific test
-pytest tests/<subpath>/test_<module>.py --run-gpu -m gpu -v
+pytest tests/<subpath>/test_<module>.py -m gpu -v
 
 # Single test class method
 pytest tests/<subpath>/test_<module>.py::TestMyClass::test_basic_behavior -v
@@ -249,7 +250,7 @@ black tests/<subpath>/test_<module>.py
 | `from __future__` | Required after header |
 | Magic numbers | Define as named constants with explanatory comments |
 | Simulation tests | Initialize/teardown in `setup_method`/`teardown_method` |
-| CUDA coverage | Use `@pytest.mark.gpu`; run with `--run-gpu -m gpu` |
+| CUDA coverage | Use `@pytest.mark.gpu`; select it with `-m gpu` when needed |
 | Long integration | Use `@pytest.mark.slow`; keep it out of normal PR runs |
 | Pure-logic tests | Use mock objects, no real sim |
 | `SceneEntityCfg` | Use `MagicMock(uid="...")` in tests |
@@ -273,7 +274,7 @@ black tests/<subpath>/test_<module>.py
 | Action | Command |
 |--------|---------|
 | Run default tests | `pytest tests/` |
-| Run GPU tests | `pytest tests/ --run-gpu -m gpu` |
+| Run GPU tests only | `pytest tests/ -m gpu` |
 | Run single file | `pytest tests/<path>/test_<name>.py -v` |
 | Run single test | `pytest tests/<path>::test_<name> -v` |
 | Run with print output | `pytest -s tests/<path>/test_<name>.py` |

--- a/.agents/skills/add-test/SKILL.md
+++ b/.agents/skills/add-test/SKILL.md
@@ -89,6 +89,7 @@ class TestMySimComponent:
 
     def teardown_method(self):
         self.sim.destroy()
+        SimulationManager.flush_cleanup_queue()
 
     def test_basic_behavior(self):
         result = self.sim.do_something()
@@ -98,6 +99,30 @@ class TestMySimComponent:
         with pytest.raises(ValueError):
             self.sim.do_something(bad_input)
 ```
+
+## Resource-Aware Test Classification
+
+Use the narrowest test type that proves the behavior:
+
+- Prefer mocks or CPU-only inputs for pure logic and shape validation.
+- Mark a test `@pytest.mark.gpu` only when it executes CUDA code or validates a CUDA-specific contract.
+- Mark long end-to-end tests `@pytest.mark.slow`.
+- Mark explicit real-simulation integration tests `@pytest.mark.requires_sim` when the module does not import `SimulationManager` at module scope.
+
+GPU tests are skipped by default to keep normal test runs within the shared VRAM budget. Run them explicitly and serially:
+
+```bash
+# Default suite: GPU-marked tests are skipped.
+pytest tests/
+
+# Dedicated GPU suite. Do not add -n unless pytest-xdist is installed.
+pytest tests/ --run-gpu -m gpu
+```
+
+For backend/device matrices, run the complete contract on one representative
+configuration and use small (one environment, low-resolution) smoke tests for
+the remaining configurations. Always destroy a real `SimulationManager` and
+flush its cleanup queue in teardown.
 
 ## Mocking Patterns for Functor Tests
 
@@ -199,6 +224,9 @@ pytest tests/<subpath>/test_<module>.py -v
 # Single test function
 pytest tests/<subpath>/test_<module>.py::test_expected_output -v
 
+# GPU-specific test
+pytest tests/<subpath>/test_<module>.py --run-gpu -m gpu -v
+
 # Single test class method
 pytest tests/<subpath>/test_<module>.py::TestMyClass::test_basic_behavior -v
 ```
@@ -219,6 +247,8 @@ black tests/<subpath>/test_<module>.py
 | `from __future__` | Required after header |
 | Magic numbers | Define as named constants with explanatory comments |
 | Simulation tests | Initialize/teardown in `setup_method`/`teardown_method` |
+| CUDA coverage | Use `@pytest.mark.gpu`; run with `--run-gpu -m gpu` |
+| Long integration | Use `@pytest.mark.slow`; keep it out of normal PR runs |
 | Pure-logic tests | Use mock objects, no real sim |
 | `SceneEntityCfg` | Use `MagicMock(uid="...")` in tests |
 | Assertions | `assert`, `pytest.approx`, `torch.allclose`, `pytest.raises` |
@@ -232,14 +262,16 @@ black tests/<subpath>/test_<module>.py
 | Using real `SimulationManager` for functor tests | Use `MockEnv`/`MockSim` — much faster, no GPU needed |
 | Hardcoded numbers without explanation | Define as `EXPECTED_DISTANCE = 0.5  # cube at origin, target at (0.5, 0, 0)` |
 | Testing multiple concepts in one function | Split into separate `test_<scenario>` functions |
-| Forgetting `teardown_method` | Always call `self.sim.destroy()` in teardown |
+| Forgetting cleanup | Call `self.sim.destroy()` and `SimulationManager.flush_cleanup_queue()` in teardown |
+| Using full matrices | Use one full representative case and low-resource smoke coverage elsewhere |
 | Not running `black` on test file | CI checks all files including tests |
 
 ## Quick Reference
 
 | Action | Command |
 |--------|---------|
-| Run all tests | `pytest tests/` |
+| Run default tests | `pytest tests/` |
+| Run GPU tests | `pytest tests/ --run-gpu -m gpu` |
 | Run single file | `pytest tests/<path>/test_<name>.py -v` |
 | Run single test | `pytest tests/<path>::test_<name> -v` |
 | Run with print output | `pytest -s tests/<path>/test_<name>.py` |

--- a/.agents/skills/add-test/SKILL.md
+++ b/.agents/skills/add-test/SKILL.md
@@ -111,15 +111,14 @@ Use the narrowest test type that proves the behavior:
   cannot reveal that requirement (for example, a hidden CUDA helper or an
   end-to-end toolkit test).
 
-The full suite includes GPU tests by default. Use a marker expression only when
-you intentionally need a lower-resource local run:
+GPU tests are skipped by default to keep normal test runs within the shared VRAM budget. Run them explicitly and serially:
 
 ```bash
-# Full suite, including GPU tests.
+# Default suite: GPU-marked tests are skipped.
 pytest tests/
 
-# Optional lower-resource local suite.
-pytest tests/ -m "not gpu"
+# Dedicated GPU suite. Do not add -n unless pytest-xdist is installed.
+pytest tests/ --run-gpu -m gpu
 ```
 
 For backend/device matrices, run the complete contract on one representative
@@ -228,7 +227,7 @@ pytest tests/<subpath>/test_<module>.py -v
 pytest tests/<subpath>/test_<module>.py::test_expected_output -v
 
 # GPU-specific test
-pytest tests/<subpath>/test_<module>.py -m gpu -v
+pytest tests/<subpath>/test_<module>.py --run-gpu -m gpu -v
 
 # Single test class method
 pytest tests/<subpath>/test_<module>.py::TestMyClass::test_basic_behavior -v
@@ -250,7 +249,7 @@ black tests/<subpath>/test_<module>.py
 | `from __future__` | Required after header |
 | Magic numbers | Define as named constants with explanatory comments |
 | Simulation tests | Initialize/teardown in `setup_method`/`teardown_method` |
-| CUDA coverage | Use `@pytest.mark.gpu`; select it with `-m gpu` when needed |
+| CUDA coverage | Use `@pytest.mark.gpu`; run with `--run-gpu -m gpu` |
 | Long integration | Use `@pytest.mark.slow`; keep it out of normal PR runs |
 | Pure-logic tests | Use mock objects, no real sim |
 | `SceneEntityCfg` | Use `MagicMock(uid="...")` in tests |
@@ -274,7 +273,7 @@ black tests/<subpath>/test_<module>.py
 | Action | Command |
 |--------|---------|
 | Run default tests | `pytest tests/` |
-| Run GPU tests only | `pytest tests/ -m gpu` |
+| Run GPU tests | `pytest tests/ --run-gpu -m gpu` |
 | Run single file | `pytest tests/<path>/test_<name>.py -v` |
 | Run single test | `pytest tests/<path>::test_<name> -v` |
 | Run with print output | `pytest -s tests/<path>/test_<name>.py` |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -164,18 +164,12 @@ jobs:
             --extra-index-url https://download.blender.org/pypi/
           pip install pytest-xdist
 
-      - name: Run default tests
+      - name: Run full test suite
         run: |
-          echo "Default test suite (GPU-marked tests are skipped)"
+          echo "Full test suite, including GPU-marked tests"
           export HF_ENDPOINT=https://hf-mirror.com
           pytest tests/docs -q --confcutdir=tests/docs
           pytest tests
-
-      - name: Run GPU tests serially
-        run: |
-          echo "Dedicated GPU test suite"
-          export HF_ENDPOINT=https://hf-mirror.com
-          pytest tests --run-gpu -m gpu
 
   release-build:
     if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -164,12 +164,18 @@ jobs:
             --extra-index-url https://download.blender.org/pypi/
           pip install pytest-xdist
 
-      - name: Run full test suite
+      - name: Run default tests
         run: |
-          echo "Full test suite, including GPU-marked tests"
+          echo "Default test suite (GPU-marked tests are skipped)"
           export HF_ENDPOINT=https://hf-mirror.com
           pytest tests/docs -q --confcutdir=tests/docs
           pytest tests
+
+      - name: Run GPU tests serially
+        run: |
+          echo "Dedicated GPU test suite"
+          export HF_ENDPOINT=https://hf-mirror.com
+          pytest tests --run-gpu -m gpu
 
   release-build:
     if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -156,16 +156,26 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/activate-conda
-      - name: Run tests
+      - name: Install test package
         run: |
           pip install -e ".[gensim]" \
             --extra-index-url http://pyp.open3dv.site:2345/simple/ \
             --trusted-host pyp.open3dv.site \
             --extra-index-url https://download.blender.org/pypi/
-          echo "Unit test Start"
+          pip install pytest-xdist
+
+      - name: Run default tests
+        run: |
+          echo "Default test suite (GPU-marked tests are skipped)"
           export HF_ENDPOINT=https://hf-mirror.com
           pytest tests/docs -q --confcutdir=tests/docs
           pytest tests
+
+      - name: Run GPU tests serially
+        run: |
+          echo "Dedicated GPU test suite"
+          export HF_ENDPOINT=https://hf-mirror.com
+          pytest tests --run-gpu -m gpu
 
   release-build:
     if: startsWith(github.ref, 'refs/tags/v')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,4 +77,6 @@ exclude = ["docs"]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "requires_sim: marks tests that require a real simulation backend",
+    "gpu: marks tests that execute CUDA/GPU code (run serially)",
+    "renderer: marks tests that exercise a rendering backend",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,12 @@ def pytest_addoption(parser):
         default="hybrid",
         help="Specify the renderer backend: hybrid, or fast-rt",
     )
+    parser.addoption(
+        "--run-gpu",
+        action="store_true",
+        default=False,
+        help="Run tests marked gpu; these are skipped by default to limit VRAM use.",
+    )
 
 
 def pytest_configure(config):
@@ -96,6 +102,15 @@ def pytest_collection_modifyitems(config, items):
             "/sensors/" in nodeid or "hybrid" in nodeid or "fastrt" in nodeid
         ):
             item.add_marker(pytest.mark.renderer)
+
+        if item.get_closest_marker("gpu") is not None and not config.getoption(
+            "--run-gpu"
+        ):
+            item.add_marker(
+                pytest.mark.skip(
+                    reason="GPU tests require --run-gpu and should run in a serial job."
+                )
+            )
 
 
 @pytest.fixture(autouse=True, scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,12 +28,6 @@ def pytest_addoption(parser):
         default="hybrid",
         help="Specify the renderer backend: hybrid, or fast-rt",
     )
-    parser.addoption(
-        "--run-gpu",
-        action="store_true",
-        default=False,
-        help="Run tests marked gpu; these are skipped by default to limit VRAM use.",
-    )
 
 
 def pytest_configure(config):
@@ -102,15 +96,6 @@ def pytest_collection_modifyitems(config, items):
             "/sensors/" in nodeid or "hybrid" in nodeid or "fastrt" in nodeid
         ):
             item.add_marker(pytest.mark.renderer)
-
-        if item.get_closest_marker("gpu") is not None and not config.getoption(
-            "--run-gpu"
-        ):
-            item.add_marker(
-                pytest.mark.skip(
-                    reason="GPU tests require --run-gpu and should run in a serial job."
-                )
-            )
 
 
 @pytest.fixture(autouse=True, scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
+import inspect
 import os
 import pytest
 
@@ -26,6 +27,12 @@ def pytest_addoption(parser):
         action="store",
         default="hybrid",
         help="Specify the renderer backend: hybrid, or fast-rt",
+    )
+    parser.addoption(
+        "--run-gpu",
+        action="store_true",
+        default=False,
+        help="Run tests marked gpu; these are skipped by default to limit VRAM use.",
     )
 
 
@@ -42,34 +49,78 @@ def pytest_configure(config):
 
         cfg.DEFAULT_RENDERER = renderer
 
-        # PREVENT IMPLICIT INITIALIZATION BY EXPLICITLY INITIALIZING DEXSIM HERE
-        import dexsim
-        import dexsim.types
+        # DexSim initialization is intentionally deferred to the first real-simulation
+        # test.  Most of the suite consists of pure-Python tests and should not acquire
+        # a CUDA/Vulkan context merely because pytest has started.
 
-        # Map string to dexsim configuration types
-        renderer_map = {
-            "hybrid": dexsim.types.Renderer.HYBRID,
-            "fast-rt": dexsim.types.Renderer.FASTRT,
-        }
-        backend_map = {
-            "hybrid": dexsim.types.Backend.VULKAN,
-            "fast-rt": dexsim.types.Backend.VULKAN,
-        }
 
-        if dexsim.get_world_num() == 0:
-            sim_config = dexsim.WorldConfig()
-            sim_config.renderer = renderer_map.get(
-                renderer, dexsim.types.Renderer.HYBRID
+def _requires_real_sim(item):
+    """Return whether a test module creates a real SimulationManager."""
+    if item.get_closest_marker("requires_sim") is not None:
+        return True
+    module = getattr(item, "module", None)
+    if module is not None and "SimulationManager" in vars(module):
+        return True
+
+    # Some planner regression tests intentionally import the simulation manager
+    # inside the test body to keep their module import lightweight.
+    try:
+        return "SimulationManager" in inspect.getsource(item.obj)
+    except (OSError, TypeError):
+        return False
+
+
+def _initialize_sim_engine(renderer):
+    """Initialize DexSim once, immediately before the first real-sim test."""
+    import dexsim
+    import dexsim.types
+
+    if dexsim.get_world_num() != 0:
+        return
+
+    renderer_map = {
+        "hybrid": dexsim.types.Renderer.HYBRID,
+        "fast-rt": dexsim.types.Renderer.FASTRT,
+    }
+    sim_config = dexsim.WorldConfig()
+    sim_config.renderer = renderer_map[renderer]
+    sim_config.backend = dexsim.types.Backend.VULKAN
+    sim_config.open_windows = False
+    dexsim.init_sim_engine(sim_config)
+
+
+def pytest_collection_modifyitems(config, items):
+    """Classify real-simulation tests for fast and resource-aware test selection."""
+    for item in items:
+        nodeid = item.nodeid.lower()
+        requires_sim = _requires_real_sim(item)
+        if requires_sim:
+            item.add_marker(pytest.mark.requires_sim)
+        if "cuda" in nodeid or "gpu" in nodeid:
+            item.add_marker(pytest.mark.gpu)
+        if requires_sim and (
+            "/sensors/" in nodeid or "hybrid" in nodeid or "fastrt" in nodeid
+        ):
+            item.add_marker(pytest.mark.renderer)
+
+        if item.get_closest_marker("gpu") is not None and not config.getoption(
+            "--run-gpu"
+        ):
+            item.add_marker(
+                pytest.mark.skip(
+                    reason="GPU tests require --run-gpu and should run in a serial job."
+                )
             )
-            sim_config.backend = backend_map.get(renderer, dexsim.types.Backend.VULKAN)
-            sim_config.open_windows = False
-            # This triggers initialization with the correct properties immediately.
-            dexsim.init_sim_engine(sim_config)
 
 
 @pytest.fixture(autouse=True, scope="function")
-def wait_scene_destruction_after_test():
+def wait_scene_destruction_after_test(request):
     """Ensure C++ engine scenes are fully destructed globally after each test exits."""
+    if not _requires_real_sim(request.node):
+        yield
+        return
+
+    _initialize_sim_engine(request.config.getoption("--renderer"))
     yield
 
     # [Improvement - delayed destruction]: top-level dequeue and traceback cleanup.

--- a/tests/gym/action_bank/test_configurable_action.py
+++ b/tests/gym/action_bank/test_configurable_action.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
+from __future__ import annotations
+
 from embodichain.lab.gym.envs.action_bank.configurable_action import (
     ActionBank,
     tag_node,

--- a/tests/gym/envs/test_base_env.py
+++ b/tests/gym/envs/test_base_env.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
+from __future__ import annotations
+
 import os
 import torch
 import pytest

--- a/tests/gym/envs/test_embodied_env.py
+++ b/tests/gym/envs/test_embodied_env.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
+from __future__ import annotations
+
 import os
 import torch
 import pytest

--- a/tests/learning/test_rl.py
+++ b/tests/learning/test_rl.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
+from __future__ import annotations
+
 import os
 import json
 import pytest

--- a/tests/learning/test_rl_distributed.py
+++ b/tests/learning/test_rl_distributed.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
+from __future__ import annotations
+
 import json
 import os
 import subprocess

--- a/tests/sim/objects/test_cloth_object.py
+++ b/tests/sim/objects/test_cloth_object.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
+from __future__ import annotations
+
 import os
 from dexsim.utility.path import get_resources_data_path
 from embodichain.lab.sim import SimulationManager, SimulationManagerCfg

--- a/tests/sim/objects/test_rigid_object.py
+++ b/tests/sim/objects/test_rigid_object.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
+from __future__ import annotations
+
 import os
 import torch
 import pytest

--- a/tests/sim/objects/test_rigid_object_group.py
+++ b/tests/sim/objects/test_rigid_object_group.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
+from __future__ import annotations
+
 import os
 import torch
 import pytest

--- a/tests/sim/objects/test_soft_object.py
+++ b/tests/sim/objects/test_soft_object.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
+from __future__ import annotations
+
 import os
 from dexsim.utility.path import get_resources_data_path
 from embodichain.lab.sim import SimulationManager, SimulationManagerCfg

--- a/tests/sim/objects/test_usd.py
+++ b/tests/sim/objects/test_usd.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
+from __future__ import annotations
+
 import pytest
 import torch
 

--- a/tests/sim/planners/test_motion_generator.py
+++ b/tests/sim/planners/test_motion_generator.py
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ----------------------------------------------------------------------------
+
+from __future__ import annotations
+
 import time
 import torch
 import pytest

--- a/tests/sim/planners/test_toppra_planner.py
+++ b/tests/sim/planners/test_toppra_planner.py
@@ -5,6 +5,9 @@
 # you may not use this file except in compliance with the License.
 ...
 # ----------------------------------------------------------------------------
+
+from __future__ import annotations
+
 import torch
 import pytest
 import numpy as np

--- a/tests/sim/planners/test_toppra_planner.py
+++ b/tests/sim/planners/test_toppra_planner.py
@@ -3,7 +3,15 @@
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
-...
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # ----------------------------------------------------------------------------
 
 from __future__ import annotations

--- a/tests/sim/sensors/test_camera.py
+++ b/tests/sim/sensors/test_camera.py
@@ -26,29 +26,42 @@ from embodichain.lab.sim.objects import Articulation
 from embodichain.lab.sim.cfg import ArticulationCfg, RenderCfg
 from embodichain.data import get_data_path
 
-NUM_ENVS = 4
+FULL_NUM_ENVS = 4
+FULL_WIDTH = 640
+FULL_HEIGHT = 480
+SMOKE_NUM_ENVS = 1
+SMOKE_WIDTH = 160
+SMOKE_HEIGHT = 120
 ART_PATH = "SlidingBoxDrawer/SlidingBoxDrawer.urdf"
 
 
 class CameraTest:
-    def setup_simulation(self, sim_device, renderer="hybrid"):
+    def setup_simulation(
+        self,
+        sim_device,
+        renderer="hybrid",
+        num_envs=FULL_NUM_ENVS,
+        width=FULL_WIDTH,
+        height=FULL_HEIGHT,
+        enable_auxiliary_data=True,
+    ):
         # Setup SimulationManager
         config = SimulationManagerCfg(
             headless=True,
             sim_device=sim_device,
             render_cfg=RenderCfg(renderer=renderer),
-            num_envs=NUM_ENVS,
+            num_envs=num_envs,
         )
         self.sim = SimulationManager(config)
         # Create batch of cameras
         cfg_dict = {
             "sensor_type": "Camera",
-            "width": 640,
-            "height": 480,
-            "enable_mask": True,
-            "enable_depth": True,
-            "enable_normal": True,
-            "enable_position": True,
+            "width": width,
+            "height": height,
+            "enable_mask": enable_auxiliary_data,
+            "enable_depth": enable_auxiliary_data,
+            "enable_normal": enable_auxiliary_data,
+            "enable_position": enable_auxiliary_data,
         }
         cfg = SensorCfg.from_dict(cfg_dict)
         self.camera: Camera = self.sim.add_sensor(cfg)
@@ -68,25 +81,34 @@ class CameraTest:
             assert key in data, f"Missing key in camera data: {key}"
 
         # Check if the data shape matches the expected shape
-        assert data["color"].shape == (NUM_ENVS, 480, 640, 4), "RGB data shape mismatch"
+        assert data["color"].shape == (
+            FULL_NUM_ENVS,
+            FULL_HEIGHT,
+            FULL_WIDTH,
+            4,
+        ), "RGB data shape mismatch"
         assert data["depth"].shape == (
-            NUM_ENVS,
-            480,
-            640,
+            FULL_NUM_ENVS,
+            FULL_HEIGHT,
+            FULL_WIDTH,
         ), "Depth data shape mismatch"
         assert data["normal"].shape == (
-            NUM_ENVS,
-            480,
-            640,
+            FULL_NUM_ENVS,
+            FULL_HEIGHT,
+            FULL_WIDTH,
             3,
         ), "Normal data shape mismatch"
         assert data["position"].shape == (
-            NUM_ENVS,
-            480,
-            640,
+            FULL_NUM_ENVS,
+            FULL_HEIGHT,
+            FULL_WIDTH,
             3,
         ), "Position data shape mismatch"
-        assert data["mask"].shape == (NUM_ENVS, 480, 640), "Mask data shape mismatch"
+        assert data["mask"].shape == (
+            FULL_NUM_ENVS,
+            FULL_HEIGHT,
+            FULL_WIDTH,
+        ), "Mask data shape mismatch"
 
         # Check if the data types are correct
         assert data["color"].dtype == torch.uint8, "Color data type mismatch"
@@ -131,7 +153,7 @@ class CameraTest:
                 device=self.sim.device,
             )
             .unsqueeze(0)
-            .repeat(NUM_ENVS, 1)
+            .repeat(FULL_NUM_ENVS, 1)
         )
 
         # Set new intrinsic parameters for all environments
@@ -155,30 +177,36 @@ class CameraTest:
         gc.collect()
 
 
-class TestCameraHybrid(CameraTest):
-    def setup_method(self):
-
-        self.setup_simulation("cpu", renderer="hybrid")
-
-
 class TestCameraHybridCUDA(CameraTest):
     def setup_method(self):
 
         self.setup_simulation("cuda", renderer="hybrid")
 
 
-class TestCameraFastRT(CameraTest):
-    def setup_method(self):
-        self.setup_simulation("cpu", renderer="fast-rt")
-
-
-class TestCameraFastRTCUDA(CameraTest):
-    def setup_method(self):
-
-        self.setup_simulation("cuda", renderer="fast-rt")
+@pytest.mark.parametrize(
+    ("sim_device", "renderer"),
+    [("cpu", "hybrid"), ("cpu", "fast-rt"), ("cuda", "fast-rt")],
+)
+def test_camera_backend_smoke(sim_device, renderer):
+    """Check that each remaining backend/device pair renders a color frame."""
+    test = CameraTest()
+    test.setup_simulation(
+        sim_device,
+        renderer,
+        num_envs=SMOKE_NUM_ENVS,
+        width=SMOKE_WIDTH,
+        height=SMOKE_HEIGHT,
+        enable_auxiliary_data=False,
+    )
+    try:
+        test.camera.update()
+        data = test.camera.get_data()
+        assert data["color"].shape == (SMOKE_NUM_ENVS, SMOKE_HEIGHT, SMOKE_WIDTH, 4)
+    finally:
+        test.teardown_method()
 
 
 if __name__ == "__main__":
-    test = TestCameraFastRT()
+    test = TestCameraHybridCUDA()
     test.setup_method()
     test.test_attach_to_parent()

--- a/tests/sim/sensors/test_camera.py
+++ b/tests/sim/sensors/test_camera.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------,
 
+from __future__ import annotations
+
 import pytest
 import torch
 import os

--- a/tests/sim/sensors/test_contact.py
+++ b/tests/sim/sensors/test_contact.py
@@ -36,13 +36,15 @@ from embodichain.lab.sim.objects import RigidObject, RigidObjectCfg, Robot
 from embodichain.lab.sim.robots import URRobotCfg
 
 NUM_ENVS = 4
+CONTACT_TEST_WIDTH = 320
+CONTACT_TEST_HEIGHT = 240
 
 
 class ContactTest:
     def setup_simulation(self, sim_device, renderer="hybrid"):
         sim_cfg = SimulationManagerCfg(
-            width=1920,
-            height=1080,
+            width=CONTACT_TEST_WIDTH,
+            height=CONTACT_TEST_HEIGHT,
             num_envs=2,
             headless=True,
             physics_dt=1.0 / 100.0,  # Physics timestep (100 Hz)

--- a/tests/sim/sensors/test_contact.py
+++ b/tests/sim/sensors/test_contact.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------,
 
+from __future__ import annotations
+
 import pytest
 import torch
 from embodichain.lab.sim import SimulationManager, SimulationManagerCfg

--- a/tests/sim/sensors/test_stereo.py
+++ b/tests/sim/sensors/test_stereo.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------,
 
+from __future__ import annotations
+
 import pytest
 import torch
 

--- a/tests/sim/sensors/test_stereo.py
+++ b/tests/sim/sensors/test_stereo.py
@@ -22,28 +22,39 @@ from embodichain.lab.sim import SimulationManager, SimulationManagerCfg
 from embodichain.lab.sim.sensors import StereoCamera, SensorCfg
 
 NUM_ENVS = 4
+SMOKE_NUM_ENVS = 1
+SMOKE_WIDTH = 160
+SMOKE_HEIGHT = 120
 
 
 class StereoCameraTest:
-    def setup_simulation(self, sim_device, renderer="hybrid"):
+    def setup_simulation(
+        self,
+        sim_device,
+        renderer="hybrid",
+        num_envs=NUM_ENVS,
+        width=640,
+        height=480,
+        enable_auxiliary_data=True,
+    ):
         # Setup SimulationManager
         config = SimulationManagerCfg(
             headless=True,
             sim_device=sim_device,
-            num_envs=NUM_ENVS,
+            num_envs=num_envs,
             render_cfg=RenderCfg(renderer=renderer),
         )
         self.sim = SimulationManager(config)
         # Create batch of cameras
         cfg_dict = {
             "sensor_type": "StereoCamera",
-            "width": 640,
-            "height": 480,
-            "enable_mask": True,
-            "enable_depth": True,
-            "enable_normal": True,
-            "enable_position": True,
-            "enable_disparity": True,
+            "width": width,
+            "height": height,
+            "enable_mask": enable_auxiliary_data,
+            "enable_depth": enable_auxiliary_data,
+            "enable_normal": enable_auxiliary_data,
+            "enable_position": enable_auxiliary_data,
+            "enable_disparity": enable_auxiliary_data,
             "left_to_right_pos": (0.1, 0.0, 0.0),
         }
         cfg = SensorCfg.from_dict(cfg_dict)
@@ -158,25 +169,30 @@ class StereoCameraTest:
         gc.collect()
 
 
-class TestStereoCameraHybrid(StereoCameraTest):
-    def setup_method(self):
-
-        self.setup_simulation("cpu", renderer="hybrid")
-
-
 class TestStereoCameraHybridCUDA(StereoCameraTest):
     def setup_method(self):
 
         self.setup_simulation("cuda", renderer="hybrid")
 
 
-class TestStereoCameraFastRT(StereoCameraTest):
-    def setup_method(self):
-
-        self.setup_simulation("cpu", renderer="fast-rt")
-
-
-class TestStereoCameraFastRTCUDA(StereoCameraTest):
-    def setup_method(self):
-
-        self.setup_simulation("cuda", renderer="fast-rt")
+@pytest.mark.parametrize(
+    ("sim_device", "renderer"),
+    [("cpu", "hybrid"), ("cpu", "fast-rt"), ("cuda", "fast-rt")],
+)
+def test_stereo_camera_backend_smoke(sim_device, renderer):
+    """Check that each remaining backend/device pair renders a color frame."""
+    test = StereoCameraTest()
+    test.setup_simulation(
+        sim_device,
+        renderer,
+        num_envs=SMOKE_NUM_ENVS,
+        width=SMOKE_WIDTH,
+        height=SMOKE_HEIGHT,
+        enable_auxiliary_data=False,
+    )
+    try:
+        test.camera.update()
+        data = test.camera.get_data()
+        assert data["color"].shape == (SMOKE_NUM_ENVS, SMOKE_HEIGHT, SMOKE_WIDTH, 4)
+    finally:
+        test.teardown_method()

--- a/tests/sim/solvers/test_differential_solver.py
+++ b/tests/sim/solvers/test_differential_solver.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
+from __future__ import annotations
+
 import os
 import torch
 import pytest
@@ -122,6 +124,7 @@ class BaseSolverTest:
     def teardown_method(self):
         """Clean up resources after each test method."""
         self.sim.destroy()
+        SimulationManager.flush_cleanup_queue()
 
 
 class TestDifferentialSolver(BaseSolverTest):

--- a/tests/sim/solvers/test_neural_ik_solver.py
+++ b/tests/sim/solvers/test_neural_ik_solver.py
@@ -73,21 +73,13 @@ class TestNeuralIKSolver:
         cfg_dict = {
             "fpath": urdf,
             "control_parts": {
-                "main_arm": [
-                    "Joint1",
-                    "Joint2",
-                    "Joint3",
-                    "Joint4",
-                    "Joint5",
-                    "Joint6",
-                    "Joint7",
-                ],
+                "main_arm": [f"fr3_joint{index}" for index in range(1, 8)],
             },
             "solver_cfg": {
                 "main_arm": {
                     "class_type": "NeuralIKSolver",
-                    "end_link_name": "ee_link",
-                    "root_link_name": "base_link",
+                    "end_link_name": "fr3_hand_tcp",
+                    "root_link_name": "base",
                     "tcp": TCP,
                     "checkpoint_path": checkpoint_path,
                     "num_arm_joints": NUM_ARM_JOINTS,
@@ -100,12 +92,15 @@ class TestNeuralIKSolver:
             },
         }
 
-        self.robot: Robot = self.sim.add_robot(cfg=RobotCfg.from_dict(cfg_dict))
+        self.robot = self.sim.add_robot(cfg=RobotCfg.from_dict(cfg_dict))
         self.sim.update(step=100)
 
     def teardown_method(self):
         if self.sim is not None:
             self.sim.destroy()
+            SimulationManager.flush_cleanup_queue()
+        self.sim = None
+        self.robot = None
 
     def _make_solver_input(self):
         """Create a standard qpos and its FK target for solver tests."""

--- a/tests/sim/solvers/test_opw_solver.py
+++ b/tests/sim/solvers/test_opw_solver.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
+from __future__ import annotations
+
 import torch
 import pytest
 import numpy as np
@@ -189,6 +191,7 @@ class BaseSolverTest:
     def teardown_method(self):
         """Clean up resources after each test method."""
         self.sim.destroy()
+        SimulationManager.flush_cleanup_queue()
 
 
 class TestOPWSolver(BaseSolverTest):

--- a/tests/sim/solvers/test_pink_solver.py
+++ b/tests/sim/solvers/test_pink_solver.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
+from __future__ import annotations
+
 import os
 import torch
 import pytest
@@ -126,6 +128,7 @@ class BaseSolverTest:
     def teardown_method(self):
         """Clean up resources after each test method."""
         self.sim.destroy()
+        SimulationManager.flush_cleanup_queue()
 
 
 @pytest.mark.skip(reason="Skipping Pink tests temporarily")

--- a/tests/sim/solvers/test_pinocchio_solver.py
+++ b/tests/sim/solvers/test_pinocchio_solver.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
+from __future__ import annotations
+
 import os
 import torch
 import pytest
@@ -107,6 +109,7 @@ class BaseSolverTest:
     def teardown_method(self):
         """Clean up resources after each test method."""
         self.sim.destroy()
+        SimulationManager.flush_cleanup_queue()
 
 
 class TestPinocchioSolver(BaseSolverTest):

--- a/tests/sim/solvers/test_pytorch_solver.py
+++ b/tests/sim/solvers/test_pytorch_solver.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
+from __future__ import annotations
+
 import os
 import torch
 import pytest
@@ -171,6 +173,7 @@ class BaseSolverTest:
     def teardown_method(self):
         """Clean up resources after each test method."""
         self.sim.destroy()
+        SimulationManager.flush_cleanup_queue()
 
 
 class TestPytorchSolver(BaseSolverTest):

--- a/tests/sim/solvers/test_srs_solver.py
+++ b/tests/sim/solvers/test_srs_solver.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
+from __future__ import annotations
+
 import os
 import torch
 
@@ -343,6 +345,7 @@ class BaseRobotSolverTest:
     def teardown_method(self):
         """Clean up resources after each test method."""
         self.sim.destroy()
+        SimulationManager.flush_cleanup_queue()
 
 
 class TestSRSCPUSolver(BaseSolverTest):

--- a/tests/sim/solvers/test_ur_solver.py
+++ b/tests/sim/solvers/test_ur_solver.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
+from __future__ import annotations
+
 import torch
 import pytest
 import numpy as np
@@ -189,6 +191,7 @@ class BaseSolverTest:
     def teardown_method(self):
         """Clean up resources after each test method."""
         self.sim.destroy()
+        SimulationManager.flush_cleanup_queue()
 
 
 class TestURSolverCUDA(BaseSolverTest):

--- a/tests/sim/utility/test_workspace_analyze.py
+++ b/tests/sim/utility/test_workspace_analyze.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
+from __future__ import annotations
+
 import torch
 import pytest
 import numpy as np
@@ -79,6 +81,7 @@ class BaseWorkspaceAnalyzeTest:
     def teardown_method(self):
         """Clean up resources after each test method."""
         self.sim.destroy()
+        SimulationManager.flush_cleanup_queue()
 
 
 class TestJointWorkspaceAnalyzeTest(BaseWorkspaceAnalyzeTest):

--- a/tests/toolkits/test_batch_convex_collision.py
+++ b/tests/toolkits/test_batch_convex_collision.py
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ----------------------------------------------------------------------------
+
+from __future__ import annotations
+
 import torch
 from embodichain.data import get_data_path
 import trimesh

--- a/tests/toolkits/test_grasp_pose_generator.py
+++ b/tests/toolkits/test_grasp_pose_generator.py
@@ -19,6 +19,8 @@ This script demonstrates the creation and simulation of a robot that grasps a ri
 in a simulated environment using the SimulationManager and grasp planning utilities.
 """
 
+from __future__ import annotations
+
 import argparse
 import numpy as np
 import time
@@ -263,6 +265,7 @@ def test_grasp_pose_generator():
         assert grab_traj.shape == torch.Size([1, 200, 8])
     finally:
         sim.destroy()
+        SimulationManager.flush_cleanup_queue()
 
 
 if __name__ == "__main__":

--- a/tests/toolkits/test_grasp_pose_generator.py
+++ b/tests/toolkits/test_grasp_pose_generator.py
@@ -22,6 +22,7 @@ in a simulated environment using the SimulationManager and grasp planning utilit
 import argparse
 import numpy as np
 import time
+import pytest
 import torch
 
 from embodichain.lab.sim import SimulationManager, SimulationManagerCfg
@@ -196,66 +197,72 @@ def get_grasp_traj(sim: SimulationManager, robot: Robot, grasp_xpos: torch.Tenso
     return interp_trajectory
 
 
+@pytest.mark.requires_sim
+@pytest.mark.gpu
+@pytest.mark.slow
 def test_grasp_pose_generator():
 
     sim = initialize_simulation()
-    robot = create_robot(sim, position=[0.0, 0.0, 0.0])
-    mug = create_mug(sim)
+    try:
+        robot = create_robot(sim, position=[0.0, 0.0, 0.0])
+        mug = create_mug(sim)
 
-    # get mug grasp pose
-    grasp_cfg = GraspGeneratorCfg(
-        viser_port=11801,
-        antipodal_sampler_cfg=AntipodalSamplerCfg(
-            n_sample=10000, max_length=0.088, min_length=0.003
-        ),
-        is_partial_annotate=False,
-        is_filter_ground_collision=True,
-        n_top_grasps=30,
-    )
-
-    gripper_collision_cfg = GripperCollisionCfg(
-        max_open_length=0.088, finger_length=0.078, point_sample_dense=0.012
-    )
-
-    vertices = mug.get_vertices(env_ids=[0], scale=True)[0]
-    triangles = mug.get_triangles(env_ids=[0])[0]
-    grasp_generator = GraspGenerator(
-        vertices=vertices,
-        triangles=triangles,
-        cfg=grasp_cfg,
-        gripper_collision_cfg=gripper_collision_cfg,
-    )
-
-    # Annotate grasp region (populates internal antipodal point pairs)
-    grasp_generator.annotate()
-
-    # Compute grasp poses per environment
-    approach_direction = torch.tensor(
-        [0, 0, -1], dtype=torch.float32, device=sim.device
-    )
-    obj_poses = mug.get_local_pose(to_matrix=True)
-    grasp_xpos_list = []
-
-    rest_xpos = robot.compute_fk(
-        qpos=robot.get_qpos("arm"), name="arm", to_matrix=True
-    )[0]
-    for i, obj_pose in enumerate(obj_poses):
-        is_success, grasp_pose, open_length = grasp_generator.get_grasp_poses(
-            obj_pose,
-            approach_direction,
-            visualize_collision=False,
-            visualize_pose=False,
+        # get mug grasp pose
+        grasp_cfg = GraspGeneratorCfg(
+            viser_port=11801,
+            antipodal_sampler_cfg=AntipodalSamplerCfg(
+                n_sample=10000, max_length=0.088, min_length=0.003
+            ),
+            is_partial_annotate=False,
+            is_filter_ground_collision=True,
+            n_top_grasps=30,
         )
-        if is_success:
-            grasp_xpos_list.append(grasp_pose.unsqueeze(0))
-        else:
-            logger.log_warning(f"No valid grasp pose found for {i}-th object.")
-            grasp_xpos_list.append(rest_xpos.unsqueeze(0))
 
-    grasp_xpos = torch.cat(grasp_xpos_list, dim=0)
-    grab_traj = get_grasp_traj(sim, robot, grasp_xpos)
-    assert grasp_xpos.shape == torch.Size([1, 4, 4])
-    assert grab_traj.shape == torch.Size([1, 200, 8])
+        gripper_collision_cfg = GripperCollisionCfg(
+            max_open_length=0.088, finger_length=0.078, point_sample_dense=0.012
+        )
+
+        vertices = mug.get_vertices(env_ids=[0], scale=True)[0]
+        triangles = mug.get_triangles(env_ids=[0])[0]
+        grasp_generator = GraspGenerator(
+            vertices=vertices,
+            triangles=triangles,
+            cfg=grasp_cfg,
+            gripper_collision_cfg=gripper_collision_cfg,
+        )
+
+        # Annotate grasp region (populates internal antipodal point pairs)
+        grasp_generator.annotate()
+
+        # Compute grasp poses per environment
+        approach_direction = torch.tensor(
+            [0, 0, -1], dtype=torch.float32, device=sim.device
+        )
+        obj_poses = mug.get_local_pose(to_matrix=True)
+        grasp_xpos_list = []
+
+        rest_xpos = robot.compute_fk(
+            qpos=robot.get_qpos("arm"), name="arm", to_matrix=True
+        )[0]
+        for i, obj_pose in enumerate(obj_poses):
+            is_success, grasp_pose, open_length = grasp_generator.get_grasp_poses(
+                obj_pose,
+                approach_direction,
+                visualize_collision=False,
+                visualize_pose=False,
+            )
+            if is_success:
+                grasp_xpos_list.append(grasp_pose.unsqueeze(0))
+            else:
+                logger.log_warning(f"No valid grasp pose found for {i}-th object.")
+                grasp_xpos_list.append(rest_xpos.unsqueeze(0))
+
+        grasp_xpos = torch.cat(grasp_xpos_list, dim=0)
+        grab_traj = get_grasp_traj(sim, robot, grasp_xpos)
+        assert grasp_xpos.shape == torch.Size([1, 4, 4])
+        assert grab_traj.shape == torch.Size([1, 200, 8])
+    finally:
+        sim.destroy()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

This PR reduces test-suite GPU pressure by deferring DexSim initialization, separating GPU coverage from the default suite, and reducing redundant sensor backend coverage. It also fixes the Neural IK test fixture for the current Panda URDF.

The CI workflow now installs `pytest-xdist` and runs default and GPU-marked tests in separate sequential steps.

Dependencies: `pytest-xdist` is installed by the CI test job.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which improves an existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (existing functionality will not work without user modification)
- [ ] Documentation update

## Checklist

- [x] I have run the `black .` command to format the code base.
- [x] I have made corresponding changes to the documentation.
- [x] I have added or updated tests that prove the fix is effective.
- [x] Dependencies have been updated, if applicable.

## Validation

- `pytest tests/sim/solvers/test_neural_ik_solver.py -q`
- `pytest tests/sim/sensors/test_camera.py tests/sim/sensors/test_stereo.py tests/sim/sensors/test_contact.py -q`
- `pytest tests/sim/solvers/test_opw_solver.py -q -rs`
- `black --check --diff --color ./`