### PR TITLE
Fix action-agent LeRobot episode persistence

### DIFF
--- a/embodichain/gen_sim/action_agent_pipeline/env_adapters/tableware/agent_env.py
+++ b/embodichain/gen_sim/action_agent_pipeline/env_adapters/tableware/agent_env.py
@@ -57,6 +57,9 @@ class AgenticGenSimEnv(EmbodiedEnv):
     def reset(
         self, seed: int | None = None, options: dict[str, Any] | None = None
     ) -> tuple[Any, dict[str, Any]]:
+        if self._agent_runtime_state_ready:
+            # Preserve the completed episode result before reset invalidates runtime caches.
+            self.episode_success_status |= self.is_task_success()
         self._agent_runtime_state_ready = False
         obs, info = super().reset(seed=seed, options=options)
         self._draw_arrangement_debug_markers()

--- a/embodichain/gen_sim/action_agent_pipeline/generation/action_agent_config.py
+++ b/embodichain/gen_sim/action_agent_pipeline/generation/action_agent_config.py
@@ -1172,6 +1172,7 @@ def _make_stacking_dataset_config(
                     "task_description": spec.task_description,
                     "data_type": "sim",
                 },
+                "save_failed_episodes": True,
                 "use_videos": True,
             },
         }

--- a/embodichain/gen_sim/action_agent_pipeline/generation/config_blocks.py
+++ b/embodichain/gen_sim/action_agent_pipeline/generation/config_blocks.py
@@ -574,6 +574,7 @@ def _make_dataset_config(
                     ),
                     "data_type": "sim",
                 },
+                "save_failed_episodes": True,
                 "use_videos": True,
             },
         }
@@ -609,6 +610,7 @@ def _make_relative_dataset_config(
                     "task_description": spec.task_description,
                     "data_type": "sim",
                 },
+                "save_failed_episodes": True,
                 "use_videos": True,
             },
         }
@@ -639,6 +641,7 @@ def _make_arrangement_dataset_config(
                     "task_description": spec.task_description,
                     "data_type": "sim",
                 },
+                "save_failed_episodes": True,
                 "use_videos": True,
             },
         }

--- a/embodichain/lab/gym/envs/embodied_env.py
+++ b/embodichain/lab/gym/envs/embodied_env.py
@@ -527,7 +527,10 @@ class EmbodiedEnv(BaseEnv):
 
         # Save dataset before clearing buffers for environments that are being reset
         if save_data and self.dataset_manager:
-            if "save" in self.dataset_manager.available_modes:
+            if (
+                self.current_rollout_step > 0
+                and "save" in self.dataset_manager.available_modes
+            ):
 
                 # Dataset collection normally keeps successful episodes only.
                 # Recorders can opt in to retain failed episodes for debugging,

--- a/embodichain/lab/gym/envs/managers/dataset_manager.py
+++ b/embodichain/lab/gym/envs/managers/dataset_manager.py
@@ -33,6 +33,9 @@ if TYPE_CHECKING:
     from embodichain.lab.gym.envs import EmbodiedEnv
 
 
