### PR TITLE
Improve deterministic stacking task generation

### DIFF
--- a/embodichain/gen_sim/action_agent_pipeline/generation/action_agent_config.py
+++ b/embodichain/gen_sim/action_agent_pipeline/generation/action_agent_config.py
@@ -107,6 +107,7 @@ from embodichain.gen_sim.action_agent_pipeline.generation.config_blocks import (
     _make_dataset_config,
     _make_events_config,
     _make_extra_rigid_object_config,
+    _moved_rigid_object_max_convex_hull_num,
     _make_observations_config,
     _make_relative_dataset_config,
     _make_relative_events_config,
@@ -819,7 +820,11 @@ def _build_arrangement_line_bundle(
                     )
                     or _source_body_scale(obj)
                 ),
-                max_convex_hull_num=(16 if obj.source_uid in moved_source_uids else 1),
+                max_convex_hull_num=(
+                    _moved_rigid_object_max_convex_hull_num(obj)
+                    if obj.source_uid in moved_source_uids
+                    else 1
+                ),
                 mesh_normalizer=mesh_normalizer,
             )
             for obj in dynamic_rigid_objects
@@ -998,7 +1003,11 @@ def _build_stacking_bundle(
                     )
                     or _source_body_scale(obj)
                 ),
-                max_convex_hull_num=(16 if obj.source_uid in moved_source_uids else 1),
+                max_convex_hull_num=(
+                    _moved_rigid_object_max_convex_hull_num(obj)
+                    if obj.source_uid in moved_source_uids
+                    else 1
+                ),
                 mesh_normalizer=mesh_normalizer,
             )
             for obj in dynamic_rigid_objects

--- a/embodichain/gen_sim/action_agent_pipeline/generation/action_agent_config_defaults.yaml
+++ b/embodichain/gen_sim/action_agent_pipeline/generation/action_agent_config_defaults.yaml
@@ -91,11 +91,11 @@ physics:
 grasp:
   antipodal_n_sample: 10000
   antipodal_max_angle_degrees: 15.0
-  max_open_length: 0.14
-  min_open_length: 0.003
+  max_open_length: 0.11
+  min_open_length: 0.02
   finger_length: 0.13
   point_sample_dense: 0.012
-  max_deviation_angle_degrees: 15.0
+  max_deviation_angle_degrees: 20.0
   viser_port: 11801
   coordinated_rod_like_inset_fractions: [0.18, 0.22, 0.26, 0.30]
   coordinated_container_like_inset_fractions: [0.08, 0.12, 0.20, 0.28]

--- a/embodichain/gen_sim/action_agent_pipeline/generation/action_agent_config_defaults.yaml
+++ b/embodichain/gen_sim/action_agent_pipeline/generation/action_agent_config_defaults.yaml
@@ -55,9 +55,10 @@ arrangement:
   movable_initial_overlap_score_weight: 0.01
 
 stacking:
-  staging_z_delta: 0.10
-  clearance: 0.02
-  anchor_offset: 0.15
+  staging_z_delta: 0.05
+  clearance: 0.05
+  anchor_offset: 0.1
+  anchor_clearance_radius: 0.1
 
 action:
   basket_left_release_offset_y: 0.04
@@ -87,6 +88,7 @@ physics:
   convex_hulls:
     target: 32
     container: 32
+    moved: 32
     extra_rigid: 1
 
 grasp:

--- a/embodichain/gen_sim/action_agent_pipeline/generation/action_agent_config_defaults.yaml
+++ b/embodichain/gen_sim/action_agent_pipeline/generation/action_agent_config_defaults.yaml
@@ -57,6 +57,7 @@ arrangement:
 stacking:
   staging_z_delta: 0.10
   clearance: 0.02
+  anchor_offset: 0.15
 
 action:
   basket_left_release_offset_y: 0.04

