### PR TITLE
Defer release publication until publish

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -14,6 +14,8 @@ on:
         description: "Existing CI/CD Pipeline run ID to deploy from instead of rebuilding"
         required: false
         type: string
+  release:
+    types: [published]
 
 permissions:
   actions: read
@@ -30,7 +32,8 @@ jobs:
     if: >
       (github.event_name == 'workflow_run' &&
        github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.event == 'push') ||
+       github.event.workflow_run.event == 'push' &&
+       github.event.workflow_run.head_branch == 'main') ||
       (github.event_name == 'workflow_dispatch' &&
        inputs.artifact_run_id != '')
     runs-on: ubuntu-latest
@@ -56,7 +59,11 @@ jobs:
         uses: actions/deploy-pages@v4
 
   build-and-deploy:
-    if: github.event_name == 'workflow_dispatch' && inputs.artifact_run_id == ''
+    if: >
+      (github.event_name == 'workflow_dispatch' && inputs.artifact_run_id == '') ||
+      (github.event_name == 'release' &&
+       github.event.action == 'published' &&
+       startsWith(github.event.release.tag_name, 'v'))
     runs-on: Linux
     env:
       NVIDIA_DRIVER_CAPABILITIES: all
@@ -77,7 +84,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref != '' && inputs.ref || 'main' }}
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.ref != '' && inputs.ref || 'main' }}
       - uses: ./.github/actions/activate-conda
 
       - name: Restore full multi-version docs site
@@ -92,7 +99,7 @@ jobs:
         shell: bash
         run: |
           SITE_URL="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}"
-          TARGET_REF="${{ inputs.ref != '' && inputs.ref || 'main' }}"
+          TARGET_REF="${{ github.event_name == 'release' && github.event.release.tag_name || inputs.ref != '' && inputs.ref || 'main' }}"
           SKIP_VERSION="main"
           if [[ "${TARGET_REF}" == v* ]]; then
             SKIP_VERSION="${TARGET_REF}"
@@ -105,7 +112,7 @@ jobs:
       - name: Build docs site
         shell: bash
         run: |
-          TARGET_REF="${{ inputs.ref != '' && inputs.ref || 'main' }}"
+          TARGET_REF="${{ github.event_name == 'release' && github.event.release.tag_name || inputs.ref != '' && inputs.ref || 'main' }}"
           pip install -e ".[gensim]" \
             --extra-index-url http://pyp.open3dv.site:2345/simple/ \
             --trusted-host pyp.open3dv.site \
@@ -144,7 +151,11 @@ jobs:
           path: ${{ github.workspace }}/docs/build/html
 
   deploy-manual-build:
-    if: github.event_name == 'workflow_dispatch' && inputs.artifact_run_id == ''
+    if: >
+      (github.event_name == 'workflow_dispatch' && inputs.artifact_run_id == '') ||
+      (github.event_name == 'release' &&
+       github.event.action == 'published' &&
+       startsWith(github.event.release.tag_name, 'v'))
     needs: build-and-deploy
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -214,24 +214,3 @@ jobs:
         with:
           name: python-distributions
           path: dist/
-
-  release-publish:
-    if: startsWith(github.ref, 'refs/tags/v')
-    needs: release-build
-    runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/p/embodichain
-    permissions:
-      contents: read
-      id-token: write   # PyPI Trusted Publishing
-
-    steps:
-      - name: (Release) Download distributions
-        uses: actions/download-artifact@v4
-        with:
-          name: python-distributions
-          path: dist/
-
-      - name: (Release) Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,37 @@
+name: Publish Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    if: startsWith(github.event.release.tag_name, 'v')
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/embodichain
+    permissions:
+      contents: read
+      id-token: write  # PyPI Trusted Publishing
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Build distributions from the published tag
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build
+          python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Description

This PR prevents a GitHub release draft tag from publishing EmbodiChain distributions to PyPI or deploying versioned documentation.

Tag pushes continue to build CI artifacts. PyPI publication and release-doc deployment now run only when the associated GitHub release is published.

Dependencies: None.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (existing functionality will not work without user modification)
- [ ] Documentation update

## Screenshots

Not applicable.

## Checklist

- [x] I have run the Black formatting check.
- [ ] I have made corresponding changes to the documentation
- [x] I have run the relevant docs publication tests.
- [ ] Dependencies have been updated, if applicable.