+_MANAGER_ONLY_PARAMS = frozenset({"save_failed_episodes"})
+
+
 class DatasetManager(ManagerBase):
     """Manager for orchestrating dataset collection and saving using functors.
 
@@ -236,10 +239,15 @@ class DatasetManager(ManagerBase):
 
         # iterate over all the dataset functors for this mode
         for functor_cfg in self._mode_functor_cfgs[mode]:
+            functor_params = {
+                key: value
+                for key, value in functor_cfg.params.items()
+                if key not in _MANAGER_ONLY_PARAMS
+            }
             functor_cfg.func(
                 self._env,
                 env_ids,
-                **functor_cfg.params,
+                **functor_params,
             )
 
     def finalize(self) -> Optional[str]:

--- a/tests/gen_sim/action_agent_pipeline/test_base_agent_env_config.py
+++ b/tests/gen_sim/action_agent_pipeline/test_base_agent_env_config.py
@@ -24,6 +24,7 @@ import torch
 from embodichain.gen_sim.action_agent_pipeline.env_adapters.tableware.agent_env import (
     AgenticGenSimEnv,
 )
+from embodichain.lab.gym.envs import EmbodiedEnv
 
 
 class _SingleEnvAgenticGenSimEnv(AgenticGenSimEnv):
@@ -73,6 +74,33 @@ def test_agentic_gen_sim_env_preserves_success_validation_after_runtime_ready() 
 
     with pytest.raises(ValueError, match="requires an initial height"):
         env.is_task_success()
+
+
+def test_agentic_gen_sim_env_reset_latches_success_before_invalidating_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    env = _SingleEnvAgenticGenSimEnv.__new__(_SingleEnvAgenticGenSimEnv)
+    env._agent_runtime_state_ready = True
+    env.episode_success_status = torch.zeros(1, dtype=torch.bool)
+    env.is_task_success = Mock(return_value=torch.tensor([True]))
+    env._draw_arrangement_debug_markers = Mock()
+    env.get_states = Mock()
+    runtime_ready_during_parent_reset = None
+
+    def fake_parent_reset(self, seed=None, options=None):
+        nonlocal runtime_ready_during_parent_reset
+        runtime_ready_during_parent_reset = self._agent_runtime_state_ready
+        return "obs", {}
+
+    monkeypatch.setattr(EmbodiedEnv, "reset", fake_parent_reset)
+
+    obs, info = env.reset()
+
+    assert env.episode_success_status.tolist() == [True]
+    assert runtime_ready_during_parent_reset is False
+    assert env._agent_runtime_state_ready is True
+    assert obs == "obs"
+    assert info == {}
 
 
 def test_agentic_gen_sim_env_rejects_reserved_common_agent_config_keys() -> None:

--- a/tests/gen_sim/action_agent_pipeline/test_ur5_basket_config_generation.py
+++ b/tests/gen_sim/action_agent_pipeline/test_ur5_basket_config_generation.py
@@ -56,9 +56,12 @@ MeshFrameNormalizer = GlbGeometryNormalizer
 BODY_SCALE_BAKE_POLICY_VERSION = GLB_GEOMETRY_BAKE_POLICY_VERSION
 bake_body_scale_into_meshes = bake_body_scale_into_glbs
 from embodichain.gen_sim.action_agent_pipeline.generation.config_blocks import (
+    _make_arrangement_dataset_config,
     _make_arrangement_events_config,
+    _make_dataset_config,
     _make_events_config,
     _make_observations_config,
+    _make_relative_dataset_config,
     _make_relative_events_config,
     _record_camera_event_configs,
     _rotate_camera_extrinsics_around_target_z,
@@ -92,6 +95,7 @@ from embodichain.gen_sim.action_agent_pipeline.generation.naming import (
 )
 from embodichain.gen_sim.action_agent_pipeline.generation.action_agent_config import (
     TargetReplacementSpec,
+    _make_stacking_dataset_config,
     generate_action_agent_config_from_project,
 )
 from embodichain.gen_sim.action_agent_pipeline.generation.prompt_builders import (
@@ -695,6 +699,58 @@ def test_action_agent_config_generator_uses_selected_robot_profile(
     assert dataset_params["robot_meta"]["robot_type"] == expected_meta_type
     assert paths.summary["robot_profile"]["robot_meta_type"] == expected_meta_type
     assert paths.summary["robot_profile"]["display_name"] in basic_background
+
+
+@pytest.mark.parametrize(
+    "dataset_config",
+    [
+        _make_dataset_config(
+            "test_scene",
+            SimpleNamespace(
+                container_runtime_uid="basket",
+                left_target_noun="apple",
+                right_target_noun="block",
+            ),
+        ),
+        _make_relative_dataset_config(
+            "test_scene",
+            SimpleNamespace(
+                intent="placement",
+                placements=(
+                    SimpleNamespace(
+                        active_side="left",
+                        moved_runtime_uid="apple",
+                        relation="left_of",
+                        reference_runtime_uid="basket",
+                    ),
+                ),
+                task_description="Place the apple left of the basket.",
+            ),
+            relation_phrase=lambda relation: relation,
+        ),
+        _make_arrangement_dataset_config(
+            "test_scene",
+            SimpleNamespace(
+                steps=(SimpleNamespace(runtime_uid="block"),),
+                task_description="Arrange the block.",
+            ),
+        ),
+        _make_stacking_dataset_config(
+            "test_scene",
+            SimpleNamespace(
+                steps=(SimpleNamespace(runtime_uid="block"),),
+                anchor_runtime_uid=None,
+                task_description="Stack the block.",
+            ),
+            robot_profile=resolve_robot_profile("ur10"),
+        ),
+    ],
+    ids=("basket", "relative", "arrangement", "stacking"),
+)
+def test_action_agent_dataset_configs_save_failed_episodes(
+    dataset_config: dict,
+) -> None:
+    assert dataset_config["lerobot"]["params"]["save_failed_episodes"] is True
 
 
 def test_generator_normalizes_glb_meshes_and_preserves_source_rot(

--- a/tests/gym/envs/managers/test_dataset_manager.py
+++ b/tests/gym/envs/managers/test_dataset_manager.py
@@ -1,0 +1,89 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import torch
+
+from embodichain.lab.gym.envs import EmbodiedEnv
+from embodichain.lab.gym.envs.managers.dataset_manager import DatasetManager
+
+
+def test_apply_does_not_forward_save_failed_episode_policy() -> None:
+    calls = []
+
+    def recorder(env, env_ids, *, use_videos: bool) -> None:
+        calls.append((env, env_ids, use_videos))
+
+    env = object()
+    env_ids = torch.tensor([0])
+    manager = DatasetManager.__new__(DatasetManager)
+    manager._env = env
+    manager._mode_functor_names = {"save": ["recorder"]}
+    manager._mode_functor_cfgs = {
+        "save": [
+            SimpleNamespace(
+                func=recorder,
+                params={"save_failed_episodes": True, "use_videos": True},
+            )
+        ]
+    }
+
+    manager.apply(mode="save", env_ids=env_ids)
+
+    assert calls == [(env, env_ids, True)]
+
+
+def _make_episode_env(current_rollout_step: int) -> SimpleNamespace:
+    dataset_manager = Mock()
+    dataset_manager.available_modes = ["save"]
+    dataset_manager.save_failed_episodes = True
+    return SimpleNamespace(
+        num_envs=1,
+        device=torch.device("cpu"),
+        current_rollout_step=current_rollout_step,
+        dataset_manager=dataset_manager,
+        cfg=SimpleNamespace(events=None, observations=None, rewards=None),
+        event_manager=None,
+        observation_manager=None,
+        reward_manager=None,
+        rollout_buffer={},
+        _rollout_buffer_mode="expert",
+        episode_success_status=torch.tensor([False]),
+        _task_success=torch.tensor([False]),
+    )
+
+
+def test_initialize_episode_skips_empty_failed_episode() -> None:
+    env = _make_episode_env(current_rollout_step=0)
+
+    EmbodiedEnv._initialize_episode(env, env_ids=[0])
+
+    env.dataset_manager.apply.assert_not_called()
+
+
+def test_initialize_episode_saves_recorded_episode_regardless_of_task_success() -> None:
+    env = _make_episode_env(current_rollout_step=1)
+
+    EmbodiedEnv._initialize_episode(env, env_ids=[0])
+
+    env.dataset_manager.apply.assert_called_once()
+    call = env.dataset_manager.apply.call_args
+    assert call.kwargs["mode"] == "save"
+    assert call.kwargs["env_ids"].tolist() == [0]


### PR DESCRIPTION
# Description

Preserve action-agent LeRobot episodes across both reset ordering and task outcomes.

Previously, reset invalidated the action-agent runtime cache before the record manager evaluated the completed episode. A successful run could therefore be treated as failed and skipped. This PR latches the success result before invalidation.

WAIC action-agent configs now also set `save_failed_episodes: true` for basket, relative placement, line arrangement, and stacking tasks. Failed long-horizon executions are therefore retained for frontend preview and debugging instead of leaving metadata-only dataset directories.

Dependencies: None.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Not applicable. This is a backend episode-recording fix.

## Checklist

- [x] I have run the `black .` command to format the code base.
- [x] Documentation changes are not required for this internal behavior fix.
- [x] I have added tests that prove my fix is effective.
- [x] Dependencies are unchanged.

## Testing

- Full Black check: 679 files unchanged before the follow-up; all three follow-up files pass Black.
- Failed-episode configuration coverage: 4 passed across basket, relative placement, arrangement, and stacking.
- Focused runtime-state regression tests: 3 passed.
- `tests/gym/envs/test_embodied_env.py`: 1 passed, 1 skipped.
- Full `test_base_agent_env_config.py`: 7 passed, 1 unrelated existing failure in `test_agentic_gen_sim_env_rejects_batched_state_init`, where the test fixture accesses an uninitialized robot before reaching its expected batched-environment validation.