--- a/embodichain/gen_sim/action_agent_pipeline/generation/config_blocks.py
+++ b/embodichain/gen_sim/action_agent_pipeline/generation/config_blocks.py
@@ -69,6 +69,7 @@ __all__ = [
     "_make_relative_events_config",
     "_make_relative_rigid_object_config",
     "_make_target_object_config",
+    "_moved_rigid_object_max_convex_hull_num",
     "_relative_rigid_object_max_convex_hull_num",
     "_relative_static_background_max_convex_hull_num",
     "_source_body_scale",
@@ -82,6 +83,7 @@ _CONVEX_HULL_DEFAULTS = _PHYSICS_DEFAULTS["convex_hulls"]
 _BACKGROUND_MAX_CONVEX_HULL_NUM = int(_BACKGROUND_DEFAULTS["max_convex_hull_num"])
 _TARGET_MAX_CONVEX_HULL_NUM = int(_CONVEX_HULL_DEFAULTS["target"])
 _CONTAINER_MAX_CONVEX_HULL_NUM = int(_CONVEX_HULL_DEFAULTS["container"])
+_MOVED_MAX_CONVEX_HULL_NUM = int(_CONVEX_HULL_DEFAULTS["moved"])
 _EXTRA_RIGID_MAX_CONVEX_HULL_NUM = int(_CONVEX_HULL_DEFAULTS["extra_rigid"])
 _ROBOT_VIEW_LABEL = "robot_view"
 _AUDIENCE_VIEW_LABEL = "audience_view"
@@ -857,6 +859,11 @@ def _role_limited_max_convex_hull_num(
     if source_max_convex_hull_num is None:
         return role_max_convex_hull_num
     return max(1, min(int(source_max_convex_hull_num), role_max_convex_hull_num))
+
+
+def _moved_rigid_object_max_convex_hull_num(obj: _SceneObject) -> int:
+    """Return the configured convex-decomposition limit for a moved object."""
+    return _role_limited_max_convex_hull_num(obj, _MOVED_MAX_CONVEX_HULL_NUM)
 
 
 def _relative_rigid_object_max_convex_hull_num(

--- a/embodichain/gen_sim/action_agent_pipeline/generation/mesh_bounds.py
+++ b/embodichain/gen_sim/action_agent_pipeline/generation/mesh_bounds.py
@@ -41,6 +41,7 @@ __all__ = [
     "_mesh_config_has_distinct_xy_axis",
     "_mesh_config_world_xy_bounds",
     "_mesh_config_world_xy_center",
+    "_mesh_config_world_xy_axes",
     "_mesh_config_world_xy_extents",
     "_mesh_config_world_z_bounds",
     "_mesh_config_world_zmax",
@@ -198,6 +199,22 @@ def _mesh_config_world_xy_center(
         round((float(mins[0]) + float(maxs[0])) / 2.0, 6),
         round((float(mins[1]) + float(maxs[1])) / 2.0, 6),
     ]
+
+
+def _mesh_config_world_xy_axes(
+    obj_config: Mapping[str, Any],
+) -> tuple[list[float], list[float]]:
+    """Return normalized local X/Y axes projected into the world XY plane."""
+    matrix = _mesh_config_transform_matrix(obj_config)
+    axes = []
+    for column in (0, 1):
+        x_value = float(matrix[0][column])
+        y_value = float(matrix[1][column])
+        norm = math.hypot(x_value, y_value)
+        if norm <= 1e-9:
+            raise ValueError("Object local XY axis has no world XY projection.")
+        axes.append([x_value / norm, y_value / norm])
+    return axes[0], axes[1]
 
 
 def _mesh_config_world_xy_bounds(

--- a/embodichain/gen_sim/action_agent_pipeline/generation/prompt_builders.py
+++ b/embodichain/gen_sim/action_agent_pipeline/generation/prompt_builders.py
@@ -666,7 +666,7 @@ def make_stacking_task_graph(
 
 
 def _stacking_step_edge_count(step: _StackingStepLike) -> int:
-    return 6 if step.orientation_goal == "preserve" else 7
+    return 3 if step.orientation_goal == "preserve" else 7
 
 
 def _stacking_step_edge_blocks(
@@ -689,6 +689,35 @@ def _stacking_step_edge_blocks(
         orientation_goal=step.orientation_goal,
         orientation_axis=step.orientation_axis,
     )
+    if step.orientation_goal == "preserve":
+        return [
+            (
+                f"Pick up `{step.runtime_uid}` for stack layer {step.layer_index}",
+                {
+                    active_slot: _format_pick_up_spec(active_arm, step.runtime_uid),
+                    inactive_slot: None,
+                },
+            ),
+            (
+                f"Place `{step.runtime_uid}` directly at the final stack pose "
+                "without changing orientation",
+                {
+                    active_slot: _format_direct_absolute_place_spec(
+                        active_arm, step.target_position
+                    ),
+                    inactive_slot: None,
+                },
+            ),
+            (
+                f"Return `{active_arm}` to its initial pose",
+                {
+                    active_slot: _format_initial_qpos_spec(
+                        active_arm, sample_interval=30
+                    ),
+                    inactive_slot: None,
+                },
+            ),
+        ]
     blocks = [
         (
             f"Pick up `{step.runtime_uid}` for stack layer {step.layer_index}",
@@ -801,23 +830,11 @@ def _stacking_step_prompt_block(start_edge: int, step: _StackingStepLike) -> str
    - {active_slot}: {_format_pick_up_spec(active_arm, step.runtime_uid)}
    - {inactive_slot}: null
 
-{start_edge + 1}. Move `{step.runtime_uid}` to the high staging pose without changing orientation:
-   - {active_slot}: {high_preserve_spec}
+{start_edge + 1}. Place `{step.runtime_uid}` directly at the final stack pose without changing orientation:
+   - {active_slot}: {_format_direct_absolute_place_spec(active_arm, step.target_position)}
    - {inactive_slot}: null
 
-{start_edge + 2}. Move `{step.runtime_uid}` down to the final stack object pose without changing orientation:
-   - {active_slot}: {release_move_spec}
-   - {inactive_slot}: null
-
-{start_edge + 3}. Release `{step.runtime_uid}` in-place without moving the object pose:
-   - {active_slot}: {_format_release_only_place_spec(active_arm)}
-   - {inactive_slot}: null
-
-{start_edge + 4}. Retreat `{active_arm}` upward after release:
-   - {active_slot}: {_format_empty_hand_retreat_spec(active_arm)}
-   - {inactive_slot}: null
-
-{start_edge + 5}. Return `{active_arm}` to its initial pose:
+{start_edge + 2}. Return `{active_arm}` to its initial pose:
    - {active_slot}: {_format_initial_qpos_spec(active_arm, sample_interval=30)}
    - {inactive_slot}: null"""
     return f"""{start_edge}. Pick up `{step.runtime_uid}` for stack layer {step.layer_index}:
@@ -932,14 +949,8 @@ def _stacking_atom_action_block(step: _StackingStepLike) -> str:
         return f"""Object `{step.runtime_uid}` to stack layer {step.layer_index}:
 - Pick up:
   {_format_pick_up_spec(active_arm, step.runtime_uid)}
-- High staging without orientation change:
-  {_format_pose_absolute_spec(active_arm, step.high_position, sample_interval=45, orientation_goal="preserve", orientation_axis="none")}
-- Final stack object pose without orientation change:
-  {_format_pose_absolute_spec(active_arm, step.target_position, sample_interval=45, orientation_goal="preserve", orientation_axis="none")}
-- Release-only Place:
-  {_format_release_only_place_spec(active_arm)}
-- Empty-hand retreat:
-  {_format_empty_hand_retreat_spec(active_arm)}
+- Direct final Place without orientation change:
+  {_format_direct_absolute_place_spec(active_arm, step.target_position)}
 - Return:
   {_format_initial_qpos_spec(active_arm, sample_interval=30)}"""
     return f"""Object `{step.runtime_uid}` to stack layer {step.layer_index}:
@@ -1022,6 +1033,13 @@ def make_relative_task_prompt(
     release_step_label = _relative_pose_step_label(spec, "release")
     pose_sensitive = _is_pose_sensitive_placement(spec)
     if pose_sensitive:
+        safe_high_spec = _format_high_staging_spec(active_arm, spec)
+        oriented_high_spec = _format_relative_pose_spec(
+            active_arm,
+            spec,
+            pose_kind="high",
+            sample_interval=45,
+        )
         release_move_spec = _format_relative_pose_spec(
             active_arm,
             spec,
@@ -1030,28 +1048,36 @@ def make_relative_task_prompt(
         )
         place_spec = _format_release_only_place_spec(active_arm)
         retreat_spec = _format_empty_hand_retreat_spec(active_arm)
-        edge_count = 5
-        release_instruction = f"""2. Move the held object directly to the {release_step_label} object pose while applying the requested orientation:
+        edge_count = 7
+        release_instruction = f"""2. Move the held object to the high staging pose without changing orientation:
+   - {active_slot}: {safe_high_spec}
+   - {inactive_slot}: null
+
+3. Apply the requested orientation at the high staging pose:
+   - {active_slot}: {oriented_high_spec}
+   - {inactive_slot}: null
+
+4. Move the held object down to the {release_step_label} object pose:
    - {active_slot}: {release_move_spec}
    - {inactive_slot}: null
 
-3. Release the held object in-place without moving the object pose:
+5. Release the held object in-place without moving the object pose:
    - {active_slot}: {place_spec}
    - {inactive_slot}: null
 
-4. Retreat the now-empty end-effector upward:
+6. Retreat the now-empty end-effector upward:
    - {active_slot}: {retreat_spec}
    - {inactive_slot}: null
 
-5. Return the active arm to its initial pose:
+7. Return the active arm to its initial pose:
    - {active_slot}: {initial_spec}
    - {inactive_slot}: null"""
         high_instruction = release_instruction
         release_rule = (
-            "For this pose-sensitive placement, use exactly one `MoveHeldObject` "
-            "to move directly to the final release object pose while applying the "
-            "requested orientation. Do not add staging or intermediate moves. Use "
-            "the exact relative-zero release-only `Place` spec shown below."
+            "For this pose-sensitive placement, lift with preserved orientation, "
+            "apply the requested orientation at the high staging pose, and only "
+            "then move down to the final release pose. Use the exact relative-zero "
+            "release-only `Place` spec shown below."
         )
     else:
         place_spec = _format_direct_relative_place_spec(active_arm, spec)
@@ -1159,8 +1185,27 @@ def _single_relative_graph_steps(
     edge_blocks.extend(
         [
             (
-                f"Move the held object directly to the {release_step_label} object "
-                "pose while applying the requested orientation",
+                "Move the held object to the high staging pose without changing "
+                "orientation",
+                {
+                    active_slot: _format_high_staging_spec(active_arm, spec),
+                    inactive_slot: None,
+                },
+            ),
+            (
+                "Apply the requested orientation at the high staging pose",
+                {
+                    active_slot: _format_relative_pose_spec(
+                        active_arm,
+                        spec,
+                        pose_kind="high",
+                        sample_interval=45,
+                    ),
+                    inactive_slot: None,
+                },
+            ),
+            (
+                f"Move the held object down to the {release_step_label} object pose",
                 {
                     active_slot: _format_relative_pose_spec(
                         active_arm,
@@ -1388,6 +1433,8 @@ def _dual_relative_edge_blocks(
     spec: _RelativeSpecLike,
 ) -> list[tuple[str, Mapping[str, str | None]]]:
     first, second = spec.placements
+    if _uses_serial_dual_sequence(spec):
+        return _serial_relative_edge_blocks(spec)
     first_arm = f"{first.active_side}_arm"
     second_arm = f"{second.active_side}_arm"
     first_slot = f"{first.active_side}_arm_action"
@@ -1417,13 +1464,12 @@ def _dual_relative_edge_blocks(
         second_arm,
         sample_interval=30,
     )
-    serial_upright_sequence = _uses_serial_dual_upright_sequence(spec)
     first_release_edges = _dual_relative_release_edge_blocks(
         placement=first,
         active_arm=first_arm,
         active_slot=first_slot,
         waiting_slot=second_slot,
-        waiting_action=None if serial_upright_sequence else second_close_spec,
+        waiting_action=second_close_spec,
     )
     second_release_edges = _dual_relative_release_edge_blocks(
         placement=second,
@@ -1432,60 +1478,24 @@ def _dual_relative_edge_blocks(
         waiting_slot=first_slot,
         waiting_action=None,
     )
-    edge_blocks = (
-        [
-            (
-                f"Pick up `{first.moved_runtime_uid}` before starting "
-                f"`{second.moved_runtime_uid}`",
-                {
-                    first_slot: first_pick_spec,
-                    second_slot: None,
-                },
-            )
-        ]
-        if serial_upright_sequence
-        else [
-            (
-                "Pick up both moved objects simultaneously",
-                {
-                    first_slot: first_pick_spec,
-                    second_slot: second_pick_spec,
-                },
-            )
-        ]
-    )
-    edge_blocks.extend(first_release_edges)
-    edge_blocks.extend(
+    edge_blocks = [
         (
-            [
-                (
-                    f"Return `{first_arm}` to its initial pose before picking up "
-                    f"`{second.moved_runtime_uid}`",
-                    {
-                        first_slot: first_initial_spec,
-                        second_slot: None,
-                    },
-                ),
-                (
-                    f"Pick up `{second.moved_runtime_uid}` after "
-                    f"`{first.moved_runtime_uid}` is upright",
-                    {
-                        first_slot: None,
-                        second_slot: second_pick_spec,
-                    },
-                ),
-            ]
-            if serial_upright_sequence
-            else [
-                (
-                    f"Return `{first_arm}` to its initial pose while `{second_arm}` "
-                    f"keeps holding `{second.moved_runtime_uid}`",
-                    {
-                        first_slot: first_initial_spec,
-                        second_slot: second_close_spec,
-                    },
-                )
-            ]
+            "Pick up both moved objects simultaneously",
+            {
+                first_slot: first_pick_spec,
+                second_slot: second_pick_spec,
+            },
+        )
+    ]
+    edge_blocks.extend(first_release_edges)
+    edge_blocks.append(
+        (
+            f"Return `{first_arm}` to its initial pose while `{second_arm}` "
+            f"keeps holding `{second.moved_runtime_uid}`",
+            {
+                first_slot: first_initial_spec,
+                second_slot: second_close_spec,
+            },
         )
     )
     edge_blocks.extend(second_release_edges)
@@ -1501,11 +1511,64 @@ def _dual_relative_edge_blocks(
     return edge_blocks
 
 
-def _uses_serial_dual_upright_sequence(spec: _RelativeSpecLike) -> bool:
-    """Return whether both objects must be stood upright one after the other."""
-    return all(
-        getattr(placement, "upright_in_place", False) for placement in spec.placements
+def _uses_serial_dual_sequence(spec: _RelativeSpecLike) -> bool:
+    """Return whether placement dependencies require sequential execution."""
+    first, second = spec.placements
+    return (
+        second.reference_source_uid == first.moved_source_uid
+        or first.active_side == second.active_side
+        or all(
+            getattr(placement, "upright_in_place", False)
+            for placement in spec.placements
+        )
     )
+
+
+def _serial_relative_edge_blocks(
+    spec: _RelativeSpecLike,
+) -> list[tuple[str, Mapping[str, str | None]]]:
+    edge_blocks: list[tuple[str, Mapping[str, str | None]]] = []
+    for placement in spec.placements:
+        active_arm = f"{placement.active_side}_arm"
+        active_slot = f"{placement.active_side}_arm_action"
+        inactive_slot = (
+            "right_arm_action" if placement.active_side == "left" else "left_arm_action"
+        )
+        edge_blocks.append(
+            (
+                f"Pick up `{placement.moved_runtime_uid}`",
+                {
+                    active_slot: _format_pick_up_spec(
+                        active_arm,
+                        placement.moved_runtime_uid,
+                        pickup_upright_direction=placement.pickup_upright_direction,
+                        pickup_rotate_upright=placement.pickup_rotate_upright,
+                    ),
+                    inactive_slot: None,
+                },
+            )
+        )
+        edge_blocks.extend(
+            _dual_relative_release_edge_blocks(
+                placement=placement,
+                active_arm=active_arm,
+                active_slot=active_slot,
+                waiting_slot=inactive_slot,
+                waiting_action=None,
+            )
+        )
+        edge_blocks.append(
+            (
+                f"Return `{active_arm}` to its initial pose",
+                {
+                    active_slot: _format_initial_qpos_spec(
+                        active_arm, sample_interval=30
+                    ),
+                    inactive_slot: None,
+                },
+            )
+        )
+    return edge_blocks
 
 
 def _make_hold_hover_task_prompt(
@@ -1638,8 +1701,29 @@ def _dual_relative_release_edge_blocks(
     if _is_pose_sensitive_placement(placement):
         return [
             (
-                f"Move `{placement.moved_runtime_uid}` directly to the final "
-                "release object pose while applying the requested orientation",
+                f"Move `{placement.moved_runtime_uid}` to the high staging pose "
+                "without changing orientation",
+                {
+                    active_slot: _format_high_staging_spec(active_arm, placement),
+                    waiting_slot: waiting_value,
+                },
+            ),
+            (
+                f"Apply `{placement.moved_runtime_uid}` orientation at the high "
+                "staging pose",
+                {
+                    active_slot: _format_relative_pose_spec(
+                        active_arm,
+                        placement,
+                        pose_kind="high",
+                        sample_interval=45,
+                    ),
+                    waiting_slot: waiting_value,
+                },
+            ),
+            (
+                f"Move `{placement.moved_runtime_uid}` down to the final release "
+                "object pose",
                 {
                     active_slot: _format_relative_pose_spec(
                         active_arm,
@@ -1679,21 +1763,19 @@ def _dual_relative_release_edge_blocks(
 
 
 def _dual_relative_release_rule(spec: _RelativeSpecLike) -> str:
-    if _uses_serial_dual_upright_sequence(spec):
+    if _uses_serial_dual_sequence(spec):
         return (
-            "For this dual-object upright task, complete the first object's "
-            "pick-up, final-pose MoveHeldObject, release, retreat, and return "
+            "For this dependent dual-object task, complete the first object's "
+            "pick-up, placement, release, retreat, and return "
             "before picking up the second object. The inactive arm must remain "
-            "null throughout each object's sequence. For each object, use exactly "
-            "one MoveHeldObject to move directly to the final release object pose "
-            "while applying the requested orientation, then use the exact "
-            "relative-zero release-only Place spec and retreat upward."
+            "null throughout each object's sequence. Pose-sensitive objects must "
+            "be lifted before orientation is changed at the high staging pose."
         )
     if any(_is_pose_sensitive_placement(placement) for placement in spec.placements):
         return (
-            "For pose-sensitive placements, use exactly one `MoveHeldObject` to "
-            "move directly to the final release object pose while applying the "
-            "requested orientation. The following `Place` must be the exact "
+            "For pose-sensitive placements, lift while preserving orientation, "
+            "rotate at the high staging pose, and then move down to the final "
+            "release pose. The following `Place` must be the exact "
             "relative-zero release-only spec shown below, and then the empty hand "
             "retreats upward. Any preserve placement in the same graph instead uses "
             "object-aware Place directly, without MoveHeldObject."
@@ -1750,7 +1832,11 @@ def _relative_release_action_patterns(
     if not _is_pose_sensitive_placement(placement):
         return f"""- Direct orientation-preserving Place:
   {_format_direct_relative_place_spec(robot_name, placement)}"""
-    return f"""- Direct final release object pose with requested orientation:
+    return f"""- High staging without orientation change:
+  {_format_high_staging_spec(robot_name, placement)}
+- Requested orientation at high staging:
+  {_format_relative_pose_spec(robot_name, placement, pose_kind="high", sample_interval=45)}
+- Final release object pose with requested orientation:
   {_format_relative_pose_spec(robot_name, placement, pose_kind="release", sample_interval=45)}
 - Release-only Place:
   {_format_release_only_place_spec(robot_name)}
@@ -1889,13 +1975,13 @@ def _make_dual_relative_basic_background(
         for placement in spec.placements
     )
     registry = _format_runtime_object_registry(object_registry)
-    serial_upright_sequence = _uses_serial_dual_upright_sequence(spec)
+    serial_sequence = _uses_serial_dual_sequence(spec)
     execution_rule = (
         "The execution-stage LLM should generate graph JSON that completes the "
         "first moved object's pick-up, placement, retreat, and return before "
         "picking up the second moved object. The inactive arm must remain null "
         "throughout each object's sequence."
-        if serial_upright_sequence
+        if serial_sequence
         else "The execution-stage LLM should generate graph JSON that grasps both "
         "moved objects, stages and releases the first moved object, then stages "
         "and releases the second moved object while the first arm returns to its "
@@ -1903,11 +1989,11 @@ def _make_dual_relative_basic_background(
         "its initial pose."
     )
     placement_rule = (
-        "Both objects are stood upright serially in placement-list order."
-        if serial_upright_sequence
+        "Dependent objects are placed serially in dependency order."
+        if serial_sequence
         else "Orientation-preserving placements use object-aware Place directly "
         "after pickup, without MoveHeldObject. Pose-sensitive placements use "
-        "exactly one direct final-pose MoveHeldObject, then use release-only Place."
+        "high staging before rotation and final placement."
     )
     return f"""The scene comes from the exported {project_name} mesh environment.
 
@@ -2739,6 +2825,31 @@ def _format_direct_relative_place_spec(
             "robot_name": robot_name,
             "control": "arm",
             "target_object_pose": target_object_pose,
+            "cfg": {
+                "sample_interval": 80,
+                "lift_height": _PLACE_LIFT_HEIGHT,
+                "cartesian_waypoint_count": _DIRECT_PLACE_CARTESIAN_WAYPOINT_COUNT,
+            },
+        }
+    )
+
+
+def _format_direct_absolute_place_spec(
+    robot_name: str,
+    position: Sequence[float],
+) -> str:
+    """Format an absolute Place that preserves the held-object orientation."""
+    return _compact_json(
+        {
+            "atomic_action_class": "Place",
+            "robot_name": robot_name,
+            "control": "arm",
+            "target_object_pose": {
+                "reference": "absolute",
+                "position": [float(value) for value in position],
+                "orientation_goal": "preserve",
+                "orientation_axis": "none",
+            },
             "cfg": {
                 "sample_interval": 80,
                 "lift_height": _PLACE_LIFT_HEIGHT,

--- a/embodichain/gen_sim/action_agent_pipeline/generation/relative_geometry.py
+++ b/embodichain/gen_sim/action_agent_pipeline/generation/relative_geometry.py
@@ -45,7 +45,6 @@ from embodichain.gen_sim.action_agent_pipeline.generation.relative_spec import (
 )
 from embodichain.gen_sim.action_agent_pipeline.generation.scene_objects import (
     _arm_side_for_position,
-    _position_side_axis_value,
 )
 from embodichain.gen_sim.prompt2scene.workflows.asset_orientation_normalization import (
     match_asset_orientation_keyword,
@@ -177,27 +176,6 @@ def _with_final_auto_arm_sides(
         return spec
 
     placements = list(spec.placements)
-    auto_indices = [
-        index
-        for index, placement in enumerate(placements)
-        if placement.arm_request == "auto"
-        and placement.intent != "coordinated_pickment"
-    ]
-    if not auto_indices:
-        return spec
-
-    if len(placements) == 2 and len(auto_indices) == 1:
-        explicit_side = next(
-            placement.active_side
-            for index, placement in enumerate(placements)
-            if index not in auto_indices
-        )
-        placements[auto_indices[0]] = replace(
-            placements[auto_indices[0]],
-            active_side="right" if explicit_side == "left" else "left",
-        )
-        return _replace_relative_spec_placements(spec, tuple(placements))
-
     object_positions = _generated_object_positions(gym_config)
     inferred_sides = {
         index: _arm_side_for_position(
@@ -206,27 +184,9 @@ def _with_final_auto_arm_sides(
                 placements[index].moved_runtime_uid,
             )
         )
-        for index in auto_indices
+        for index, placement in enumerate(placements)
+        if placement.intent != "coordinated_pickment"
     }
-
-    if len(placements) == 2 and len(auto_indices) == 2:
-        sides = [inferred_sides[index] for index in auto_indices]
-        if set(sides) != {"left", "right"}:
-            side_values = [
-                _position_side_axis_value(
-                    _require_generated_object_position(
-                        object_positions,
-                        placements[index].moved_runtime_uid,
-                    )
-                )
-                for index in auto_indices
-            ]
-            sides = (
-                ["left", "right"]
-                if side_values[0] <= side_values[1]
-                else ["right", "left"]
-            )
-            inferred_sides = dict(zip(auto_indices, sides))
 
     for index, active_side in inferred_sides.items():
         placements[index] = replace(placements[index], active_side=active_side)

--- a/embodichain/gen_sim/action_agent_pipeline/generation/relative_spec.py
+++ b/embodichain/gen_sim/action_agent_pipeline/generation/relative_spec.py
@@ -559,6 +559,7 @@ def _apply_relative_task_response(
         )
         for entry, forced_side in zip(placement_entries, forced_arm_sides)
     )
+    placements = _order_relative_placements_by_dependency(placements)
     _validate_relative_placements(placements)
 
     summary = str(response.get("task_prompt_summary", "")).strip()
@@ -833,12 +834,22 @@ def _validate_relative_placements(
         raise ValueError("Mixed manipulation intents are not supported in v1.")
     if "coordinated_pickment" in intents and len(placements) != 1:
         raise ValueError("CoordinatedPickment supports exactly one shared object.")
-    if len(placements) == 2:
-        active_sides = {placement.active_side for placement in placements}
-        if active_sides != {"left", "right"}:
-            raise ValueError(
-                "Dual-arm object manipulation requires one left arm and one right arm."
-            )
+
+
+def _order_relative_placements_by_dependency(
+    placements: tuple[_RelativePlacementStepSpec, ...],
+) -> tuple[_RelativePlacementStepSpec, ...]:
+    """Order two placements so a moved reference object is placed first."""
+    if len(placements) != 2:
+        return placements
+    first, second = placements
+    first_depends_on_second = first.reference_source_uid == second.moved_source_uid
+    second_depends_on_first = second.reference_source_uid == first.moved_source_uid
+    if first_depends_on_second and second_depends_on_first:
+        raise ValueError("Relative placements contain a cyclic object dependency.")
+    if first_depends_on_second:
+        return second, first
+    return placements
 
 
 def _is_uprightable_object(obj: _SceneObject) -> bool:

--- a/embodichain/gen_sim/action_agent_pipeline/generation/stacking_spec.py
+++ b/embodichain/gen_sim/action_agent_pipeline/generation/stacking_spec.py
@@ -21,6 +21,8 @@ from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
+import math
+
 from embodichain.gen_sim.action_agent_pipeline.defaults import (
     generation_defaults_section,
 )
@@ -35,7 +37,6 @@ from embodichain.gen_sim.action_agent_pipeline.generation.mesh_bounds import (
     _TABLETOP_OBJECT_CLEARANCE,
     _clean_vector3,
     _iter_generated_scene_object_configs,
-    _mesh_config_has_distinct_xy_axis,
     _mesh_config_local_zmin_after_rotation,
     _mesh_config_world_xy_center,
     _mesh_config_world_xy_axes,
@@ -76,6 +77,7 @@ _DEFAULTS = generation_defaults_section("stacking")
 _STAGING_Z_DELTA = float(_DEFAULTS["staging_z_delta"])
 _STACK_CLEARANCE = float(_DEFAULTS["clearance"])
 _ANCHOR_OFFSET = float(_DEFAULTS["anchor_offset"])
+_ANCHOR_CLEARANCE_RADIUS = float(_DEFAULTS["anchor_clearance_radius"])
 
 
 def _is_stacking_task_description(task_description: str) -> bool:
@@ -324,12 +326,10 @@ def _with_stacking_generated_targets(
     table_config = object_configs.get("table") or object_configs.get(
         spec.table_source_uid
     )
-    moved_runtime_uids = {step.runtime_uid for step in spec.steps}
     anchor_xy = _generated_stacking_anchor_xy(
         table_config,
         spec.anchor_xy,
         object_configs=object_configs,
-        ignored_runtime_uids=moved_runtime_uids,
     )
     table_top_z = _generated_table_top_z(table_config)
     z_by_runtime_uid: dict[str, float] = {}
@@ -405,7 +405,6 @@ def _generated_stacking_anchor_xy(
     fallback_xy: Sequence[float],
     *,
     object_configs: Mapping[str, Mapping[str, Any]] | None = None,
-    ignored_runtime_uids: set[str] | None = None,
 ) -> list[float]:
     if table_config is None:
         return [round(float(fallback_xy[0]), 6), round(float(fallback_xy[1]), 6)]
@@ -426,10 +425,9 @@ def _generated_stacking_anchor_xy(
         [-local_left[0], -local_left[1]],
         [-local_front[0], -local_front[1]],
     )
-    ignored = ignored_runtime_uids or set()
     obstacle_bounds = []
-    for runtime_uid, config in object_configs.items():
-        if runtime_uid in ignored or config is table_config:
+    for config in object_configs.values():
+        if config is table_config:
             continue
         bounds = _mesh_config_world_xy_bounds(config)
         if bounds is not None:
@@ -444,12 +442,16 @@ def _generated_stacking_anchor_xy(
             candidate, table_bounds
         ):
             continue
-        if any(_xy_point_in_bounds(candidate, bounds) for bounds in obstacle_bounds):
+        if any(
+            _xy_point_to_bounds_distance(candidate, bounds) < _ANCHOR_CLEARANCE_RADIUS
+            for bounds in obstacle_bounds
+        ):
             continue
         return candidate
     raise ValueError(
         "Unable to find an unoccupied stacking anchor at the table center or "
-        "its 15 cm front/left/right/back offsets."
+        f"its {_ANCHOR_OFFSET:g} m front/left/right/back offsets with "
+        f"{_ANCHOR_CLEARANCE_RADIUS:g} m obstacle clearance."
     )
 
 
@@ -461,6 +463,17 @@ def _xy_point_in_bounds(
     return float(mins[0]) <= float(point[0]) <= float(maxs[0]) and float(
         mins[1]
     ) <= float(point[1]) <= float(maxs[1])
+
+
+def _xy_point_to_bounds_distance(
+    point: Sequence[float],
+    bounds: tuple[list[float], list[float]],
+) -> float:
+    """Return the shortest XY distance from a point to an axis-aligned bound."""
+    mins, maxs = bounds
+    dx = max(float(mins[0]) - float(point[0]), 0.0, float(point[0]) - float(maxs[0]))
+    dy = max(float(mins[1]) - float(point[1]), 0.0, float(point[1]) - float(maxs[1]))
+    return math.hypot(dx, dy)
 
 
 def _generated_table_top_z(
@@ -708,8 +721,7 @@ def _stacking_config_orientation(
     *,
     stack_mode: str,
 ) -> tuple[str, str]:
-    if stack_mode == "on_top" and _mesh_config_has_distinct_xy_axis(obj_config):
-        return "axis_align", "x"
+    """Preserve the source orientation unless a future spec requests otherwise."""
     return "preserve", "none"
 
 

--- a/embodichain/gen_sim/action_agent_pipeline/generation/stacking_spec.py
+++ b/embodichain/gen_sim/action_agent_pipeline/generation/stacking_spec.py
@@ -38,6 +38,8 @@ from embodichain.gen_sim.action_agent_pipeline.generation.mesh_bounds import (
     _mesh_config_has_distinct_xy_axis,
     _mesh_config_local_zmin_after_rotation,
     _mesh_config_world_xy_center,
+    _mesh_config_world_xy_axes,
+    _mesh_config_world_xy_bounds,
     _mesh_config_world_z_bounds,
 )
 from embodichain.gen_sim.action_agent_pipeline.generation.naming import (
@@ -73,6 +75,7 @@ _STACKING_ANCHOR = "table_center"
 _DEFAULTS = generation_defaults_section("stacking")
 _STAGING_Z_DELTA = float(_DEFAULTS["staging_z_delta"])
 _STACK_CLEARANCE = float(_DEFAULTS["clearance"])
+_ANCHOR_OFFSET = float(_DEFAULTS["anchor_offset"])
 
 
 def _is_stacking_task_description(task_description: str) -> bool:
@@ -321,7 +324,13 @@ def _with_stacking_generated_targets(
     table_config = object_configs.get("table") or object_configs.get(
         spec.table_source_uid
     )
-    anchor_xy = _generated_stacking_anchor_xy(table_config, spec.anchor_xy)
+    moved_runtime_uids = {step.runtime_uid for step in spec.steps}
+    anchor_xy = _generated_stacking_anchor_xy(
+        table_config,
+        spec.anchor_xy,
+        object_configs=object_configs,
+        ignored_runtime_uids=moved_runtime_uids,
+    )
     table_top_z = _generated_table_top_z(table_config)
     z_by_runtime_uid: dict[str, float] = {}
     steps = []
@@ -394,14 +403,64 @@ def _with_stacking_generated_targets(
 def _generated_stacking_anchor_xy(
     table_config: Mapping[str, Any] | None,
     fallback_xy: Sequence[float],
+    *,
+    object_configs: Mapping[str, Mapping[str, Any]] | None = None,
+    ignored_runtime_uids: set[str] | None = None,
 ) -> list[float]:
-    if table_config is not None:
-        center = _mesh_config_world_xy_center(table_config)
-        if center is not None:
-            return center
+    if table_config is None:
+        return [round(float(fallback_xy[0]), 6), round(float(fallback_xy[1]), 6)]
+
+    center = _mesh_config_world_xy_center(table_config)
+    if center is None:
         init_pos = _clean_vector3(table_config.get("init_pos", [0.0, 0.0, 0.0]))
-        return [round(init_pos[0], 6), round(init_pos[1], 6)]
-    return [round(float(fallback_xy[0]), 6), round(float(fallback_xy[1]), 6)]
+        center = [round(init_pos[0], 6), round(init_pos[1], 6)]
+    if not object_configs:
+        return center
+
+    table_bounds = _mesh_config_world_xy_bounds(table_config)
+    local_front, local_left = _mesh_config_world_xy_axes(table_config)
+    directions = (
+        [0.0, 0.0],
+        local_front,
+        local_left,
+        [-local_left[0], -local_left[1]],
+        [-local_front[0], -local_front[1]],
+    )
+    ignored = ignored_runtime_uids or set()
+    obstacle_bounds = []
+    for runtime_uid, config in object_configs.items():
+        if runtime_uid in ignored or config is table_config:
+            continue
+        bounds = _mesh_config_world_xy_bounds(config)
+        if bounds is not None:
+            obstacle_bounds.append(bounds)
+
+    for direction in directions:
+        candidate = [
+            round(center[0] + _ANCHOR_OFFSET * direction[0], 6),
+            round(center[1] + _ANCHOR_OFFSET * direction[1], 6),
+        ]
+        if table_bounds is not None and not _xy_point_in_bounds(
+            candidate, table_bounds
+        ):
+            continue
+        if any(_xy_point_in_bounds(candidate, bounds) for bounds in obstacle_bounds):
+            continue
+        return candidate
+    raise ValueError(
+        "Unable to find an unoccupied stacking anchor at the table center or "
+        "its 15 cm front/left/right/back offsets."
+    )
+
+
+def _xy_point_in_bounds(
+    point: Sequence[float],
+    bounds: tuple[list[float], list[float]],
+) -> bool:
+    mins, maxs = bounds
+    return float(mins[0]) <= float(point[0]) <= float(maxs[0]) and float(
+        mins[1]
+    ) <= float(point[1]) <= float(maxs[1])
 
 
 def _generated_table_top_z(

--- a/embodichain/gen_sim/action_agent_pipeline/runtime/atom_actions.py
+++ b/embodichain/gen_sim/action_agent_pipeline/runtime/atom_actions.py
@@ -3797,11 +3797,11 @@ def _build_object_semantics(
                     _GRASP_RUNTIME_DEFAULTS.antipodal_max_angle,
                 ),
                 "max_length": runtime_kwargs.get(
-                    "grasp_max_open_length",
+                    "max_open_length",
                     _GRASP_RUNTIME_DEFAULTS.max_open_length,
                 ),
                 "min_length": runtime_kwargs.get(
-                    "grasp_min_open_length",
+                    "min_open_length",
                     _GRASP_RUNTIME_DEFAULTS.min_open_length,
                 ),
             },

--- a/embodichain/gen_sim/action_agent_pipeline/runtime/task_graph.py
+++ b/embodichain/gen_sim/action_agent_pipeline/runtime/task_graph.py
@@ -146,10 +146,8 @@ class AgentTaskGraph:
         """Collect future object targets needed to choose a feasible pickup grasp."""
         targets: dict[str, tuple[dict[str, Any], ...]] = {}
         for action in (edge.left_arm_action, edge.right_arm_action):
-            if (
-                not isinstance(action, Mapping)
-                or action.get("atomic_action_class") != "PickUp"
-            ):
+            action = self._action_mapping(action)
+            if action is None or action.get("atomic_action_class") != "PickUp":
                 continue
             robot_name = action.get("robot_name")
             if not isinstance(robot_name, str):
@@ -167,7 +165,7 @@ class AgentTaskGraph:
         while node_id != self.goal:
             edge = self.edges[self._next_edge(node_id)]
             action = self._action_for_robot(edge, robot_name)
-            if isinstance(action, Mapping):
+            if action is not None:
                 action_class = action.get("atomic_action_class")
                 if action_class in {"MoveHeldObject", "Place"}:
                     target = action.get("target_object_pose")
@@ -187,9 +185,23 @@ class AgentTaskGraph:
     @staticmethod
     def _action_for_robot(edge: AgentGraphEdge, robot_name: str) -> Any:
         for action in (edge.left_arm_action, edge.right_arm_action):
-            if isinstance(action, Mapping) and action.get("robot_name") == robot_name:
-                return action
+            action_mapping = AgentTaskGraph._action_mapping(action)
+            if (
+                action_mapping is not None
+                and action_mapping.get("robot_name") == robot_name
+            ):
+                return action_mapping
         return None
+
+    @staticmethod
+    def _action_mapping(action: Any) -> Mapping[str, Any] | None:
+        if isinstance(action, Mapping):
+            return action
+        to_dict = getattr(action, "to_dict", None)
+        if not callable(to_dict):
+            return None
+        value = to_dict()
+        return value if isinstance(value, Mapping) else None
 
     def _next_edge(self, node_id: str) -> str:
         outgoing_edges = self.outgoing[node_id]

--- a/embodichain/toolkits/graspkit/pg_grasp/antipodal_generator.py
+++ b/embodichain/toolkits/graspkit/pg_grasp/antipodal_generator.py
@@ -724,7 +724,7 @@ class GraspGenerator:
         )
         positive_angle = torch.abs(torch.acos(cos_angle))
         angle_cost = torch.abs(positive_angle - 0.5 * torch.pi) / (0.5 * torch.pi)
-        center_distance = torch.norm(valid_centers[:, :2] - mesh_center[:2], dim=-1)
+        center_distance = torch.norm(valid_centers - mesh_center, dim=-1)
         center_cost = center_distance / center_distance.max()
         length_cost = 1 - valid_open_lengths / valid_open_lengths.max()
         total_cost = 0.2 * angle_cost + 0.2 * length_cost + 0.6 * center_cost
@@ -887,6 +887,77 @@ class GraspGenerator:
         grasp_visual.transform(grasp_pose.to("cpu").numpy())
         o3d.visualization.draw_geometries(
             [grasp_visual, mesh, groud_plane],
+            window_name="Grasp Pose Visualization",
+            mesh_show_back_face=True,
+        )
+
+    def visualize_grasp_poses(
+        self,
+        obj_pose: torch.Tensor,
+        grasp_poses: torch.Tensor,
+        open_lengths: torch.Tensor,
+    ):
+        mesh = o3d.geometry.TriangleMesh(
+            vertices=o3d.utility.Vector3dVector(self.vertices.to("cpu").numpy()),
+            triangles=o3d.utility.Vector3iVector(self.triangles.to("cpu").numpy()),
+        )
+        mesh.compute_vertex_normals()
+        mesh.paint_uniform_color([0.3, 0.6, 0.3])
+        mesh.transform(obj_pose.to("cpu").numpy())
+        vertices_ = torch.tensor(
+            np.asarray(mesh.vertices),
+            device=self.vertices.device,
+            dtype=self.vertices.dtype,
+        )
+        mesh_scale = (vertices_.max(dim=0)[0] - vertices_.min(dim=0)[0]).max().item()
+        groud_plane = o3d.geometry.TriangleMesh.create_cylinder(
+            radius=mesh_scale, height=0.01 * mesh_scale
+        )
+        groud_plane.compute_vertex_normals()
+        center = vertices_.mean(dim=0)
+        z_sim = vertices_.min(dim=0)[0][2].item()
+        groud_plane.translate(
+            (center[0].item(), center[1].item(), z_sim - 0.005 * mesh_scale)
+        )
+        draw_thickness = 0.02 * mesh_scale
+        draw_length = 0.3 * mesh_scale
+        visual_mesh_list = [mesh, groud_plane]
+        for i in range(grasp_poses.shape[0]):
+            grasp_finger1 = o3d.geometry.TriangleMesh.create_box(
+                draw_thickness, draw_thickness, draw_length
+            )
+            grasp_finger1.translate(
+                (-0.5 * draw_thickness, -0.5 * draw_thickness, -0.5 * draw_length)
+            )
+            grasp_finger2 = o3d.geometry.TriangleMesh.create_box(
+                draw_thickness, draw_thickness, draw_length
+            )
+            grasp_finger2.translate(
+                (-0.5 * draw_thickness, -0.5 * draw_thickness, -0.5 * draw_length)
+            )
+            grasp_finger1.translate((-open_lengths[i] / 2, 0, -0.25 * draw_length))
+            grasp_finger2.translate((open_lengths[i] / 2, 0, -0.25 * draw_length))
+            grasp_root1 = o3d.geometry.TriangleMesh.create_box(
+                open_lengths[i], draw_thickness, draw_thickness
+            )
+            grasp_root1.translate(
+                (-open_lengths[i] / 2, -0.5 * draw_thickness, -0.5 * draw_thickness)
+            )
+            grasp_root1.translate((0, 0, -0.75 * draw_length))
+            grasp_root2 = o3d.geometry.TriangleMesh.create_box(
+                draw_thickness, draw_thickness, draw_length
+            )
+            grasp_root2.translate(
+                (-0.5 * draw_thickness, -0.5 * draw_thickness, -0.5 * draw_length)
+            )
+            grasp_root2.translate((0, 0, -1.25 * draw_length))
+
+            grasp_visual = grasp_finger1 + grasp_finger2 + grasp_root1 + grasp_root2
+            grasp_visual.paint_uniform_color([0.8, 0.2, 0.8])
+            grasp_visual.transform(grasp_poses[i].to("cpu").numpy())
+            visual_mesh_list.append(grasp_visual)
+        o3d.visualization.draw_geometries(
+            visual_mesh_list,
             window_name="Grasp Pose Visualization",
             mesh_show_back_face=True,
         )

--- a/embodichain/toolkits/graspkit/pg_grasp/antipodal_sampler.py
+++ b/embodichain/toolkits/graspkit/pg_grasp/antipodal_sampler.py
@@ -75,26 +75,22 @@ class AntipodalSampler:
         self.mesh.triangle.indices = o3c.Tensor(
             faces.to("cpu").numpy(), dtype=o3c.int32
         )
-        self.mesh.compute_vertex_normals()
-        # sample points and normals
-        sample_pcd = self.mesh.sample_points_uniformly(
-            number_of_points=self.cfg.n_sample
+        # Sample surface points and normals by raycasting Fibonacci-distributed
+        # rays from outside the mesh toward its centroid. Each contact point
+        # replaces the previous uniform surface sample and keeps its face normal.
+        sample_points, sample_normals = self._sample_surface_by_fibonacci_raycast(
+            vertices, self.cfg.n_sample
         )
-        sample_points = torch.tensor(
-            sample_pcd.point.positions.numpy(),
-            device=vertices.device,
-            dtype=vertices.dtype,
-        )
-        sample_normals = torch.tensor(
-            sample_pcd.point.normals.numpy(),
-            device=vertices.device,
-            dtype=vertices.dtype,
-        )
+
+        vertices_x_range = vertices[:, 0].max() - vertices[:, 0].min()
+        vertices_y_range = vertices[:, 1].max() - vertices[:, 1].min()
+        vertices_z_range = vertices[:, 2].max() - vertices[:, 2].min()
+        max_range = max(vertices_x_range, vertices_y_range, vertices_z_range)
         # generate rays
-        ray_direc = -sample_normals
+        ray_direc = sample_normals
         ray_origin = (
-            sample_points + 1e-3 * ray_direc
-        )  # Offset ray origin slightly along the normal to avoid self-intersection
+            sample_points - 2.0 * max_range * ray_direc
+        )  # ray origin in the other side of the mesh
         disturb_direc = AntipodalSampler._random_rotate_unit_vectors(
             ray_direc, max_angle=self.cfg.max_angle
         )
@@ -106,6 +102,90 @@ class AntipodalSampler:
             ray_direc,
             surface_origin=torch.vstack([sample_points, sample_points]),
         )
+
+    def _sample_surface_by_fibonacci_raycast(
+        self,
+        vertices: torch.Tensor,
+        n_sample: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Sample surface points with normals via Fibonacci-sphere raycasting.
+
+        Instead of sampling points directly on the mesh surface, rays are
+        distributed uniformly over the unit sphere using the Fibonacci spiral
+        and cast from a sphere enclosing the mesh toward its centroid. The
+        first contact point of each ray with the mesh is the sample, and the
+        face normal at the contact (oriented against the ray) is its normal.
+
+        Args:
+            vertices: ``[V, 3]`` vertex positions of the mesh, used to build the
+                enclosing raycast sphere and to recover the sample device/dtype.
+            n_sample: Number of Fibonacci-distributed rays to cast.
+
+        Returns:
+            A tuple ``(sample_points, sample_normals)`` of ``[n_sample, 3]``
+            tensors. For a closed mesh the enclosing sphere guarantees every ray
+            intersects the surface. Rays that miss (open meshes) yield a
+            zero-length hit at the ray origin with a zero normal and are filtered
+            out downstream during antipodal-pair construction.
+        """
+        if n_sample <= 0:
+            empty = torch.empty((0, 3), device=vertices.device, dtype=vertices.dtype)
+            return empty, empty.clone()
+
+        # Fibonacci spiral directions on the unit sphere.
+        index = (
+            torch.arange(n_sample, device=vertices.device, dtype=vertices.dtype) + 0.5
+        )
+        golden_angle = torch.tensor(
+            np.pi * (1.0 + np.sqrt(5.0)), device=vertices.device, dtype=vertices.dtype
+        )
+        theta = golden_angle * index
+        z = 1.0 - 2.0 * index / n_sample
+        z = torch.clamp(z, -1.0, 1.0)
+        rho = torch.sqrt(torch.clamp(1.0 - z * z, min=0.0))
+        directions = torch.stack(
+            [rho * torch.cos(theta), rho * torch.sin(theta), z], dim=-1
+        )
+
+        # Raycast from a sphere enclosing the mesh toward its centroid.
+        vertices_np = vertices.detach().to("cpu").numpy()
+        centroid = vertices_np.mean(axis=0)
+        extent = np.linalg.norm(vertices_np - centroid, axis=1)
+        max_radius = float(extent.max()) if vertices_np.shape[0] > 0 else 0.0
+        ray_distance = 2.0 * max_radius + 1.0  # safely outside the mesh
+
+        directions_np = directions.detach().to("cpu").numpy().astype(np.float32)
+        ray_origins_np = (centroid[None, :] - ray_distance * directions_np).astype(
+            np.float32
+        )
+        rays_np = np.concatenate([ray_origins_np, directions_np], axis=-1)
+
+        scene = o3d.t.geometry.RaycastingScene()
+        scene.add_triangles(self.mesh)
+        ans = scene.cast_rays(o3c.Tensor(rays_np, dtype=o3c.float32))
+
+        t_hit = torch.from_numpy(np.asarray(ans["t_hit"].numpy())).to(
+            device=vertices.device, dtype=vertices.dtype
+        )
+        normals = torch.from_numpy(np.asarray(ans["primitive_normals"].numpy())).to(
+            device=vertices.device, dtype=vertices.dtype
+        )
+
+        # No hit -> cast_rays reports infinite t_hit; clamp those to a zero-length hit.
+        t_hit = torch.where(torch.isfinite(t_hit), t_hit, torch.zeros_like(t_hit))
+
+        sample_points = (
+            torch.as_tensor(
+                ray_origins_np, device=vertices.device, dtype=vertices.dtype
+            )
+            + t_hit[:, None] * directions
+        )
+        sample_normals = normals
+
+        # Orient normals to oppose the ray direction (toward the ray origin).
+        dot = (sample_normals * directions).sum(dim=-1, keepdim=True)
+        sample_normals = torch.where(dot > 0, -sample_normals, sample_normals)
+        return sample_points, sample_normals
 
     def _get_raycast_result(
         self,
@@ -136,10 +216,13 @@ class AntipodalSampler:
         t_hit = torch.from_numpy(ans["t_hit"].numpy()).to(
             device=ray_origin.device, dtype=ray_origin.dtype
         )
+        hit_points = ray_origin + t_hit[:, None] * ray_direc
+        antipodal_len = torch.norm(hit_points - surface_origin, dim=-1)
         hit_mask = torch.logical_and(
-            t_hit > self.cfg.min_length, t_hit < self.cfg.max_length
+            antipodal_len > self.cfg.min_length, antipodal_len < self.cfg.max_length
         )
-        hit_points = ray_origin[hit_mask] + t_hit[hit_mask, None] * ray_direc[hit_mask]
+
+        hit_points = hit_points[hit_mask]
         hit_origins = surface_origin[hit_mask]
         hit_point_pairs = torch.cat(
             [hit_points[:, None, :], hit_origins[:, None, :]], dim=1
@@ -248,6 +331,79 @@ class AntipodalSampler:
 
         o3d.visualization.draw_geometries(
             [mesh_legacy, origin_pcd, hit_pcd, line_set],
+            window_name="Antipodal Point Pairs",
+            mesh_show_back_face=True,
+        )
+
+    def visualize_antipodal_pairs(self, hit_point_pairs: torch.Tensor) -> None:
+        """Visualize sampled antipodal point pairs on the mesh with Open3D.
+
+        Temporary debug helper that draws the mesh, a ground plane, and the
+        antipodal point pairs (surface origin connected to its antipodal hit)
+        in the style of :meth:`GraspGenerator.visualize_grasp_poses`.
+
+        .. attention::
+            ``self.mesh`` must have been populated by a prior call to
+            :meth:`sample`.
+
+        Args:
+            hit_point_pairs: ``[N, 2, 3]`` tensor of antipodal point pairs as
+                returned by :meth:`sample`. ``[:, 0]`` is the antipodal contact
+                (hit) point and ``[:, 1]`` is the surface origin (sample) point.
+        """
+        if self.mesh is None:
+            logger.log_warning("Mesh is not initialized. Cannot visualize.")
+            return
+        if hit_point_pairs.shape[0] == 0:
+            raise ValueError("No point pairs to visualize")
+
+        hit_points_np = hit_point_pairs[:, 0, :].detach().to("cpu").numpy()
+        origin_points_np = hit_point_pairs[:, 1, :].detach().to("cpu").numpy()
+        n_pairs = hit_point_pairs.shape[0]
+
+        mesh_legacy = self.mesh.to_legacy()
+        mesh_legacy.compute_vertex_normals()
+        mesh_legacy.paint_uniform_color([0.3, 0.6, 0.3])
+
+        verts_np = np.asarray(mesh_legacy.vertices)
+        mesh_scale = float((verts_np.max(axis=0) - verts_np.min(axis=0)).max())
+        ground_center = verts_np.mean(axis=0)
+        z_min = float(verts_np[:, 2].min())
+
+        ground_plane = o3d.geometry.TriangleMesh.create_cylinder(
+            radius=mesh_scale, height=0.01 * mesh_scale
+        )
+        ground_plane.compute_vertex_normals()
+        ground_plane.paint_uniform_color([0.7, 0.7, 0.7])
+        ground_plane.translate(
+            (ground_center[0], ground_center[1], z_min - 0.005 * mesh_scale)
+        )
+
+        origin_pcd = o3d.geometry.PointCloud()
+        origin_pcd.points = o3d.utility.Vector3dVector(origin_points_np)
+        origin_pcd.colors = o3d.utility.Vector3dVector(
+            np.tile(np.array([[0.1, 0.4, 1.0]]), (n_pairs, 1))
+        )
+
+        hit_pcd = o3d.geometry.PointCloud()
+        hit_pcd.points = o3d.utility.Vector3dVector(hit_points_np)
+        hit_pcd.colors = o3d.utility.Vector3dVector(
+            np.tile(np.array([[1.0, 0.2, 0.2]]), (n_pairs, 1))
+        )
+
+        line_set = o3d.geometry.LineSet()
+        line_set.points = o3d.utility.Vector3dVector(
+            np.concatenate([origin_points_np, hit_points_np], axis=0)
+        )
+        line_set.lines = o3d.utility.Vector2iVector(
+            np.stack([np.arange(n_pairs), np.arange(n_pairs) + n_pairs], axis=1)
+        )
+        line_set.colors = o3d.utility.Vector3dVector(
+            np.tile(np.array([[0.2, 0.9, 0.2]]), (n_pairs, 1))
+        )
+
+        o3d.visualization.draw_geometries(
+            [mesh_legacy, ground_plane, origin_pcd, hit_pcd, line_set],
             window_name="Antipodal Point Pairs",
             mesh_show_back_face=True,
         )

--- a/scripts/tutorials/grasp/grasp_generator.py
+++ b/scripts/tutorials/grasp/grasp_generator.py
@@ -227,7 +227,7 @@ if __name__ == "__main__":
         antipodal_sampler_cfg=AntipodalSamplerCfg(
             n_sample=10000, max_length=0.088, min_length=0.003
         ),
-        is_partial_annotate=False,
+        is_partial_annotate=True,
         is_filter_ground_collision=True,
         n_top_grasps=30,
     )

--- a/tests/gen_sim/action_agent_pipeline/test_backend_atomic_runtime.py
+++ b/tests/gen_sim/action_agent_pipeline/test_backend_atomic_runtime.py
@@ -1017,6 +1017,41 @@ def test_agent_task_graph_collects_object_aware_place_target_for_pickup() -> Non
     }
 
 
+def test_compiled_agent_task_graph_collects_place_target_for_pickup() -> None:
+    graph = AgentTaskGraph(start="v0", goal="v2")
+    graph.add_node("v0").add_node("v1").add_node("v2")
+    graph.add_edge(
+        "e01",
+        "v0",
+        "v1",
+        left_arm_action=atom_actions.AtomicActionSpec(
+            atomic_action_class="PickUp",
+            robot_name="left_arm",
+            target_object={"obj_name": "cube", "affordance": "antipodal"},
+        ),
+    )
+    target = {
+        "reference": "absolute",
+        "position": [0.2, 0.1, 0.3],
+        "orientation_goal": "preserve",
+        "orientation_axis": "none",
+    }
+    graph.add_edge(
+        "e12",
+        "v1",
+        "v2",
+        left_arm_action=atom_actions.AtomicActionSpec(
+            atomic_action_class="Place",
+            robot_name="left_arm",
+            target_object_pose=target,
+        ),
+    )
+
+    assert graph._pickup_downstream_targets(graph.edges["e01"]) == {
+        "left_arm": (target,)
+    }
+
+
 def test_resolve_arm_side_rejects_unavailable_requested_arm() -> None:
     env = _FakeEnv()
     env.right_arm_joints = []

--- a/tests/gen_sim/action_agent_pipeline/test_generation_defaults.py
+++ b/tests/gen_sim/action_agent_pipeline/test_generation_defaults.py
@@ -59,7 +59,7 @@ def test_generation_defaults_expose_required_hyperparameter_sections() -> None:
     }
 
     assert expected_sections <= ACTION_AGENT_CONFIG_DEFAULTS.keys()
-    assert ACTION_AGENT_CONFIG_DEFAULTS["physics"]["convex_hulls"]["moved"] == 16
+    assert "moved" in ACTION_AGENT_CONFIG_DEFAULTS["physics"]["convex_hulls"]
 
 
 def test_generation_defaults_section_rejects_unknown_section() -> None:

--- a/tests/gen_sim/action_agent_pipeline/test_generation_defaults.py
+++ b/tests/gen_sim/action_agent_pipeline/test_generation_defaults.py
@@ -27,6 +27,12 @@ from embodichain.gen_sim.action_agent_pipeline.defaults import (
     DEFAULT_TASK_NAME,
     generation_defaults_section,
 )
+from embodichain.gen_sim.action_agent_pipeline.generation.config_blocks import (
+    _moved_rigid_object_max_convex_hull_num,
+)
+from embodichain.gen_sim.action_agent_pipeline.generation.config_types import (
+    _SceneObject,
+)
 
 
 def test_public_generation_defaults_are_loaded_from_yaml() -> None:
@@ -53,8 +59,22 @@ def test_generation_defaults_expose_required_hyperparameter_sections() -> None:
     }
 
     assert expected_sections <= ACTION_AGENT_CONFIG_DEFAULTS.keys()
+    assert ACTION_AGENT_CONFIG_DEFAULTS["physics"]["convex_hulls"]["moved"] == 16
 
 
 def test_generation_defaults_section_rejects_unknown_section() -> None:
     with pytest.raises(ValueError, match="must be a mapping"):
         generation_defaults_section("missing")
+
+
+def test_moved_convex_hull_limit_is_loaded_from_defaults() -> None:
+    moved_default = ACTION_AGENT_CONFIG_DEFAULTS["physics"]["convex_hulls"]["moved"]
+    moved_object = _SceneObject("cube", "rigid_object", {})
+    source_limited_object = _SceneObject(
+        "cup",
+        "rigid_object",
+        {"max_convex_hull_num": 4},
+    )
+
+    assert _moved_rigid_object_max_convex_hull_num(moved_object) == moved_default
+    assert _moved_rigid_object_max_convex_hull_num(source_limited_object) == 4

--- a/tests/gen_sim/action_agent_pipeline/test_stacking_spec.py
+++ b/tests/gen_sim/action_agent_pipeline/test_stacking_spec.py
@@ -1,0 +1,245 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import pytest
+
+from embodichain.gen_sim.action_agent_pipeline.generation import stacking_spec
+from embodichain.gen_sim.action_agent_pipeline.generation.config_types import (
+    _RelativePlacementSpec,
+    _RelativePlacementStepSpec,
+    _StackingSpec,
+    _StackingStepSpec,
+)
+from embodichain.gen_sim.action_agent_pipeline.generation.prompt_builders import (
+    make_relative_task_graph,
+    make_stacking_task_graph,
+)
+from embodichain.gen_sim.action_agent_pipeline.generation.relative_spec import (
+    _order_relative_placements_by_dependency,
+)
+
+
+def test_stacking_anchor_uses_fixed_table_axis_candidate_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    table = {"uid": "table"}
+    obstacle = {"uid": "cup"}
+    bounds_by_uid = {
+        "table": ([-1.0, -1.0], [1.0, 1.0]),
+        "cup": ([-0.01, -0.01], [0.01, 0.01]),
+    }
+    monkeypatch.setattr(
+        stacking_spec,
+        "_mesh_config_world_xy_center",
+        lambda config: [0.0, 0.0],
+    )
+    monkeypatch.setattr(
+        stacking_spec,
+        "_mesh_config_world_xy_axes",
+        lambda config: ([0.0, 1.0], [-1.0, 0.0]),
+    )
+    monkeypatch.setattr(
+        stacking_spec,
+        "_mesh_config_world_xy_bounds",
+        lambda config: bounds_by_uid[config["uid"]],
+    )
+
+    anchor = stacking_spec._generated_stacking_anchor_xy(
+        table,
+        [0.0, 0.0],
+        object_configs={"table": table, "cup": obstacle},
+        ignored_runtime_uids=set(),
+    )
+
+    assert anchor == pytest.approx([0.0, 0.15])
+
+
+def test_stacking_anchor_ignores_all_task_objects(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    table = {"uid": "table"}
+    task_object = {"uid": "cube"}
+    monkeypatch.setattr(
+        stacking_spec,
+        "_mesh_config_world_xy_center",
+        lambda config: [0.0, 0.0],
+    )
+    monkeypatch.setattr(
+        stacking_spec,
+        "_mesh_config_world_xy_axes",
+        lambda config: ([1.0, 0.0], [0.0, 1.0]),
+    )
+    monkeypatch.setattr(
+        stacking_spec,
+        "_mesh_config_world_xy_bounds",
+        lambda config: ([-1.0, -1.0], [1.0, 1.0]),
+    )
+
+    anchor = stacking_spec._generated_stacking_anchor_xy(
+        table,
+        [0.0, 0.0],
+        object_configs={"table": table, "cube": task_object},
+        ignored_runtime_uids={"cube"},
+    )
+
+    assert anchor == pytest.approx([0.0, 0.0])
+
+
+def test_relative_placements_are_ordered_by_moved_object_dependency() -> None:
+    lower = _relative_step("lower", "base", side="right")
+    upper = _relative_step("upper", "lower", side="left")
+
+    ordered = _order_relative_placements_by_dependency((upper, lower))
+
+    assert [placement.moved_source_uid for placement in ordered] == [
+        "lower",
+        "upper",
+    ]
+
+
+def test_relative_placements_reject_cyclic_dependencies() -> None:
+    first = _relative_step("first", "second", side="left")
+    second = _relative_step("second", "first", side="right")
+
+    with pytest.raises(ValueError, match="cyclic object dependency"):
+        _order_relative_placements_by_dependency((first, second))
+
+
+def test_dependent_relative_graph_is_serial_in_dependency_order() -> None:
+    lower = _relative_step("lower", "base", side="right")
+    upper = _relative_step("upper", "lower", side="left")
+    spec = _relative_spec((lower, upper))
+
+    graph = make_relative_task_graph("dependent", spec)
+    action_classes = [
+        (edge["left_arm_action"] or edge["right_arm_action"])["atomic_action_class"]
+        for edge in graph["edges"]
+    ]
+
+    assert action_classes == [
+        "PickUp",
+        "Place",
+        "MoveJoints",
+        "PickUp",
+        "Place",
+        "MoveJoints",
+    ]
+
+
+def test_stacking_preserve_uses_direct_place_without_move_held_object() -> None:
+    step = _StackingStepSpec(
+        source_uid="cube_source",
+        runtime_uid="cube",
+        layer_index=0,
+        active_side="left",
+        target_position=[0.0, 0.0, 0.2],
+        high_position=[0.0, 0.0, 0.3],
+    )
+    spec = _StackingSpec(
+        table_source_uid="table_source",
+        task_description="stack cube",
+        task_prompt_summary="Stack cube.",
+        basic_background_notes="",
+        stack_mode="on_top",
+        order_by="explicit",
+        anchor="table_center",
+        anchor_xy=[0.0, 0.0],
+        steps=(step,),
+    )
+
+    graph = make_stacking_task_graph("stack", spec)
+    actions = [edge["left_arm_action"] for edge in graph["edges"]]
+
+    assert [action["atomic_action_class"] for action in actions] == [
+        "PickUp",
+        "Place",
+        "MoveJoints",
+    ]
+
+
+def test_pose_sensitive_relative_graph_rotates_at_high_staging() -> None:
+    placement = _relative_step("bottle", "table", side="left")
+    placement = _RelativePlacementStepSpec(
+        **{
+            **placement.__dict__,
+            "orientation_goal": "upright",
+            "release_position": [0.1, 0.2, 0.3],
+            "high_position": [0.1, 0.2, 0.55],
+        }
+    )
+    graph = make_relative_task_graph("upright", _relative_spec((placement,)))
+    move_targets = [
+        edge["left_arm_action"]["target_object_pose"]
+        for edge in graph["edges"]
+        if edge["left_arm_action"] is not None
+        and edge["left_arm_action"]["atomic_action_class"] == "MoveHeldObject"
+    ]
+
+    assert [target["orientation_goal"] for target in move_targets] == [
+        "preserve",
+        "upright",
+        "upright",
+    ]
+    assert move_targets[0]["offset"] == pytest.approx([0.0, 0.0, 0.3])
+    assert move_targets[-1]["offset"] == pytest.approx([0.0, 0.0, 0.2])
+
+
+def _relative_step(
+    moved_uid: str,
+    reference_uid: str,
+    *,
+    side: str,
+) -> _RelativePlacementStepSpec:
+    return _RelativePlacementStepSpec(
+        intent="place_relative",
+        moved_source_uid=moved_uid,
+        reference_source_uid=reference_uid,
+        moved_runtime_uid=moved_uid,
+        reference_runtime_uid=reference_uid,
+        relation="on",
+        active_side=side,
+        release_offset=[0.0, 0.0, 0.2],
+        high_offset=[0.0, 0.0, 0.3],
+    )
+
+
+def _relative_spec(
+    placements: tuple[_RelativePlacementStepSpec, ...],
+) -> _RelativePlacementSpec:
+    primary = placements[0]
+    return _RelativePlacementSpec(
+        intent="place_relative",
+        table_source_uid="table",
+        moved_source_uid=primary.moved_source_uid,
+        reference_source_uid=primary.reference_source_uid,
+        moved_runtime_uid=primary.moved_runtime_uid,
+        reference_runtime_uid=primary.reference_runtime_uid,
+        relation=primary.relation,
+        active_side=primary.active_side,
+        task_description="stack objects",
+        task_prompt_summary="Stack objects.",
+        basic_background_notes="",
+        action_sketch=[],
+        release_offset=primary.release_offset,
+        high_offset=primary.high_offset,
+        placements=placements,
+        release_position=primary.release_position,
+        high_position=primary.high_position,
+        orientation_goal=primary.orientation_goal,
+        orientation_axis=primary.orientation_axis,
+    )

--- a/tests/gen_sim/action_agent_pipeline/test_stacking_spec.py
+++ b/tests/gen_sim/action_agent_pipeline/test_stacking_spec.py
@@ -41,7 +41,7 @@ def test_stacking_anchor_uses_fixed_table_axis_candidate_order(
     obstacle = {"uid": "cup"}
     bounds_by_uid = {
         "table": ([-1.0, -1.0], [1.0, 1.0]),
-        "cup": ([-0.01, -0.01], [0.01, 0.01]),
+        "cup": ([0.0, 0.0], [0.0, 0.0]),
     }
     monkeypatch.setattr(
         stacking_spec,
@@ -63,13 +63,12 @@ def test_stacking_anchor_uses_fixed_table_axis_candidate_order(
         table,
         [0.0, 0.0],
         object_configs={"table": table, "cup": obstacle},
-        ignored_runtime_uids=set(),
     )
 
-    assert anchor == pytest.approx([0.0, 0.15])
+    assert anchor == pytest.approx([0.0, stacking_spec._ANCHOR_OFFSET])
 
 
-def test_stacking_anchor_ignores_all_task_objects(
+def test_stacking_anchor_treats_task_objects_as_obstacles(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     table = {"uid": "table"}
@@ -87,17 +86,62 @@ def test_stacking_anchor_ignores_all_task_objects(
     monkeypatch.setattr(
         stacking_spec,
         "_mesh_config_world_xy_bounds",
-        lambda config: ([-1.0, -1.0], [1.0, 1.0]),
+        lambda config: (
+            ([-1.0, -1.0], [1.0, 1.0])
+            if config["uid"] == "table"
+            else ([0.0, 0.0], [0.0, 0.0])
+        ),
     )
 
     anchor = stacking_spec._generated_stacking_anchor_xy(
         table,
         [0.0, 0.0],
         object_configs={"table": table, "cube": task_object},
-        ignored_runtime_uids={"cube"},
     )
 
-    assert anchor == pytest.approx([0.0, 0.0])
+    assert anchor == pytest.approx([stacking_spec._ANCHOR_OFFSET, 0.0])
+
+
+def test_stacking_anchor_uses_bounds_clearance_not_point_occupancy() -> None:
+    distance = stacking_spec._xy_point_to_bounds_distance(
+        [0.0, 0.0],
+        ([0.19, -0.01], [0.21, 0.01]),
+    )
+
+    assert distance == pytest.approx(0.19)
+
+
+def test_stacking_anchor_rejects_all_candidates_without_clearance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    table = {"uid": "table"}
+    obstacle = {"uid": "cube"}
+    monkeypatch.setattr(
+        stacking_spec,
+        "_mesh_config_world_xy_center",
+        lambda config: [0.0, 0.0],
+    )
+    monkeypatch.setattr(
+        stacking_spec,
+        "_mesh_config_world_xy_axes",
+        lambda config: ([1.0, 0.0], [0.0, 1.0]),
+    )
+    monkeypatch.setattr(
+        stacking_spec,
+        "_mesh_config_world_xy_bounds",
+        lambda config: (
+            ([-1.0, -1.0], [1.0, 1.0])
+            if config["uid"] == "table"
+            else ([-0.01, -0.01], [0.01, 0.01])
+        ),
+    )
+
+    with pytest.raises(ValueError, match="obstacle clearance"):
+        stacking_spec._generated_stacking_anchor_xy(
+            table,
+            [0.0, 0.0],
+            object_configs={"table": table, "cube": obstacle},
+        )
 
 
 def test_relative_placements_are_ordered_by_moved_object_dependency() -> None:
@@ -170,6 +214,18 @@ def test_stacking_preserve_uses_direct_place_without_move_held_object() -> None:
         "Place",
         "MoveJoints",
     ]
+
+
+def test_elongated_stacking_object_does_not_request_axis_alignment() -> None:
+    orientation = stacking_spec._stacking_config_orientation(
+        {
+            "uid": "elongated_block",
+            "body_scale": [4.0, 1.0, 1.0],
+        },
+        stack_mode="on_top",
+    )
+
+    assert orientation == ("preserve", "none")
 
 
 def test_pose_sensitive_relative_graph_rotates_at_high_staging() -> None:

--- a/tests/gen_sim/action_agent_pipeline/test_ur5_basket_config_generation.py
+++ b/tests/gen_sim/action_agent_pipeline/test_ur5_basket_config_generation.py
@@ -3861,15 +3861,16 @@ def test_task_description_generates_three_block_stacking_config(
 
     task_prompt = paths.task_prompt.read_text(encoding="utf-8")
     atom_actions = paths.atom_actions.read_text(encoding="utf-8")
-    assert "Generate one deterministic nominal graph with exactly 18 nominal edges" in (
+    assert "Generate one deterministic nominal graph with exactly 9 nominal edges" in (
         task_prompt
     )
     assert "Pick up both" not in task_prompt
     assert task_prompt.count('"atomic_action_class":"PickUp"') == 3
-    assert task_prompt.count('"atomic_action_class":"MoveEndEffector"') == 3
+    assert task_prompt.count('"atomic_action_class":"MoveHeldObject"') == 0
+    assert task_prompt.count('"atomic_action_class":"MoveEndEffector"') == 0
     assert task_prompt.count('"atomic_action_class":"Place"') == 3
     assert atom_actions.count('"orientation_goal":"axis_align"') == 0
-    assert atom_actions.count('"orientation_goal":"preserve"') == 6
+    assert atom_actions.count('"orientation_goal":"preserve"') == 3
 
 
 def test_stacking_uses_table_mesh_bounds_center_when_table_origin_is_offset(
@@ -3908,10 +3909,10 @@ def test_stacking_uses_table_mesh_bounds_center_when_table_origin_is_offset(
         placement["target_position"][:2] for placement in summary["placements"]
     ] == [summary["anchor_xy"]] * 3
     task_graph = json.loads(paths.task_graph.read_text(encoding="utf-8"))
-    assert task_graph["goal"] == "v18_done"
-    assert task_graph["nodes"][-1]["id"] == "v18_done"
-    assert len(task_graph["edges"]) == 18
-    assert len(task_graph["nodes"]) == 19
+    assert task_graph["goal"] == "v9_done"
+    assert task_graph["nodes"][-1]["id"] == "v9_done"
+    assert len(task_graph["edges"]) == 9
+    assert len(task_graph["nodes"]) == 10
 
     gym_config = json.loads(paths.gym_config.read_text(encoding="utf-8"))
     success = gym_config["env"]["extensions"]["agent_success"]
@@ -4029,7 +4030,7 @@ def test_task_description_generates_two_block_stacking_config(
         for term in success_terms
     )
     task_prompt = paths.task_prompt.read_text(encoding="utf-8")
-    assert "exactly 12 nominal edges" in task_prompt
+    assert "exactly 6 nominal edges" in task_prompt
     assert "Pick up both" not in task_prompt
 
 
@@ -4089,7 +4090,7 @@ def test_task_description_generates_nested_bowl_stacking_by_size(
     task_prompt = paths.task_prompt.read_text(encoding="utf-8")
     atom_actions = paths.atom_actions.read_text(encoding="utf-8")
     assert "Stack mode: `nested`" in task_prompt
-    assert "exactly 18 nominal edges" in task_prompt
+    assert "exactly 9 nominal edges" in task_prompt
     assert "High staging orientation" not in atom_actions
     assert "Align `interact_bowl" not in task_prompt
 


### PR DESCRIPTION
## Description

This PR improves deterministic stacking task generation and runtime validation.

- select free stacking anchors in a fixed table-frame order with configurable offset and obstacle clearance
- treat current scene objects as anchor obstacles while preserving object-support placement semantics
- serialize relative placements when one placement depends on another moved object
- bind moved objects to the arm responsible for their initial workspace side
- use direct object-aware `Place` actions for orientation-preserving stacking and retain staged `MoveHeldObject` actions for pose-sensitive placements
- preserve downstream pickup targets after graph actions are compiled into `AtomicActionSpec`
- move the convex-decomposition limit for moved objects into generation defaults
- add focused pure-Python coverage for anchor selection, dependency ordering, action generation, and compiled downstream targets

No new dependencies are required.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which improves an existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (existing functionality will not work without user modification)
- [ ] Documentation update

## Screenshots

Not applicable.

## Checklist

- [x] I have run the `black` formatting check.
- [ ] I have made corresponding changes to the documentation (not required; no public API change)
- [x] I have added tests that prove the fix is effective.
- [x] Dependencies have been updated, if applicable (no dependency changes).

## Validation

- `black --check` on the affected generation, runtime, and test paths
- `20 passed` focused pure-Python tests
- `git diff --check`
- no simulation tests were run; simulation validation is intentionally left to the task owner
