### PR TITLE
Preserve DexSim world up in window camera capture

### DIFF
--- a/embodichain/lab/sim/sim_manager.py
+++ b/embodichain/lab/sim/sim_manager.py
@@ -2431,9 +2431,10 @@ class SimulationManager:
         """Convert a DexSim window model matrix to look-at vectors.
 
         DexSim stores the viewer camera model matrix with columns
-        ``[right, up, -forward]``. ``Windows.set_look_at`` expects the
-        corresponding world-space look-at vectors, so the conversion is done
-        from the matrix columns rather than by assuming a fixed world axis.
+        ``[right, up, -forward]``. The local camera up axis changes while the
+        viewer orbits, but ``Windows.set_look_at`` uses a world-up reference.
+        Always use DexSim's default Z-up vector so a captured snippet retains
+        the standard viewer controls.
 
         Args:
             pose: A 4x4 homogeneous viewer camera pose matrix.
@@ -2452,7 +2453,7 @@ class SimulationManager:
             )
         eye = matrix[:3, 3]
         look_at = eye - matrix[:3, 2]
-        up = matrix[:3, 1]
+        up = np.array([0.0, 0.0, 1.0], dtype=np.float64)
         return eye, look_at, up
 
     @staticmethod

--- a/tests/sim/test_sim_manager.py
+++ b/tests/sim/test_sim_manager.py
@@ -104,6 +104,18 @@ def _make_sim_manager(window: object | None = None) -> SimulationManager:
     return sim
 
 
+def test_window_camera_pose_to_look_at_uses_dexsim_world_up() -> None:
+    """Captured look-at snippets preserve DexSim's default Z-up controls."""
+    pose = np.eye(4, dtype=np.float32)
+    pose[:3, 3] = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+
+    eye, look_at, up = SimulationManager._window_camera_pose_to_look_at(pose)
+
+    np.testing.assert_allclose(eye, [1.0, 2.0, 3.0])
+    np.testing.assert_allclose(look_at, [1.0, 2.0, 2.0])
+    np.testing.assert_allclose(up, [0.0, 0.0, 1.0])
+
+
 def test_start_window_record_rejects_invalid_parameters() -> None:
     sim = _make_sim_manager()
 


### PR DESCRIPTION
## Description

This PR makes `P`-captured `window.set_look_at(...)` snippets use DexSim's standard world-up vector, `(0, 0, 1)`.

The viewer camera's local Y axis changes during orbit and pitch. Reusing that axis as the `up` argument changed the behavior of the default DexSim window controls. The captured eye position and look-at direction are unchanged.

Dependencies: None

Issue: No linked issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (existing functionality will not work without user modification)
- [ ] Documentation update

## Screenshots

Not applicable.

## Checklist

- [x] I have formatted the modified Python files with `black`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] Dependencies have been updated, if applicable.