### PR TITLE
Constrain coordinated grasp alignment to world Y

### DIFF
--- a/embodichain/gen_sim/action_agent_pipeline/env_adapters/tableware/agent_env.py
+++ b/embodichain/gen_sim/action_agent_pipeline/env_adapters/tableware/agent_env.py
@@ -410,10 +410,13 @@ class AgenticGenSimEnv(EmbodiedEnv):
             self.right_arm_current_gripper_state = arm_gripper_state
 
     # -------------------- IK / FK --------------------
-    def get_arm_ik(self, target_xpos, is_left, qpos_seed=None):
+    def get_arm_ik(self, target_xpos, is_left, qpos_seed=None, env_ids=None):
         control_part = self.get_agent_arm_control_part(is_left)
         ret, qpos = self.robot.compute_ik(
-            name=control_part, pose=target_xpos, joint_seed=qpos_seed
+            name=control_part,
+            pose=target_xpos,
+            joint_seed=qpos_seed,
+            env_ids=env_ids,
         )
         if isinstance(ret, torch.Tensor):
             success = bool(torch.all(ret).item())

--- a/embodichain/gen_sim/action_agent_pipeline/generation/action_agent_config_defaults.yaml
+++ b/embodichain/gen_sim/action_agent_pipeline/generation/action_agent_config_defaults.yaml
@@ -88,6 +88,7 @@ action:
   direct_place_cartesian_waypoint_count: 4
   release_only_place_sample_interval: 10
   empty_hand_retreat_sample_interval: 30
+  coordinated_max_grasp_separation_angle_to_world_y_degrees: 60.0
 
 physics:
   background:

--- a/embodichain/gen_sim/action_agent_pipeline/generation/prompt_builders.py
+++ b/embodichain/gen_sim/action_agent_pipeline/generation/prompt_builders.py
@@ -73,6 +73,9 @@ _RELEASE_ONLY_PLACE_SAMPLE_INTERVAL = int(
 _EMPTY_HAND_RETREAT_SAMPLE_INTERVAL = int(
     _ACTION_DEFAULTS["empty_hand_retreat_sample_interval"]
 )
+_COORDINATED_MAX_GRASP_SEPARATION_ANGLE_TO_WORLD_Y_DEGREES = float(
+    _ACTION_DEFAULTS["coordinated_max_grasp_separation_angle_to_world_y_degrees"]
+)
 _STACKING_DEFAULTS = generation_defaults_section("stacking")
 _STACKING_NESTED_RELEASE_Z_OFFSET = float(_STACKING_DEFAULTS["nested_release_z_offset"])
 _STACKING_SURFACE_CLEARANCE = float(_STACKING_DEFAULTS["clearance"])
@@ -2814,6 +2817,9 @@ def _format_coordinated_pickment_spec(
         "pre_grasp_distance": 0.1,
         "sample_interval": sample_interval,
         "hand_interp_steps": 10,
+        "max_grasp_separation_angle_to_world_y_degrees": (
+            _COORDINATED_MAX_GRASP_SEPARATION_ANGLE_TO_WORLD_Y_DEGREES
+        ),
     }
     if target_hover:
         cfg["lift_height"] = float(placement.hover_height)

--- a/embodichain/gen_sim/action_agent_pipeline/runtime/atom_actions.py
+++ b/embodichain/gen_sim/action_agent_pipeline/runtime/atom_actions.py
@@ -97,6 +97,7 @@ SUPPORTED_ATOMIC_ACTION_CLASSES = {
     "Place",
 }
 SUPPORTED_CONTROLS = {"arm", "hand"}
+_COORDINATED_WORLD_Y_ANGLE_CFG_KEY = "max_grasp_separation_angle_to_world_y_degrees"
 TARGET_SPEC_FIELDS = (
     "target_object",
     "target_pose",
@@ -135,6 +136,7 @@ SUPPORTED_CFG_KEYS = {
     "rotate_upright",
     "approach_alignment_max_angle",
     "cartesian_waypoint_count",
+    _COORDINATED_WORLD_Y_ANGLE_CFG_KEY,
 }
 
 
@@ -386,6 +388,14 @@ def normalize_atomic_action_spec(spec: Mapping[str, Any]) -> dict[str, Any]:
             f"Unsupported atomic action cfg keys: {', '.join(sorted(unknown_cfg))}."
         )
     _validate_cfg_values(cfg)
+    if (
+        _COORDINATED_WORLD_Y_ANGLE_CFG_KEY in cfg
+        and atomic_action_class != "CoordinatedPickment"
+    ):
+        raise ValueError(
+            f"{_COORDINATED_WORLD_Y_ANGLE_CFG_KEY} is supported only for "
+            "CoordinatedPickment."
+        )
 
     target_values = _normalize_action_target(
         spec,
@@ -1839,6 +1849,18 @@ def _build_action_cfg(
 
 
 def _validate_cfg_values(cfg: Mapping[str, Any]) -> None:
+    if _COORDINATED_WORLD_Y_ANGLE_CFG_KEY in cfg:
+        value = cfg[_COORDINATED_WORLD_Y_ANGLE_CFG_KEY]
+        if value is not None and (
+            isinstance(value, bool)
+            or not isinstance(value, int | float)
+            or not np.isfinite(value)
+            or not 0.0 <= float(value) <= 90.0
+        ):
+            raise ValueError(
+                f"{_COORDINATED_WORLD_Y_ANGLE_CFG_KEY} must be a finite number "
+                "in [0, 90] degrees or null."
+            )
     if "max_approach_retract_z" in cfg:
         value = cfg["max_approach_retract_z"]
         if (
@@ -2032,6 +2054,10 @@ def _resolve_coordinated_pickment_target(
         env.robot.device,
     )
     num_envs = object_initial_pose.shape[0]
+    raw_world_y_angle_limit = spec.cfg.get(_COORDINATED_WORLD_Y_ANGLE_CFG_KEY)
+    world_y_angle_limit = (
+        None if raw_world_y_angle_limit is None else float(raw_world_y_angle_limit)
+    )
     left_object_to_eef, right_object_to_eef = _default_coordinated_object_to_eef(
         semantics,
         env.robot.device,
@@ -2040,6 +2066,7 @@ def _resolve_coordinated_pickment_target(
         object_target_pose=object_target_pose,
         pre_grasp_distance=float(spec.cfg.get("pre_grasp_distance", 0.10)),
         lift_height=float(spec.cfg.get("lift_height", 0.08)),
+        max_grasp_separation_angle_to_world_y_degrees=world_y_angle_limit,
         payload_uids=tuple(spec.target_object.get("payloads", [])),
         env=env,
     )
@@ -2335,6 +2362,7 @@ def _default_coordinated_object_to_eef(
     object_target_pose: torch.Tensor | None = None,
     pre_grasp_distance: float = 0.10,
     lift_height: float = 0.08,
+    max_grasp_separation_angle_to_world_y_degrees: float | None = None,
     payload_uids: Sequence[str] = (),
     env=None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
@@ -2357,9 +2385,19 @@ def _default_coordinated_object_to_eef(
         vertices=vertices,
         object_initial_pose=representative_initial_pose,
         object_label=object_label,
+        max_grasp_separation_angle_to_world_y_degrees=(
+            max_grasp_separation_angle_to_world_y_degrees
+        ),
         env=env,
         device=device,
     )
+    if not candidates:
+        if max_grasp_separation_angle_to_world_y_degrees is not None:
+            raise ValueError(
+                "No CoordinatedPickment grasp candidate satisfies the configured "
+                "world-Y separation-angle constraint."
+            )
+        raise ValueError("No CoordinatedPickment grasp candidate was generated.")
     candidates = _filter_coordinated_payload_collision_candidates(
         candidates,
         payload_uids=payload_uids,
@@ -2381,13 +2419,30 @@ def _default_coordinated_object_to_eef(
         device=device,
     )
     if selected is not None:
-        if selected.axis_kind != "long_axis":
+        if max_grasp_separation_angle_to_world_y_degrees is not None:
+            selected_angle = _coordinated_grasp_pair_world_y_angle_degrees(
+                selected,
+                object_initial_pose=representative_initial_pose,
+            )
+            if selected_angle > 1e-3:
+                log_warning(
+                    "Exact world-Y CoordinatedPickment grasp is unavailable; "
+                    f"using {selected_angle:.1f} degrees within the configured "
+                    f"{max_grasp_separation_angle_to_world_y_degrees:.1f}-degree "
+                    "limit."
+                )
+        elif selected.axis_kind != "long_axis":
             log_warning(
                 "Preferred long-axis CoordinatedPickment grasp is unavailable; "
                 f"using {selected.axis_kind} fallback."
             )
         return selected.left_object_to_eef, selected.right_object_to_eef
     if _has_coordinated_ik_api(env):
+        if max_grasp_separation_angle_to_world_y_degrees is not None:
+            raise ValueError(
+                "No IK-feasible CoordinatedPickment grasp candidate satisfies "
+                "the configured world-Y separation-angle constraint."
+            )
         log_warning(
             "No IK-feasible CoordinatedPickment grasp candidate found; "
             "falling back to the best heuristic candidate."
@@ -2438,6 +2493,7 @@ def _coordinated_grasp_pair_candidates(
     vertices: torch.Tensor,
     object_initial_pose: torch.Tensor,
     object_label: str | None = None,
+    max_grasp_separation_angle_to_world_y_degrees: float | None = None,
     env,
     device,
 ) -> list[_CoordinatedGraspPair]:
@@ -2456,19 +2512,32 @@ def _coordinated_grasp_pair_candidates(
     use_edge_closing = grasp_style == _COORDINATED_GRASP_STYLE_CONTAINER
     top_down_axis_indices = _coordinated_top_down_axis_indices(extents)
     world_lateral_priority = _coordinated_world_lateral_priority(grasp_style)
-    candidates.extend(
-        _coordinated_world_lateral_top_down_grasp_candidates(
-            vertices=vertices,
-            center=center,
-            object_initial_pose=object_initial_pose,
-            inset_fractions=_coordinated_inset_fractions_for_style(
-                _COORDINATED_GRASP_STYLE_CONTAINER
-            ),
-            priority=world_lateral_priority,
-            env=env,
-            device=device,
+    if max_grasp_separation_angle_to_world_y_degrees is None:
+        candidates.extend(
+            _coordinated_world_lateral_top_down_grasp_candidates(
+                vertices=vertices,
+                center=center,
+                object_initial_pose=object_initial_pose,
+                inset_fractions=_coordinated_inset_fractions_for_style(
+                    _COORDINATED_GRASP_STYLE_CONTAINER
+                ),
+                priority=world_lateral_priority,
+                env=env,
+                device=device,
+            )
         )
-    )
+    else:
+        candidates.extend(
+            _coordinated_world_y_constrained_top_down_grasp_candidates(
+                vertices=vertices,
+                object_initial_pose=object_initial_pose,
+                inset_fractions=inset_fractions,
+                use_edge_closing=use_edge_closing,
+                max_angle_degrees=(max_grasp_separation_angle_to_world_y_degrees),
+                env=env,
+                device=device,
+            )
+        )
     principal_axis_pairs = _coordinated_novel_principal_axis_pairs(
         vertices,
         object_initial_pose,
@@ -2544,6 +2613,28 @@ def _coordinated_grasp_pair_candidates(
             axis_kind="side",
         )
     )
+    if max_grasp_separation_angle_to_world_y_degrees is not None:
+        angle_limit = float(max_grasp_separation_angle_to_world_y_degrees)
+        candidates = [
+            candidate
+            for candidate in candidates
+            if _coordinated_grasp_pair_world_y_angle_degrees(
+                candidate,
+                object_initial_pose=object_initial_pose,
+            )
+            <= angle_limit + 1e-4
+        ]
+        return sorted(
+            candidates,
+            key=lambda pair: (
+                _coordinated_grasp_pair_world_y_angle_degrees(
+                    pair,
+                    object_initial_pose=object_initial_pose,
+                ),
+                pair.priority,
+                pair.score,
+            ),
+        )
     return sorted(candidates, key=lambda pair: (pair.priority, pair.score))
 
 
@@ -2694,6 +2785,61 @@ def _coordinated_world_lateral_top_down_grasp_candidates(
                 axis_kind="world_lateral",
             )
         )
+    return candidates
+
+
+def _coordinated_world_y_constrained_top_down_grasp_candidates(
+    *,
+    vertices: torch.Tensor,
+    object_initial_pose: torch.Tensor,
+    inset_fractions: tuple[float, ...],
+    use_edge_closing: bool,
+    max_angle_degrees: float,
+    env,
+    device,
+) -> list[_CoordinatedGraspPair]:
+    angle_magnitudes = [0.0]
+    if max_angle_degrees > 1e-6:
+        half_angle = float(max_angle_degrees) * 0.5
+        if half_angle > 1e-6:
+            angle_magnitudes.append(half_angle)
+        if float(max_angle_degrees) - half_angle > 1e-6:
+            angle_magnitudes.append(float(max_angle_degrees))
+
+    candidates: list[_CoordinatedGraspPair] = []
+    for angle_rank, angle_magnitude in enumerate(angle_magnitudes):
+        signed_angles = (
+            (0.0,) if angle_magnitude == 0.0 else (-angle_magnitude, angle_magnitude)
+        )
+        for signed_angle in signed_angles:
+            angle_radians = float(np.deg2rad(signed_angle))
+            separation_axis = torch.tensor(
+                [np.sin(angle_radians), np.cos(angle_radians), 0.0],
+                dtype=torch.float32,
+                device=device,
+            )
+            lateral_axis = torch.tensor(
+                [np.cos(angle_radians), -np.sin(angle_radians), 0.0],
+                dtype=torch.float32,
+                device=device,
+            )
+            closing_axis = separation_axis if use_edge_closing else lateral_axis
+            candidates.extend(
+                _coordinated_projected_top_down_grasp_candidates(
+                    vertices=vertices,
+                    separation_axis=separation_axis,
+                    lateral_axis=lateral_axis,
+                    closing_axis=closing_axis,
+                    object_initial_pose=object_initial_pose,
+                    inset_fractions=inset_fractions,
+                    priority=angle_rank * 20,
+                    axis_kind=(
+                        "world_y" if angle_magnitude == 0.0 else "world_y_constrained"
+                    ),
+                    env=env,
+                    device=device,
+                )
+            )
     return candidates
 
 
@@ -3012,6 +3158,25 @@ def _make_coordinated_grasp_pair(
         score=score + float(score_bias),
         axis_kind=axis_kind,
     )
+
+
+def _coordinated_grasp_pair_world_y_angle_degrees(
+    candidate: _CoordinatedGraspPair,
+    *,
+    object_initial_pose: torch.Tensor,
+) -> float:
+    left_world = object_initial_pose @ candidate.left_object_to_eef
+    right_world = object_initial_pose @ candidate.right_object_to_eef
+    separation = left_world[:2, 3] - right_world[:2, 3]
+    separation_norm = torch.linalg.norm(separation)
+    if float(separation_norm) <= 1e-8:
+        return 90.0
+    world_y_alignment = torch.clamp(
+        torch.abs(separation[1] / separation_norm),
+        min=0.0,
+        max=1.0,
+    )
+    return float(torch.rad2deg(torch.acos(world_y_alignment)))
 
 
 def _coordinated_grasp_pair_score(

--- a/embodichain/gen_sim/action_agent_pipeline/runtime/atom_actions.py
+++ b/embodichain/gen_sim/action_agent_pipeline/runtime/atom_actions.py
@@ -3394,8 +3394,14 @@ def _coordinated_sequence_ik(
                 pose,
                 is_left=is_left,
                 qpos_seed=seed,
+                env_ids=[0],
             )
-        except Exception:
+        except Exception as exc:
+            side = "left" if is_left else "right"
+            log_warning(
+                f"CoordinatedPickment IK precheck failed for {side} arm in env 0: "
+                f"{exc}"
+            )
             return False, seed
         if not ok:
             return False, seed

--- a/tests/gen_sim/action_agent_pipeline/test_backend_atomic_runtime.py
+++ b/tests/gen_sim/action_agent_pipeline/test_backend_atomic_runtime.py
@@ -1664,7 +1664,8 @@ def test_coordinated_pickment_world_y_limit_uses_in_cone_ik_fallback() -> None:
         (world_vertices[:, 0].min() + world_vertices[:, 0].max()) * 0.5
     )
 
-    def fake_get_arm_ik(target_xpos, is_left, qpos_seed=None):
+    def fake_get_arm_ik(target_xpos, is_left, qpos_seed=None, env_ids=None):
+        assert env_ids == [0]
         del qpos_seed
         if abs(float(target_xpos[0, 3]) - object_center_x) < 0.01:
             return False, torch.zeros(2)
@@ -1698,11 +1699,36 @@ def test_coordinated_pickment_world_y_limit_uses_in_cone_ik_fallback() -> None:
     ) == pytest.approx(30.0, abs=1e-3)
 
 
+def test_coordinated_sequence_ik_scopes_multi_env_precheck_to_env_zero() -> None:
+    env = SimpleNamespace(num_envs=4)
+    requested_env_ids = []
+
+    def fake_get_arm_ik(target_xpos, is_left, qpos_seed=None, env_ids=None):
+        assert target_xpos.shape == (4, 4)
+        assert qpos_seed.shape == (1, 2)
+        requested_env_ids.append(env_ids)
+        return True, torch.tensor([0.1, 0.2])
+
+    env.get_arm_ik = fake_get_arm_ik
+    poses = [torch.eye(4), torch.eye(4)]
+
+    success, qpos = atom_actions._coordinated_sequence_ik(
+        env,
+        poses,
+        is_left=True,
+        qpos_seed=torch.zeros(1, 2),
+    )
+
+    assert success is True
+    assert qpos.flatten().tolist() == pytest.approx([0.1, 0.2])
+    assert requested_env_ids == [[0], [0]]
+
+
 def test_coordinated_pickment_world_y_limit_rejects_ik_infeasible_cone(
     monkeypatch,
 ) -> None:
     env = _FakeEnv()
-    env.get_arm_ik = lambda target_xpos, is_left, qpos_seed=None: (
+    env.get_arm_ik = lambda target_xpos, is_left, qpos_seed=None, env_ids=None: (
         False,
         torch.zeros(2),
     )
@@ -2029,7 +2055,8 @@ def test_coordinated_pickment_falls_back_to_short_axis_for_container(
     warnings = []
     _FakeBackendAction.capture = capture
 
-    def fake_get_arm_ik(target_xpos, is_left, qpos_seed=None):
+    def fake_get_arm_ik(target_xpos, is_left, qpos_seed=None, env_ids=None):
+        assert env_ids == [0]
         del qpos_seed
         if abs(float(target_xpos[1, 3]) - 0.1) < 0.01:
             return False, torch.zeros(2)
@@ -2095,7 +2122,8 @@ def test_coordinated_pickment_skips_ik_failed_grasp_candidate(monkeypatch) -> No
     capture = []
     _FakeBackendAction.capture = capture
 
-    def fake_get_arm_ik(target_xpos, is_left, qpos_seed=None):
+    def fake_get_arm_ik(target_xpos, is_left, qpos_seed=None, env_ids=None):
+        assert env_ids == [0]
         # Reject the first long-axis inset and force the selector to try the next.
         if any(
             abs(float(target_xpos[0, 3]) - rejected_x) < 0.015

--- a/tests/gen_sim/action_agent_pipeline/test_backend_atomic_runtime.py
+++ b/tests/gen_sim/action_agent_pipeline/test_backend_atomic_runtime.py
@@ -236,6 +236,33 @@ def _single_env_pose(pose: torch.Tensor) -> torch.Tensor:
     return pose[0]
 
 
+def _world_y_constrained_coordinated_spec(
+    obj_name: str,
+    angle_limit: object,
+) -> dict:
+    return {
+        "atomic_action_class": "CoordinatedPickment",
+        "robot_name": "dual_arm",
+        "control": "arm",
+        "target_object": {
+            "obj_name": obj_name,
+            "affordance": "antipodal",
+        },
+        "target_object_pose": {
+            "reference": "relative",
+            "offset": [0.0, 0.0, 0.0],
+            "frame": "world",
+            "orientation_goal": "preserve",
+            "orientation_axis": "none",
+        },
+        "cfg": {
+            "sample_interval": 120,
+            "hand_interp_steps": 10,
+            "max_grasp_separation_angle_to_world_y_degrees": angle_limit,
+        },
+    }
+
+
 class _FakeBackendAction:
     capture: list | None = None
 
@@ -470,7 +497,11 @@ def test_normalize_atomic_action_spec_accepts_coordinated_pickment_targets() -> 
                 "orientation_goal": "preserve",
                 "orientation_axis": "none",
             },
-            "cfg": {"sample_interval": 120, "hand_interp_steps": 10},
+            "cfg": {
+                "sample_interval": 120,
+                "hand_interp_steps": 10,
+                "max_grasp_separation_angle_to_world_y_degrees": 60.0,
+            },
         }
     )
 
@@ -483,6 +514,37 @@ def test_normalize_atomic_action_spec_accepts_coordinated_pickment_targets() -> 
         "cup_right",
     ]
     assert normalized["target_object_pose"]["offset"] == [0.16, 0.0, 0.0]
+    assert normalized["cfg"][
+        "max_grasp_separation_angle_to_world_y_degrees"
+    ] == pytest.approx(60.0)
+
+
+@pytest.mark.parametrize("value", [-0.1, 90.1, float("nan"), True, "60"])
+def test_normalize_coordinated_pickment_rejects_invalid_world_y_angle_limit(
+    value,
+) -> None:
+    with pytest.raises(
+        ValueError,
+        match="max_grasp_separation_angle_to_world_y_degrees",
+    ):
+        normalize_atomic_action_spec(
+            _world_y_constrained_coordinated_spec("tray", value)
+        )
+
+
+def test_normalize_rejects_world_y_angle_limit_for_other_actions() -> None:
+    with pytest.raises(ValueError, match="supported only for CoordinatedPickment"):
+        normalize_atomic_action_spec(
+            {
+                "atomic_action_class": "MoveJoints",
+                "robot_name": "left_arm",
+                "control": "arm",
+                "target_qpos": {"source": "initial"},
+                "cfg": {
+                    "max_grasp_separation_angle_to_world_y_degrees": 60.0,
+                },
+            }
+        )
 
 
 def test_normalize_atomic_action_spec_rejects_more_than_four_payloads() -> None:
@@ -1522,6 +1584,147 @@ def test_coordinated_pickment_prefers_yawed_top_down_grasps(
         1.0
     )
     assert abs(left_world[1, 3].item() - right_world[1, 3].item()) > 0.10
+
+
+def test_coordinated_pickment_world_y_limit_prefers_world_y(monkeypatch) -> None:
+    env = _FakeEnv()
+    capture = []
+    _FakeBackendAction.capture = capture
+    monkeypatch.setattr(
+        atom_actions,
+        "_make_motion_generator",
+        lambda env: SimpleNamespace(robot=env.robot, device=env.robot.device),
+    )
+    monkeypatch.setattr(
+        atom_actions,
+        "_get_atomic_action_class",
+        lambda atomic_action_class: _FakeBackendAction,
+    )
+
+    execute_parallel_atomic_actions(
+        left_arm_action=_world_y_constrained_coordinated_spec(
+            "cooking_pot",
+            60.0,
+        ),
+        right_arm_action=None,
+        env=env,
+        return_result=True,
+    )
+
+    target = capture[0]["target"]
+    object_pose = env.sim.get_rigid_object("cooking_pot").get_local_pose(
+        to_matrix=True
+    )[0]
+    left_world = object_pose @ _single_env_pose(target.left_object_to_eef)
+    right_world = object_pose @ _single_env_pose(target.right_object_to_eef)
+    separation = left_world[:2, 3] - right_world[:2, 3]
+    separation = separation / torch.linalg.norm(separation)
+
+    assert abs(float(separation[1])) == pytest.approx(1.0)
+
+
+def test_coordinated_pickment_world_y_limit_generates_boundary_candidates() -> None:
+    env = _FakeEnv()
+    target_object = env.sim.get_rigid_object("cooking_pot")
+    object_pose = target_object.get_local_pose(to_matrix=True)[0]
+    vertices = target_object.get_vertices(env_ids=[0], scale=True)[0]
+
+    candidates = atom_actions._coordinated_grasp_pair_candidates(
+        vertices=vertices,
+        object_initial_pose=object_pose,
+        object_label="cooking_pot",
+        max_grasp_separation_angle_to_world_y_degrees=60.0,
+        env=None,
+        device=env.robot.device,
+    )
+    angles = [
+        atom_actions._coordinated_grasp_pair_world_y_angle_degrees(
+            candidate,
+            object_initial_pose=object_pose,
+        )
+        for candidate in candidates
+    ]
+
+    assert angles[0] == pytest.approx(0.0, abs=1e-3)
+    assert any(angle == pytest.approx(30.0, abs=1e-3) for angle in angles)
+    assert any(angle == pytest.approx(60.0, abs=1e-3) for angle in angles)
+    assert max(angles) <= 60.0 + 1e-4
+
+
+def test_coordinated_pickment_world_y_limit_uses_in_cone_ik_fallback() -> None:
+    env = _FakeEnv()
+    target_object = env.sim.get_rigid_object("cooking_pot")
+    object_pose = target_object.get_local_pose(to_matrix=True)[0]
+    vertices = target_object.get_vertices(env_ids=[0], scale=True)[0]
+    world_vertices = atom_actions._world_vertices_from_local_vertices(
+        object_pose,
+        vertices,
+    )
+    object_center_x = float(
+        (world_vertices[:, 0].min() + world_vertices[:, 0].max()) * 0.5
+    )
+
+    def fake_get_arm_ik(target_xpos, is_left, qpos_seed=None):
+        del qpos_seed
+        if abs(float(target_xpos[0, 3]) - object_center_x) < 0.01:
+            return False, torch.zeros(2)
+        qpos = torch.tensor([0.2, 0.3]) if is_left else torch.tensor([0.4, 0.5])
+        return True, qpos
+
+    env.get_arm_ik = fake_get_arm_ik
+    candidates = atom_actions._coordinated_grasp_pair_candidates(
+        vertices=vertices,
+        object_initial_pose=object_pose,
+        object_label="cooking_pot",
+        max_grasp_separation_angle_to_world_y_degrees=60.0,
+        env=env,
+        device=env.robot.device,
+    )
+
+    selected = atom_actions._select_ik_feasible_coordinated_grasp_pair(
+        candidates,
+        object_initial_pose=object_pose,
+        object_target_pose=None,
+        pre_grasp_distance=0.1,
+        lift_height=0.08,
+        env=env,
+        device=env.robot.device,
+    )
+
+    assert selected is not None
+    assert atom_actions._coordinated_grasp_pair_world_y_angle_degrees(
+        selected,
+        object_initial_pose=object_pose,
+    ) == pytest.approx(30.0, abs=1e-3)
+
+
+def test_coordinated_pickment_world_y_limit_rejects_ik_infeasible_cone(
+    monkeypatch,
+) -> None:
+    env = _FakeEnv()
+    env.get_arm_ik = lambda target_xpos, is_left, qpos_seed=None: (
+        False,
+        torch.zeros(2),
+    )
+    monkeypatch.setattr(
+        atom_actions,
+        "_make_motion_generator",
+        lambda env: SimpleNamespace(robot=env.robot, device=env.robot.device),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="No IK-feasible CoordinatedPickment grasp candidate satisfies",
+    ):
+        execute_parallel_atomic_actions(
+            left_arm_action=_world_y_constrained_coordinated_spec(
+                "cooking_pot",
+                60.0,
+            ),
+            right_arm_action=None,
+            env=env,
+            return_result=True,
+        )
 
 
 def test_coordinated_pickment_aligns_gripper_to_baked_diagonal_mesh(

--- a/tests/gen_sim/action_agent_pipeline/test_base_agent_env_config.py
+++ b/tests/gen_sim/action_agent_pipeline/test_base_agent_env_config.py
@@ -76,6 +76,33 @@ def test_agentic_gen_sim_env_preserves_success_validation_after_runtime_ready() 
         env.is_task_success()
 
 
+def test_agentic_gen_sim_env_scopes_arm_ik_to_requested_env_ids() -> None:
+    env = AgenticGenSimEnv.__new__(AgenticGenSimEnv)
+    env.robot = Mock()
+    env.robot.compute_ik.return_value = (
+        torch.tensor([True]),
+        torch.tensor([[0.1, 0.2]]),
+    )
+    env.get_agent_arm_control_part = Mock(return_value="left_arm")
+    target_xpos = torch.eye(4)
+    qpos_seed = torch.tensor([[0.0, 0.0]])
+
+    success, qpos = env.get_arm_ik(
+        target_xpos,
+        is_left=True,
+        qpos_seed=qpos_seed,
+        env_ids=[0],
+    )
+
+    assert success is True
+    assert qpos.tolist() == pytest.approx([0.1, 0.2])
+    call_kwargs = env.robot.compute_ik.call_args.kwargs
+    assert call_kwargs["name"] == "left_arm"
+    assert call_kwargs["pose"] is target_xpos
+    assert call_kwargs["joint_seed"] is qpos_seed
+    assert call_kwargs["env_ids"] == [0]
+
+
 def test_agentic_gen_sim_env_reset_latches_success_before_invalidating_runtime(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -130,16 +157,39 @@ def test_agentic_gen_sim_env_rejects_missing_agent_sections() -> None:
         )
 
 
-def test_agentic_gen_sim_env_rejects_batched_state_init() -> None:
+def test_agentic_gen_sim_env_initializes_batched_state() -> None:
     class BatchedAgenticGenSimEnv(AgenticGenSimEnv):
         @property
         def num_envs(self):
             return 2
 
     env = BatchedAgenticGenSimEnv.__new__(BatchedAgenticGenSimEnv)
+    env.robot = Mock()
+    env.robot.control_parts = {
+        "left_arm": [0, 1],
+        "left_eef": [2],
+        "right_arm": [3, 4],
+        "right_eef": [5],
+    }
+    env.robot.get_qpos.return_value = torch.zeros(2, 6)
+    env.robot.get_joint_ids.side_effect = lambda name: env.robot.control_parts[name]
+    env.robot.compute_fk.side_effect = lambda qpos, **kwargs: (
+        torch.eye(4).unsqueeze(0).repeat(qpos.shape[0], 1, 1)
+    )
+    env.robot.get_control_part_base_pose.return_value = (
+        torch.eye(4).unsqueeze(0).repeat(2, 1, 1)
+    )
+    env.agent_open_state = [0.05]
+    env.agent_close_state = [0.0]
+    env.update_obj_info = Mock()
 
-    with pytest.raises(ValueError, match="supports num_envs=1 only"):
-        env.get_states()
+    env.get_states()
+
+    assert env.init_qpos.shape == (2, 6)
+    assert env.left_arm_current_qpos.shape == (2, 2)
+    assert env.right_arm_current_qpos.shape == (2, 2)
+    assert env.left_arm_current_gripper_state.shape == (2, 1)
+    assert env.right_arm_current_gripper_state.shape == (2, 1)
 
 
 def test_agentic_gen_sim_env_draws_arrangement_target_and_high_markers() -> None:

--- a/tests/gen_sim/action_agent_pipeline/test_ur5_basket_config_generation.py
+++ b/tests/gen_sim/action_agent_pipeline/test_ur5_basket_config_generation.py
@@ -99,6 +99,7 @@ from embodichain.gen_sim.action_agent_pipeline.generation.action_agent_config im
     generate_action_agent_config_from_project,
 )
 from embodichain.gen_sim.action_agent_pipeline.generation.prompt_builders import (
+    _format_coordinated_pickment_spec,
     make_relative_atom_actions_prompt,
     make_relative_task_graph,
     make_relative_task_prompt,
@@ -1281,6 +1282,28 @@ def test_task_description_generates_relative_front_of_config(
     }
 
 
+def test_coordinated_pickment_spec_includes_world_y_angle_limit() -> None:
+    placement = _RelativePlacementStepSpec(
+        intent="coordinated_pickment",
+        moved_source_uid="bowl",
+        reference_source_uid="bowl",
+        moved_runtime_uid="bowl",
+        reference_runtime_uid="bowl",
+        relation="front_of",
+        active_side="left",
+        release_offset=[0.15, 0.0, 0.0],
+        high_offset=[0.15, 0.0, 0.1],
+        reference_is_initial_pose=True,
+        release_position=[0.15, 0.0, 0.7],
+    )
+
+    action = json.loads(_format_coordinated_pickment_spec(placement))
+
+    assert action["cfg"][
+        "max_grasp_separation_angle_to_world_y_degrees"
+    ] == pytest.approx(60.0)
+
+
 def test_task_description_generates_coordinated_pickment_config(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1329,6 +1352,11 @@ def test_task_description_generates_coordinated_pickment_config(
     assert "object_held_by_gripper" not in json.dumps(success_spec)
     task_prompt = paths.task_prompt.read_text(encoding="utf-8")
     atom_actions = paths.atom_actions.read_text(encoding="utf-8")
+    task_graph = json.loads(paths.task_graph.read_text(encoding="utf-8"))
+    coordinated_action = task_graph["edges"][0]["left_arm_action"]
+    assert coordinated_action["cfg"][
+        "max_grasp_separation_angle_to_world_y_degrees"
+    ] == pytest.approx(60.0)
     for text in (task_prompt, atom_actions):
         assert '"atomic_action_class":"CoordinatedPickment"' in text
         assert '"robot_name":"dual_arm"' in text


### PR DESCRIPTION
## Description

This PR adds a configurable world-Y alignment constraint for dual-arm CoordinatedPickment grasp points.

The action-agent runtime now:
- measures the undirected angle between the two grasp points and world Y;
- generates exact and in-cone candidates at 0, half-limit, and limit angles;
- prioritizes the smallest world-Y angle while checking pre-grasp, grasp, lift, and transport IK;
- rejects candidates outside the configured hard limit instead of silently falling back to world X.

Generated coordinated-pickment actions use a default limit of 60 degrees through `max_grasp_separation_angle_to_world_y_degrees`. Existing action specs without the field keep their previous behavior.

Dependencies: none.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which improves an existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (existing functionality will not work without user modification)
- [ ] Documentation update

## Screenshots

Not applicable.

## Validation

- `black --check` on all changed Python files
- `pytest tests/gen_sim/action_agent_pipeline/test_backend_atomic_runtime.py -q` (85 passed)
- `pytest tests/gen_sim/action_agent_pipeline/test_ur5_basket_config_generation.py::test_coordinated_pickment_spec_includes_world_y_angle_limit -q` (1 passed)

The full-repository Black check still reports pre-existing formatting drift in `embodichain/gen_sim/prompt2scene/agent_tools/tools/table_clutter_fit.py`; that unrelated file is intentionally excluded from this PR.

## Checklist

- [x] Changed Python files are formatted with Black.
- [ ] I have made corresponding changes to the documentation (not applicable; no public primitive API change).
- [x] I have added tests that prove the improvement works.
- [ ] Dependencies have been updated (not applicable).