### PR TITLE
Fix parallel Franka coordinated pickment IK

### DIFF
--- a/embodichain/gen_sim/action_agent_pipeline/runtime/atom_actions.py
+++ b/embodichain/gen_sim/action_agent_pipeline/runtime/atom_actions.py
@@ -3305,7 +3305,7 @@ def _select_ik_feasible_coordinated_grasp_pair(
     if not _has_coordinated_ik_api(env):
         return candidates[0] if candidates else None
     for candidate in candidates:
-        if _coordinated_grasp_pair_is_ik_feasible(
+        selected = _select_coordinated_grasp_pair_tcp_roll_variant(
             candidate,
             object_initial_pose=object_initial_pose,
             object_target_pose=object_target_pose,
@@ -3313,12 +3313,13 @@ def _select_ik_feasible_coordinated_grasp_pair(
             lift_height=lift_height,
             env=env,
             device=device,
-        ):
-            return candidate
+        )
+        if selected is not None:
+            return selected
     return None
 
 
-def _coordinated_grasp_pair_is_ik_feasible(
+def _select_coordinated_grasp_pair_tcp_roll_variant(
     candidate: _CoordinatedGraspPair,
     *,
     object_initial_pose: torch.Tensor,
@@ -3327,37 +3328,77 @@ def _coordinated_grasp_pair_is_ik_feasible(
     lift_height: float,
     env,
     device,
-) -> bool:
-    left_sequence = _coordinated_grasp_ik_sequence(
-        object_initial_pose=object_initial_pose,
-        object_target_pose=object_target_pose,
-        object_to_eef=candidate.left_object_to_eef,
-        pre_grasp_distance=pre_grasp_distance,
-        lift_height=lift_height,
-    )
-    right_sequence = _coordinated_grasp_ik_sequence(
-        object_initial_pose=object_initial_pose,
-        object_target_pose=object_target_pose,
-        object_to_eef=candidate.right_object_to_eef,
-        pre_grasp_distance=pre_grasp_distance,
-        lift_height=lift_height,
-    )
+) -> _CoordinatedGraspPair | None:
     left_seed, right_seed = _current_coordinated_arm_qpos(env, device)
-    left_ok, _ = _coordinated_sequence_ik(
-        env,
-        left_sequence,
+    left_object_to_eef = _select_coordinated_arm_tcp_roll_variant(
+        candidate.left_object_to_eef,
+        object_initial_pose=object_initial_pose,
+        object_target_pose=object_target_pose,
+        pre_grasp_distance=pre_grasp_distance,
+        lift_height=lift_height,
+        env=env,
         is_left=True,
         qpos_seed=left_seed,
     )
-    if not left_ok:
-        return False
-    right_ok, _ = _coordinated_sequence_ik(
-        env,
-        right_sequence,
+    if left_object_to_eef is None:
+        return None
+    right_object_to_eef = _select_coordinated_arm_tcp_roll_variant(
+        candidate.right_object_to_eef,
+        object_initial_pose=object_initial_pose,
+        object_target_pose=object_target_pose,
+        pre_grasp_distance=pre_grasp_distance,
+        lift_height=lift_height,
+        env=env,
         is_left=False,
         qpos_seed=right_seed,
     )
-    return right_ok
+    if right_object_to_eef is None:
+        return None
+    if (
+        left_object_to_eef is candidate.left_object_to_eef
+        and right_object_to_eef is candidate.right_object_to_eef
+    ):
+        return candidate
+    return _CoordinatedGraspPair(
+        left_object_to_eef=left_object_to_eef,
+        right_object_to_eef=right_object_to_eef,
+        priority=candidate.priority,
+        score=candidate.score,
+        axis_kind=candidate.axis_kind,
+    )
+
+
+def _select_coordinated_arm_tcp_roll_variant(
+    object_to_eef: torch.Tensor,
+    *,
+    object_initial_pose: torch.Tensor,
+    object_target_pose: torch.Tensor | None,
+    pre_grasp_distance: float,
+    lift_height: float,
+    env,
+    is_left: bool,
+    qpos_seed: torch.Tensor | None,
+) -> torch.Tensor | None:
+    mirrored_object_to_eef = object_to_eef.clone()
+    mirrored_object_to_eef[:3, 0] = -mirrored_object_to_eef[:3, 0]
+    mirrored_object_to_eef[:3, 1] = -mirrored_object_to_eef[:3, 1]
+    for variant in (object_to_eef, mirrored_object_to_eef):
+        sequence = _coordinated_grasp_ik_sequence(
+            object_initial_pose=object_initial_pose,
+            object_target_pose=object_target_pose,
+            object_to_eef=variant,
+            pre_grasp_distance=pre_grasp_distance,
+            lift_height=lift_height,
+        )
+        ok, _ = _coordinated_sequence_ik(
+            env,
+            sequence,
+            is_left=is_left,
+            qpos_seed=qpos_seed,
+        )
+        if ok:
+            return variant
+    return None
 
 
 def _coordinated_grasp_ik_sequence(

--- a/embodichain/gen_sim/action_agent_pipeline/runtime/atom_actions.py
+++ b/embodichain/gen_sim/action_agent_pipeline/runtime/atom_actions.py
@@ -75,7 +75,12 @@ from embodichain.toolkits.graspkit.pg_grasp.antipodal_generator import (
     GRASP_ANNOTATOR_CACHE_DIR,
 )
 from embodichain.utils.logger import log_info, log_warning
-from embodichain.utils.math import get_offset_pose, pose_inv
+from embodichain.utils.math import (
+    get_offset_pose,
+    matrix_from_quat,
+    pose_inv,
+    quat_from_matrix,
+)
 
 __all__ = [
     "AtomicActionSpec",
@@ -2066,6 +2071,10 @@ def _resolve_coordinated_pickment_target(
         object_target_pose=object_target_pose,
         pre_grasp_distance=float(spec.cfg.get("pre_grasp_distance", 0.10)),
         lift_height=float(spec.cfg.get("lift_height", 0.08)),
+        sample_interval=int(spec.cfg.get("sample_interval", 120)),
+        hand_interp_steps=int(spec.cfg.get("hand_interp_steps", 10)),
+        hold_steps=int(spec.cfg.get("hold_steps", 4)),
+        object_motion_keyframes=int(spec.cfg.get("object_motion_keyframes", 6)),
         max_grasp_separation_angle_to_world_y_degrees=world_y_angle_limit,
         payload_uids=tuple(spec.target_object.get("payloads", [])),
         env=env,
@@ -2362,93 +2371,121 @@ def _default_coordinated_object_to_eef(
     object_target_pose: torch.Tensor | None = None,
     pre_grasp_distance: float = 0.10,
     lift_height: float = 0.08,
+    sample_interval: int = 120,
+    hand_interp_steps: int = 10,
+    hold_steps: int = 4,
+    object_motion_keyframes: int = 6,
     max_grasp_separation_angle_to_world_y_degrees: float | None = None,
     payload_uids: Sequence[str] = (),
     env=None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
+    input_was_batched = object_initial_pose.ndim == 3
+    object_initial_pose = _ensure_batched_pose_tensor(object_initial_pose, device)
+    if object_target_pose is not None:
+        object_target_pose = _ensure_batched_pose_tensor(object_target_pose, device)
+        if object_target_pose.shape[0] != object_initial_pose.shape[0]:
+            raise ValueError(
+                "CoordinatedPickment initial and target pose batches must match."
+            )
     vertices = semantics.geometry.get("mesh_vertices")
     if vertices is None:
         vertices = semantics.entity.get_vertices(env_ids=[0], scale=True)[0]
     vertices = torch.as_tensor(vertices, dtype=torch.float32, device=device)
     if vertices.ndim != 2 or vertices.shape[-1] != 3 or vertices.numel() == 0:
         raise ValueError("CoordinatedPickment mesh_vertices must have shape (N, 3).")
-    # Coordinated grasp selection is performed on a representative single env.
-    representative_initial_pose = (
-        object_initial_pose[0] if object_initial_pose.ndim == 3 else object_initial_pose
-    )
-    representative_target_pose = (
-        object_target_pose[0]
-        if object_target_pose is not None and object_target_pose.ndim == 3
-        else object_target_pose
-    )
-    candidates = _coordinated_grasp_pair_candidates(
-        vertices=vertices,
-        object_initial_pose=representative_initial_pose,
-        object_label=object_label,
-        max_grasp_separation_angle_to_world_y_degrees=(
-            max_grasp_separation_angle_to_world_y_degrees
-        ),
-        env=env,
-        device=device,
-    )
-    if not candidates:
-        if max_grasp_separation_angle_to_world_y_degrees is not None:
-            raise ValueError(
-                "No CoordinatedPickment grasp candidate satisfies the configured "
-                "world-Y separation-angle constraint."
-            )
-        raise ValueError("No CoordinatedPickment grasp candidate was generated.")
-    candidates = _filter_coordinated_payload_collision_candidates(
-        candidates,
-        payload_uids=payload_uids,
-        object_initial_pose=representative_initial_pose,
-        env=env,
-        device=device,
-    )
-    if not candidates:
-        raise ValueError(
-            "No CoordinatedPickment grasp candidate avoids the declared payloads."
+    left_transforms = []
+    right_transforms = []
+    for env_id in range(object_initial_pose.shape[0]):
+        env_context = "" if object_initial_pose.shape[0] == 1 else f" in env {env_id}"
+        initial_pose = object_initial_pose[env_id]
+        target_pose = None if object_target_pose is None else object_target_pose[env_id]
+        candidates = _coordinated_grasp_pair_candidates(
+            vertices=vertices,
+            object_initial_pose=initial_pose,
+            object_label=object_label,
+            max_grasp_separation_angle_to_world_y_degrees=(
+                max_grasp_separation_angle_to_world_y_degrees
+            ),
+            env=env,
+            device=device,
+            env_id=env_id,
         )
-    selected = _select_ik_feasible_coordinated_grasp_pair(
-        candidates,
-        object_initial_pose=representative_initial_pose,
-        object_target_pose=representative_target_pose,
-        pre_grasp_distance=pre_grasp_distance,
-        lift_height=lift_height,
-        env=env,
-        device=device,
-    )
-    if selected is not None:
-        if max_grasp_separation_angle_to_world_y_degrees is not None:
-            selected_angle = _coordinated_grasp_pair_world_y_angle_degrees(
-                selected,
-                object_initial_pose=representative_initial_pose,
-            )
-            if selected_angle > 1e-3:
-                log_warning(
-                    "Exact world-Y CoordinatedPickment grasp is unavailable; "
-                    f"using {selected_angle:.1f} degrees within the configured "
-                    f"{max_grasp_separation_angle_to_world_y_degrees:.1f}-degree "
-                    "limit."
+        if not candidates:
+            if max_grasp_separation_angle_to_world_y_degrees is not None:
+                raise ValueError(
+                    "No CoordinatedPickment grasp candidate satisfies the configured "
+                    f"world-Y separation-angle constraint in env {env_id}."
                 )
-        elif selected.axis_kind != "long_axis":
-            log_warning(
-                "Preferred long-axis CoordinatedPickment grasp is unavailable; "
-                f"using {selected.axis_kind} fallback."
-            )
-        return selected.left_object_to_eef, selected.right_object_to_eef
-    if _has_coordinated_ik_api(env):
-        if max_grasp_separation_angle_to_world_y_degrees is not None:
             raise ValueError(
-                "No IK-feasible CoordinatedPickment grasp candidate satisfies "
-                "the configured world-Y separation-angle constraint."
+                f"No CoordinatedPickment grasp candidate was generated in env {env_id}."
             )
-        log_warning(
-            "No IK-feasible CoordinatedPickment grasp candidate found; "
-            "falling back to the best heuristic candidate."
+        candidates = _filter_coordinated_payload_collision_candidates(
+            candidates,
+            payload_uids=payload_uids,
+            object_initial_pose=initial_pose,
+            env=env,
+            device=device,
+            env_id=env_id,
         )
-    fallback = min(candidates, key=lambda pair: (pair.priority, pair.score))
-    return fallback.left_object_to_eef, fallback.right_object_to_eef
+        if not candidates:
+            raise ValueError(
+                "No CoordinatedPickment grasp candidate avoids the declared "
+                f"payloads in env {env_id}."
+            )
+        selected = _select_ik_feasible_coordinated_grasp_pair(
+            candidates,
+            object_initial_pose=initial_pose,
+            object_target_pose=target_pose,
+            pre_grasp_distance=pre_grasp_distance,
+            lift_height=lift_height,
+            sample_interval=sample_interval,
+            hand_interp_steps=hand_interp_steps,
+            hold_steps=hold_steps,
+            object_motion_keyframes=object_motion_keyframes,
+            env=env,
+            device=device,
+            env_id=env_id,
+        )
+        if selected is not None:
+            if max_grasp_separation_angle_to_world_y_degrees is not None:
+                selected_angle = _coordinated_grasp_pair_world_y_angle_degrees(
+                    selected,
+                    object_initial_pose=initial_pose,
+                )
+                if selected_angle > 1e-3:
+                    log_warning(
+                        "Exact world-Y CoordinatedPickment grasp is unavailable"
+                        f"{env_context}; using {selected_angle:.1f} degrees within "
+                        "the configured "
+                        f"{max_grasp_separation_angle_to_world_y_degrees:.1f}-degree "
+                        "limit."
+                    )
+            elif selected.axis_kind != "long_axis":
+                log_warning(
+                    "Preferred long-axis CoordinatedPickment grasp is unavailable"
+                    f"{env_context}; using {selected.axis_kind} fallback."
+                )
+        else:
+            if _has_coordinated_ik_api(env):
+                if max_grasp_separation_angle_to_world_y_degrees is not None:
+                    raise ValueError(
+                        "No IK-feasible CoordinatedPickment grasp candidate satisfies "
+                        "the configured world-Y separation-angle constraint in "
+                        f"env {env_id}."
+                    )
+                log_warning(
+                    "No IK-feasible CoordinatedPickment grasp candidate found in "
+                    f"env {env_id}; falling back to the best heuristic candidate."
+                )
+            selected = min(candidates, key=lambda pair: (pair.priority, pair.score))
+        left_transforms.append(selected.left_object_to_eef)
+        right_transforms.append(selected.right_object_to_eef)
+
+    left_result = torch.stack(left_transforms)
+    right_result = torch.stack(right_transforms)
+    if not input_was_batched:
+        return left_result[0], right_result[0]
+    return left_result, right_result
 
 
 def _filter_coordinated_payload_collision_candidates(
@@ -2458,6 +2495,7 @@ def _filter_coordinated_payload_collision_candidates(
     object_initial_pose: torch.Tensor,
     env,
     device,
+    env_id: int = 0,
 ) -> list[_CoordinatedGraspPair]:
     if not payload_uids or env is None:
         return list(candidates)
@@ -2466,7 +2504,7 @@ def _filter_coordinated_payload_collision_candidates(
         payload = env.sim.get_rigid_object(str(payload_uid))
         if payload is None:
             raise ValueError(f"Unknown coordinated payload uid: {payload_uid!r}.")
-        vertices = _object_world_vertices(payload, device)
+        vertices = _object_world_vertices(payload, device, env_id=env_id)
         payload_bounds.append(
             (
                 vertices.min(dim=0).values - 0.02,
@@ -2496,6 +2534,7 @@ def _coordinated_grasp_pair_candidates(
     max_grasp_separation_angle_to_world_y_degrees: float | None = None,
     env,
     device,
+    env_id: int = 0,
 ) -> list[_CoordinatedGraspPair]:
     mins = vertices.min(dim=0).values
     maxs = vertices.max(dim=0).values
@@ -2524,6 +2563,7 @@ def _coordinated_grasp_pair_candidates(
                 priority=world_lateral_priority,
                 env=env,
                 device=device,
+                env_id=env_id,
             )
         )
     else:
@@ -2536,6 +2576,7 @@ def _coordinated_grasp_pair_candidates(
                 max_angle_degrees=(max_grasp_separation_angle_to_world_y_degrees),
                 env=env,
                 device=device,
+                env_id=env_id,
             )
         )
     principal_axis_pairs = _coordinated_novel_principal_axis_pairs(
@@ -2558,6 +2599,7 @@ def _coordinated_grasp_pair_candidates(
                 axis_kind="long_axis" if axis_rank == 0 else "short_axis",
                 env=env,
                 device=device,
+                env_id=env_id,
             )
         )
     local_priority_offset = len(principal_axis_pairs) * 20 + principal_priority_offset
@@ -2573,6 +2615,7 @@ def _coordinated_grasp_pair_candidates(
                 object_initial_pose=object_initial_pose,
                 env=env,
                 device=device,
+                env_id=env_id,
             )
         )
     side_axis_index = _coordinated_side_axis_index(extents)
@@ -2600,6 +2643,7 @@ def _coordinated_grasp_pair_candidates(
         object_initial_pose=object_initial_pose,
         env=env,
         device=device,
+        env_id=env_id,
     )
     candidates.append(
         _make_coordinated_grasp_pair(
@@ -2608,6 +2652,7 @@ def _coordinated_grasp_pair_candidates(
             object_initial_pose=object_initial_pose,
             env=env,
             device=device,
+            env_id=env_id,
             priority=len(top_down_axis_indices) * 20 + 10,
             score_bias=10.0,
             axis_kind="side",
@@ -2654,6 +2699,7 @@ def _coordinated_top_down_grasp_candidates(
     object_initial_pose: torch.Tensor,
     env,
     device,
+    env_id: int = 0,
 ) -> list[_CoordinatedGraspPair]:
     axis_local = torch.zeros(3, dtype=torch.float32, device=device)
     axis_local[axis_index] = 1.0
@@ -2674,6 +2720,7 @@ def _coordinated_top_down_grasp_candidates(
         axis_kind=axis_kind,
         env=env,
         device=device,
+        env_id=env_id,
     )
 
 
@@ -2689,6 +2736,7 @@ def _coordinated_projected_top_down_grasp_candidates(
     axis_kind: str,
     env,
     device,
+    env_id: int = 0,
 ) -> list[_CoordinatedGraspPair]:
     world_vertices = _world_vertices_from_local_vertices(object_initial_pose, vertices)
     world_bounds_min = world_vertices.min(dim=0).values
@@ -2730,6 +2778,7 @@ def _coordinated_projected_top_down_grasp_candidates(
                 object_initial_pose=object_initial_pose,
                 env=env,
                 device=device,
+                env_id=env_id,
                 priority=priority + inset_rank,
                 score_bias=0.0,
                 axis_kind=axis_kind,
@@ -2747,6 +2796,7 @@ def _coordinated_world_lateral_top_down_grasp_candidates(
     priority: int,
     env,
     device,
+    env_id: int = 0,
 ) -> list[_CoordinatedGraspPair]:
     world_bounds_min, world_bounds_max = _world_bounds_from_local_vertices(
         object_initial_pose,
@@ -2780,6 +2830,7 @@ def _coordinated_world_lateral_top_down_grasp_candidates(
                 object_initial_pose=object_initial_pose,
                 env=env,
                 device=device,
+                env_id=env_id,
                 priority=priority + inset_rank,
                 score_bias=0.0,
                 axis_kind="world_lateral",
@@ -2797,6 +2848,7 @@ def _coordinated_world_y_constrained_top_down_grasp_candidates(
     max_angle_degrees: float,
     env,
     device,
+    env_id: int = 0,
 ) -> list[_CoordinatedGraspPair]:
     angle_magnitudes = [0.0]
     if max_angle_degrees > 1e-6:
@@ -2838,6 +2890,7 @@ def _coordinated_world_y_constrained_top_down_grasp_candidates(
                     ),
                     env=env,
                     device=device,
+                    env_id=env_id,
                 )
             )
     return candidates
@@ -3059,6 +3112,7 @@ def _make_coordinated_top_down_world_grasp_pair(
     priority: int,
     score_bias: float,
     axis_kind: str,
+    env_id: int = 0,
 ) -> _CoordinatedGraspPair:
     z_axis = torch.tensor([0.0, 0.0, -1.0], dtype=torch.float32, device=device)
     x_axis = _orthogonalized_axis(closing_axis, z_axis)
@@ -3086,6 +3140,7 @@ def _make_coordinated_top_down_world_grasp_pair(
         second_world,
         env=env,
         device=device,
+        env_id=env_id,
     )
     return _make_coordinated_grasp_pair(
         _world_pose_to_object_pose(object_initial_pose, left_world),
@@ -3093,6 +3148,7 @@ def _make_coordinated_top_down_world_grasp_pair(
         object_initial_pose=object_initial_pose,
         env=env,
         device=device,
+        env_id=env_id,
         priority=priority,
         score_bias=score_bias,
         axis_kind=axis_kind,
@@ -3142,6 +3198,7 @@ def _make_coordinated_grasp_pair(
     priority: int,
     score_bias: float,
     axis_kind: str,
+    env_id: int = 0,
 ) -> _CoordinatedGraspPair:
     left_world = object_initial_pose @ left_object_to_eef
     right_world = object_initial_pose @ right_object_to_eef
@@ -3150,6 +3207,7 @@ def _make_coordinated_grasp_pair(
         right_world,
         env=env,
         device=device,
+        env_id=env_id,
     )
     return _CoordinatedGraspPair(
         left_object_to_eef=left_object_to_eef,
@@ -3185,12 +3243,13 @@ def _coordinated_grasp_pair_score(
     *,
     env,
     device,
+    env_id: int = 0,
 ) -> float:
     left_pos = left_world[:3, 3]
     right_pos = right_world[:3, 3]
     score = -0.2 * abs(float(left_pos[1] - right_pos[1]))
     score += 0.2 * abs(float(left_pos[0] - right_pos[0]))
-    arm_positions = _current_arm_positions(env, device)
+    arm_positions = _current_arm_positions(env, device, env_id=env_id)
     if arm_positions is not None:
         left_arm_pos, right_arm_pos = arm_positions
         score += float(torch.linalg.norm(left_arm_pos - left_pos))
@@ -3241,10 +3300,11 @@ def _assign_coordinated_world_grasp_pair_to_arms(
     *,
     env,
     device,
+    env_id: int = 0,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     first_world = first_pose[:3, 3]
     second_world = second_pose[:3, 3]
-    arm_positions = _current_arm_positions(env, device)
+    arm_positions = _current_arm_positions(env, device, env_id=env_id)
     if arm_positions is not None:
         left_pos, right_pos = arm_positions
         direct_cost = torch.linalg.norm(left_pos - first_world) + torch.linalg.norm(
@@ -3270,10 +3330,11 @@ def _assign_coordinated_local_grasp_pair_to_arms(
     object_initial_pose: torch.Tensor,
     env,
     device,
+    env_id: int = 0,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     first_world = _transform_local_point(object_initial_pose, first_pose[:3, 3])
     second_world = _transform_local_point(object_initial_pose, second_pose[:3, 3])
-    arm_positions = _current_arm_positions(env, device)
+    arm_positions = _current_arm_positions(env, device, env_id=env_id)
     if arm_positions is not None:
         left_pos, right_pos = arm_positions
         direct_cost = torch.linalg.norm(left_pos - first_world) + torch.linalg.norm(
@@ -3299,8 +3360,13 @@ def _select_ik_feasible_coordinated_grasp_pair(
     object_target_pose: torch.Tensor | None,
     pre_grasp_distance: float,
     lift_height: float,
+    sample_interval: int = 120,
+    hand_interp_steps: int = 10,
+    hold_steps: int = 4,
+    object_motion_keyframes: int = 6,
     env,
     device,
+    env_id: int = 0,
 ) -> _CoordinatedGraspPair | None:
     if not _has_coordinated_ik_api(env):
         return candidates[0] if candidates else None
@@ -3311,8 +3377,13 @@ def _select_ik_feasible_coordinated_grasp_pair(
             object_target_pose=object_target_pose,
             pre_grasp_distance=pre_grasp_distance,
             lift_height=lift_height,
+            sample_interval=sample_interval,
+            hand_interp_steps=hand_interp_steps,
+            hold_steps=hold_steps,
+            object_motion_keyframes=object_motion_keyframes,
             env=env,
             device=device,
+            env_id=env_id,
         )
         if selected is not None:
             return selected
@@ -3326,19 +3397,29 @@ def _select_coordinated_grasp_pair_tcp_roll_variant(
     object_target_pose: torch.Tensor | None,
     pre_grasp_distance: float,
     lift_height: float,
+    sample_interval: int = 120,
+    hand_interp_steps: int = 10,
+    hold_steps: int = 4,
+    object_motion_keyframes: int = 6,
     env,
     device,
+    env_id: int = 0,
 ) -> _CoordinatedGraspPair | None:
-    left_seed, right_seed = _current_coordinated_arm_qpos(env, device)
+    left_seed, right_seed = _current_coordinated_arm_qpos(env, device, env_id=env_id)
     left_object_to_eef = _select_coordinated_arm_tcp_roll_variant(
         candidate.left_object_to_eef,
         object_initial_pose=object_initial_pose,
         object_target_pose=object_target_pose,
         pre_grasp_distance=pre_grasp_distance,
         lift_height=lift_height,
+        sample_interval=sample_interval,
+        hand_interp_steps=hand_interp_steps,
+        hold_steps=hold_steps,
+        object_motion_keyframes=object_motion_keyframes,
         env=env,
         is_left=True,
         qpos_seed=left_seed,
+        env_id=env_id,
     )
     if left_object_to_eef is None:
         return None
@@ -3348,9 +3429,14 @@ def _select_coordinated_grasp_pair_tcp_roll_variant(
         object_target_pose=object_target_pose,
         pre_grasp_distance=pre_grasp_distance,
         lift_height=lift_height,
+        sample_interval=sample_interval,
+        hand_interp_steps=hand_interp_steps,
+        hold_steps=hold_steps,
+        object_motion_keyframes=object_motion_keyframes,
         env=env,
         is_left=False,
         qpos_seed=right_seed,
+        env_id=env_id,
     )
     if right_object_to_eef is None:
         return None
@@ -3375,9 +3461,14 @@ def _select_coordinated_arm_tcp_roll_variant(
     object_target_pose: torch.Tensor | None,
     pre_grasp_distance: float,
     lift_height: float,
+    sample_interval: int,
+    hand_interp_steps: int,
+    hold_steps: int,
+    object_motion_keyframes: int,
     env,
     is_left: bool,
     qpos_seed: torch.Tensor | None,
+    env_id: int,
 ) -> torch.Tensor | None:
     mirrored_object_to_eef = object_to_eef.clone()
     mirrored_object_to_eef[:3, 0] = -mirrored_object_to_eef[:3, 0]
@@ -3389,12 +3480,17 @@ def _select_coordinated_arm_tcp_roll_variant(
             object_to_eef=variant,
             pre_grasp_distance=pre_grasp_distance,
             lift_height=lift_height,
+            sample_interval=sample_interval,
+            hand_interp_steps=hand_interp_steps,
+            hold_steps=hold_steps,
+            object_motion_keyframes=object_motion_keyframes,
         )
         ok, _ = _coordinated_sequence_ik(
             env,
             sequence,
             is_left=is_left,
             qpos_seed=qpos_seed,
+            env_id=env_id,
         )
         if ok:
             return variant
@@ -3408,17 +3504,119 @@ def _coordinated_grasp_ik_sequence(
     object_to_eef: torch.Tensor,
     pre_grasp_distance: float,
     lift_height: float,
+    sample_interval: int = 120,
+    hand_interp_steps: int = 10,
+    hold_steps: int = 4,
+    object_motion_keyframes: int = 6,
 ) -> list[torch.Tensor]:
     grasp = object_initial_pose @ object_to_eef
     pre_grasp = grasp.clone()
     pre_grasp[:3, 3] = grasp[:3, 3] - grasp[:3, 2] * float(pre_grasp_distance)
     lift_object_pose = object_initial_pose.clone()
     lift_object_pose[2, 3] += float(lift_height)
-    lift = lift_object_pose @ object_to_eef
-    sequence = [pre_grasp, grasp, lift]
+    segments = _coordinated_pickment_segment_lengths(
+        sample_interval=sample_interval,
+        hand_interp_steps=hand_interp_steps,
+        hold_steps=hold_steps,
+    )
+    lift_object_poses = _interpolate_coordinated_object_pose(
+        object_initial_pose,
+        lift_object_pose,
+        segments["lift"],
+        include_orientation=False,
+    )
+    lift_keyframes = _coordinated_motion_keyframe_indices(
+        segments["lift"], object_motion_keyframes, object_initial_pose.device
+    )
+    sequence = [pre_grasp, grasp]
+    sequence.extend(
+        lift_object_poses[waypoint_idx] @ object_to_eef
+        for waypoint_idx in lift_keyframes.tolist()
+    )
     if object_target_pose is not None:
-        sequence.append(object_target_pose @ object_to_eef)
+        move_object_poses = _interpolate_coordinated_object_pose(
+            lift_object_pose,
+            object_target_pose,
+            segments["move"],
+            include_orientation=True,
+        )
+        move_keyframes = _coordinated_motion_keyframe_indices(
+            segments["move"], object_motion_keyframes, object_initial_pose.device
+        )
+        sequence.extend(
+            move_object_poses[waypoint_idx] @ object_to_eef
+            for waypoint_idx in move_keyframes.tolist()
+        )
     return sequence
+
+
+def _coordinated_pickment_segment_lengths(
+    *,
+    sample_interval: int,
+    hand_interp_steps: int,
+    hold_steps: int,
+) -> dict[str, int]:
+    n_close = max(2, int(hand_interp_steps))
+    n_hold = max(0, int(hold_steps))
+    n_motion = int(sample_interval) - n_close - n_hold
+    n_approach = n_motion // 3
+    n_lift = n_motion // 3
+    n_move = n_motion - n_approach - n_lift
+    if min(n_approach, n_lift, n_move) < 2:
+        raise ValueError("Not enough waypoints for CoordinatedPickment IK precheck.")
+    return {
+        "approach": n_approach,
+        "close": n_close,
+        "lift": n_lift,
+        "move": n_move,
+        "hold": n_hold,
+    }
+
+
+def _coordinated_motion_keyframe_indices(
+    n_waypoints: int,
+    object_motion_keyframes: int,
+    device,
+) -> torch.Tensor:
+    n_keyframes = min(max(2, int(object_motion_keyframes)), int(n_waypoints))
+    return (
+        torch.linspace(0, n_waypoints - 1, steps=n_keyframes, device=device)
+        .round()
+        .to(dtype=torch.long)
+    )
+
+
+def _interpolate_coordinated_object_pose(
+    start_pose: torch.Tensor,
+    end_pose: torch.Tensor,
+    n_waypoints: int,
+    *,
+    include_orientation: bool,
+) -> torch.Tensor:
+    weights = torch.linspace(
+        0.0,
+        1.0,
+        steps=n_waypoints,
+        device=start_pose.device,
+        dtype=start_pose.dtype,
+    )
+    poses = start_pose.unsqueeze(0).repeat(n_waypoints, 1, 1)
+    poses[:, :3, 3] = torch.lerp(
+        start_pose[None, :3, 3],
+        end_pose[None, :3, 3],
+        weights[:, None],
+    )
+    if not include_orientation:
+        return poses
+
+    start_quat = quat_from_matrix(start_pose[:3, :3])
+    end_quat = quat_from_matrix(end_pose[:3, :3])
+    if float(torch.sum(start_quat * end_quat)) < 0.0:
+        end_quat = -end_quat
+    quat = torch.lerp(start_quat[None], end_quat[None], weights[:, None])
+    quat = quat / torch.linalg.norm(quat, dim=-1, keepdim=True).clamp_min(1e-8)
+    poses[:, :3, :3] = matrix_from_quat(quat)
+    return poses
 
 
 def _coordinated_sequence_ik(
@@ -3427,6 +3625,7 @@ def _coordinated_sequence_ik(
     *,
     is_left: bool,
     qpos_seed: torch.Tensor | None,
+    env_id: int = 0,
 ) -> tuple[bool, torch.Tensor | None]:
     seed = qpos_seed
     for pose in poses:
@@ -3435,12 +3634,13 @@ def _coordinated_sequence_ik(
                 pose,
                 is_left=is_left,
                 qpos_seed=seed,
-                env_ids=[0],
+                env_ids=[env_id],
             )
         except Exception as exc:
             side = "left" if is_left else "right"
             log_warning(
-                f"CoordinatedPickment IK precheck failed for {side} arm in env 0: "
+                "CoordinatedPickment IK precheck failed for "
+                f"{side} arm in env {env_id}: "
                 f"{exc}"
             )
             return False, seed
@@ -3459,6 +3659,7 @@ def _has_coordinated_ik_api(env) -> bool:
 def _current_coordinated_arm_qpos(
     env,
     device,
+    env_id: int = 0,
 ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
     if env is None or not hasattr(env, "get_current_qpos_agent"):
         return None, None
@@ -3471,11 +3672,11 @@ def _current_coordinated_arm_qpos(
     if left_qpos.ndim == 1:
         left_qpos = left_qpos.unsqueeze(0)
     else:
-        left_qpos = left_qpos[0:1]
+        left_qpos = left_qpos[env_id : env_id + 1]
     if right_qpos.ndim == 1:
         right_qpos = right_qpos.unsqueeze(0)
     else:
-        right_qpos = right_qpos[0:1]
+        right_qpos = right_qpos[env_id : env_id + 1]
     return left_qpos, right_qpos
 
 
@@ -3489,7 +3690,9 @@ def _transform_local_point(object_pose: torch.Tensor, local_point: torch.Tensor)
     return (object_pose @ homogeneous)[:3]
 
 
-def _current_arm_positions(env, device) -> tuple[torch.Tensor, torch.Tensor] | None:
+def _current_arm_positions(
+    env, device, env_id: int = 0
+) -> tuple[torch.Tensor, torch.Tensor] | None:
     if env is None or not hasattr(env, "get_current_xpos_agent"):
         return None
     try:
@@ -3498,7 +3701,7 @@ def _current_arm_positions(env, device) -> tuple[torch.Tensor, torch.Tensor] | N
         right_pose = _ensure_batched_pose_tensor(right_pose, device)
     except Exception:
         return None
-    return left_pose[0, :3, 3], right_pose[0, :3, 3]
+    return left_pose[env_id, :3, 3], right_pose[env_id, :3, 3]
 
 
 def _resolve_pose_target(env, spec: AtomicActionSpec):
@@ -3698,14 +3901,14 @@ def _surface_support_top_z(env, support_uid: str, device) -> float:
     return float(world_vertices[:, 2].max())
 
 
-def _object_world_vertices(obj, device) -> torch.Tensor:
-    vertices = _object_mesh_vertices(obj, device)
+def _object_world_vertices(obj, device, env_id: int = 0) -> torch.Tensor:
+    vertices = _object_mesh_vertices(obj, device, env_id=env_id)
     pose = _ensure_batched_pose_tensor(obj.get_local_pose(to_matrix=True), device)
-    return (pose[0, :3, :3] @ vertices.T).T + pose[0, :3, 3]
+    return (pose[env_id, :3, :3] @ vertices.T).T + pose[env_id, :3, 3]
 
 
-def _object_mesh_vertices(obj, device) -> torch.Tensor:
-    vertices = obj.get_vertices(env_ids=[0], scale=True)
+def _object_mesh_vertices(obj, device, env_id: int = 0) -> torch.Tensor:
+    vertices = obj.get_vertices(env_ids=[env_id], scale=True)
     if isinstance(vertices, (list, tuple)):
         vertices = vertices[0]
     vertices = torch.as_tensor(vertices, dtype=torch.float32, device=device)

--- a/embodichain/lab/sim/atomic_actions/primitives/coordinated_pickment.py
+++ b/embodichain/lab/sim/atomic_actions/primitives/coordinated_pickment.py
@@ -557,6 +557,77 @@ class CoordinatedPickment(AtomicAction):
             .to(dtype=torch.long)
         )
 
+    def _as_success_mask(self, success: bool | torch.Tensor) -> torch.Tensor:
+        if isinstance(success, torch.Tensor):
+            success = success.to(device=self.device, dtype=torch.bool).reshape(-1)
+            if success.numel() == 1:
+                return success.repeat(self.n_envs)
+            if success.numel() != self.n_envs:
+                logger.log_error(
+                    "IK success mask must contain one value per environment, "
+                    f"but got shape {tuple(success.shape)}.",
+                    ValueError,
+                )
+            return success
+        return torch.full(
+            (self.n_envs,), bool(success), dtype=torch.bool, device=self.device
+        )
+
+    def _log_ik_failures(
+        self,
+        control_part: str,
+        target_name: str,
+        failed_mask: torch.Tensor,
+    ) -> None:
+        failed_env_ids = torch.nonzero(failed_mask, as_tuple=False).flatten().tolist()
+        if failed_env_ids:
+            logger.log_warning(
+                f"Failed to compute IK for {control_part} {target_name} in "
+                f"environment(s) {failed_env_ids}."
+            )
+
+    def _plan_masked_arm_trajectory(
+        self,
+        control_part: str,
+        start_qpos: torch.Tensor,
+        target_poses: torch.Tensor,
+        n_waypoints: int,
+        active_mask: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        n_state = target_poses.shape[1]
+        keyframe_qpos = torch.zeros(
+            (self.n_envs, n_state, start_qpos.shape[-1]),
+            dtype=torch.float32,
+            device=self.device,
+        )
+        success_mask = active_mask.clone()
+        qpos_seed = start_qpos
+        for target_idx in range(n_state):
+            ik_success, qpos = self.robot.compute_ik(
+                pose=target_poses[:, target_idx],
+                name=control_part,
+                joint_seed=qpos_seed,
+            )
+            ik_success = self._as_success_mask(ik_success)
+            failed_mask = success_mask & ~ik_success
+            self._log_ik_failures(
+                control_part, f"target state {target_idx}", failed_mask
+            )
+            success_mask &= ik_success
+            qpos = torch.as_tensor(qpos, dtype=torch.float32, device=self.device)
+            qpos_seed = torch.where(success_mask[:, None], qpos, qpos_seed)
+            keyframe_qpos[:, target_idx] = qpos_seed
+
+        keyframe_qpos = torch.cat([start_qpos.unsqueeze(1), keyframe_qpos], dim=1)
+        trajectory = (
+            self.builder.plan_joint_traj(
+                keyframe_qpos[:, 0], keyframe_qpos[:, -1], n_waypoints
+            )
+            if n_state == 1
+            else self._interpolate_keyframe_qpos(keyframe_qpos, n_waypoints)
+        )
+        return success_mask, trajectory
+
     def _plan_synchronized_object_motion(
         self,
         left_start_qpos: torch.Tensor,
@@ -564,7 +635,8 @@ class CoordinatedPickment(AtomicAction):
         object_pose_traj: torch.Tensor,
         left_object_to_eef: torch.Tensor,
         right_object_to_eef: torch.Tensor,
-    ) -> tuple[bool, torch.Tensor, torch.Tensor]:
+        active_mask: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         n_waypoints = object_pose_traj.shape[1]
         keyframe_indices = self._select_motion_keyframe_indices(n_waypoints)
         left_traj = torch.zeros(
@@ -579,6 +651,7 @@ class CoordinatedPickment(AtomicAction):
         )
         left_qpos_seed = left_start_qpos
         right_qpos_seed = right_start_qpos
+        success_mask = active_mask.clone()
         for keyframe_col, waypoint_idx in enumerate(keyframe_indices.tolist()):
             left_xpos = torch.bmm(object_pose_traj[:, waypoint_idx], left_object_to_eef)
             right_xpos = torch.bmm(
@@ -594,25 +667,36 @@ class CoordinatedPickment(AtomicAction):
                 name=self.cfg.right_arm_control_part,
                 joint_seed=right_qpos_seed,
             )
-            if not self.builder.all_envs_success(left_success):
-                logger.log_warning(
-                    f"Failed to compute IK for {self.cfg.left_arm_control_part} "
-                    f"object waypoint {waypoint_idx}."
-                )
-                return False, left_traj, right_traj
-            if not self.builder.all_envs_success(right_success):
-                logger.log_warning(
-                    f"Failed to compute IK for {self.cfg.right_arm_control_part} "
-                    f"object waypoint {waypoint_idx}."
-                )
-                return False, left_traj, right_traj
-            left_traj[:, keyframe_col] = left_qpos
-            right_traj[:, keyframe_col] = right_qpos
-            left_qpos_seed = left_qpos
-            right_qpos_seed = right_qpos
+            left_success = self._as_success_mask(left_success)
+            right_success = self._as_success_mask(right_success)
+            self._log_ik_failures(
+                self.cfg.left_arm_control_part,
+                f"object waypoint {waypoint_idx}",
+                success_mask & ~left_success,
+            )
+            self._log_ik_failures(
+                self.cfg.right_arm_control_part,
+                f"object waypoint {waypoint_idx}",
+                success_mask & ~right_success,
+            )
+            success_mask &= left_success & right_success
+            left_qpos = torch.as_tensor(
+                left_qpos, dtype=torch.float32, device=self.device
+            )
+            right_qpos = torch.as_tensor(
+                right_qpos, dtype=torch.float32, device=self.device
+            )
+            left_qpos_seed = torch.where(
+                success_mask[:, None], left_qpos, left_qpos_seed
+            )
+            right_qpos_seed = torch.where(
+                success_mask[:, None], right_qpos, right_qpos_seed
+            )
+            left_traj[:, keyframe_col] = left_qpos_seed
+            right_traj[:, keyframe_col] = right_qpos_seed
 
         return (
-            True,
+            success_mask,
             self._interpolate_qpos_keyframes(left_traj, keyframe_indices, n_waypoints),
             self._interpolate_qpos_keyframes(right_traj, keyframe_indices, n_waypoints),
         )
@@ -639,22 +723,21 @@ class CoordinatedPickment(AtomicAction):
         right_approach_targets = torch.stack(
             [right_pre_grasp_xpos, right_grasp_xpos], dim=1
         )
-        ok, left_approach_traj = self._plan_named_arm_trajectory(
+        success_mask = torch.ones(self.n_envs, dtype=torch.bool, device=self.device)
+        success_mask, left_approach_traj = self._plan_masked_arm_trajectory(
             self.cfg.left_arm_control_part,
             left_start_qpos,
             left_approach_targets,
             segments["approach"],
+            success_mask,
         )
-        if not ok:
-            return self._fail(state)
-        ok, right_approach_traj = self._plan_named_arm_trajectory(
+        success_mask, right_approach_traj = self._plan_masked_arm_trajectory(
             self.cfg.right_arm_control_part,
             right_start_qpos,
             right_approach_targets,
             segments["approach"],
+            success_mask,
         )
-        if not ok:
-            return self._fail(state)
 
         left_grasp_qpos = left_approach_traj[:, -1]
         right_grasp_qpos = right_approach_traj[:, -1]
@@ -692,15 +775,16 @@ class CoordinatedPickment(AtomicAction):
             segments["lift"],
             include_orientation=False,
         )
-        ok, left_lift_traj, right_lift_traj = self._plan_synchronized_object_motion(
-            left_grasp_qpos,
-            right_grasp_qpos,
-            lift_object_traj,
-            held_state.left_object_to_eef,
-            held_state.right_object_to_eef,
+        success_mask, left_lift_traj, right_lift_traj = (
+            self._plan_synchronized_object_motion(
+                left_grasp_qpos,
+                right_grasp_qpos,
+                lift_object_traj,
+                held_state.left_object_to_eef,
+                held_state.right_object_to_eef,
+                success_mask,
+            )
         )
-        if not ok:
-            return self._fail(state)
 
         left_lift_qpos = left_lift_traj[:, -1]
         right_lift_qpos = right_lift_traj[:, -1]
@@ -718,15 +802,16 @@ class CoordinatedPickment(AtomicAction):
             segments["move"],
             include_orientation=True,
         )
-        ok, left_move_traj, right_move_traj = self._plan_synchronized_object_motion(
-            left_lift_qpos,
-            right_lift_qpos,
-            move_object_traj,
-            held_state.left_object_to_eef,
-            held_state.right_object_to_eef,
+        success_mask, left_move_traj, right_move_traj = (
+            self._plan_synchronized_object_motion(
+                left_lift_qpos,
+                right_lift_qpos,
+                move_object_traj,
+                held_state.left_object_to_eef,
+                held_state.right_object_to_eef,
+                success_mask,
+            )
         )
-        if not ok:
-            return self._fail(state)
 
         left_target_qpos = left_move_traj[:, -1]
         right_target_qpos = right_move_traj[:, -1]
@@ -760,6 +845,11 @@ class CoordinatedPickment(AtomicAction):
             ],
             dim=1,
         )
+        full = torch.where(
+            success_mask[:, None, None],
+            full,
+            state.last_qpos.to(self.device)[:, None, :],
+        )
         coordinated_held_object = CoordinatedHeldObjectState(
             semantics=held_state.semantics,
             left_object_to_eef=held_state.left_object_to_eef,
@@ -768,7 +858,7 @@ class CoordinatedPickment(AtomicAction):
             right_grasp_xpos=right_target_xpos,
         )
         return ActionResult(
-            success=True,
+            success=success_mask,
             trajectory=full,
             next_state=WorldState(
                 last_qpos=full[:, -1, :].clone(),

--- a/tests/gen_sim/action_agent_pipeline/test_backend_atomic_runtime.py
+++ b/tests/gen_sim/action_agent_pipeline/test_backend_atomic_runtime.py
@@ -1724,6 +1724,79 @@ def test_coordinated_sequence_ik_scopes_multi_env_precheck_to_env_zero() -> None
     assert requested_env_ids == [[0], [0]]
 
 
+def test_coordinated_grasp_selector_uses_feasible_tcp_roll_variant() -> None:
+    env = _FakeEnv()
+    ik_orientations = []
+
+    def fake_get_arm_ik(target_xpos, is_left, qpos_seed=None, env_ids=None):
+        assert env_ids == [0]
+        del qpos_seed
+        x_axis_sign = float(target_xpos[0, 0])
+        ik_orientations.append((is_left, x_axis_sign))
+        is_feasible = x_axis_sign > 0.0 if is_left else x_axis_sign < 0.0
+        return is_feasible, torch.tensor([0.1, 0.2])
+
+    env.get_arm_ik = fake_get_arm_ik
+    left_object_to_eef = torch.eye(4)
+    left_object_to_eef[1, 3] = 0.2
+    right_object_to_eef = torch.eye(4)
+    right_object_to_eef[1, 3] = -0.2
+    candidate = atom_actions._CoordinatedGraspPair(
+        left_object_to_eef=left_object_to_eef,
+        right_object_to_eef=right_object_to_eef,
+        priority=3,
+        score=1.5,
+        axis_kind="world_y",
+    )
+    object_pose = torch.eye(4)
+
+    selected = atom_actions._select_ik_feasible_coordinated_grasp_pair(
+        [candidate],
+        object_initial_pose=object_pose,
+        object_target_pose=None,
+        pre_grasp_distance=0.1,
+        lift_height=0.08,
+        env=env,
+        device=env.robot.device,
+    )
+
+    assert selected is not None
+    assert selected.left_object_to_eef is left_object_to_eef
+    assert selected.right_object_to_eef[:3, 0].tolist() == pytest.approx(
+        [-1.0, 0.0, 0.0]
+    )
+    assert selected.right_object_to_eef[:3, 1].tolist() == pytest.approx(
+        [0.0, -1.0, 0.0]
+    )
+    assert selected.left_object_to_eef[:3, 3].tolist() == pytest.approx(
+        candidate.left_object_to_eef[:3, 3].tolist()
+    )
+    assert selected.right_object_to_eef[:3, 3].tolist() == pytest.approx(
+        candidate.right_object_to_eef[:3, 3].tolist()
+    )
+    assert selected.priority == candidate.priority
+    assert selected.score == pytest.approx(candidate.score)
+    assert selected.axis_kind == candidate.axis_kind
+    assert atom_actions._coordinated_grasp_pair_world_y_angle_degrees(
+        selected,
+        object_initial_pose=object_pose,
+    ) == pytest.approx(
+        atom_actions._coordinated_grasp_pair_world_y_angle_degrees(
+            candidate,
+            object_initial_pose=object_pose,
+        )
+    )
+    assert ik_orientations == [
+        (True, 1.0),
+        (True, 1.0),
+        (True, 1.0),
+        (False, 1.0),
+        (False, -1.0),
+        (False, -1.0),
+        (False, -1.0),
+    ]
+
+
 def test_coordinated_pickment_world_y_limit_rejects_ik_infeasible_cone(
     monkeypatch,
 ) -> None:

--- a/tests/gen_sim/action_agent_pipeline/test_backend_atomic_runtime.py
+++ b/tests/gen_sim/action_agent_pipeline/test_backend_atomic_runtime.py
@@ -43,6 +43,7 @@ from embodichain.gen_sim.action_agent_pipeline.runtime.task_graph import (
 )
 from embodichain.lab.sim.atomic_actions import (
     ActionResult,
+    AntipodalAffordance,
     CoordinatedHeldObjectState,
     CoordinatedPickmentCfg,
     CoordinatedPickmentTarget,
@@ -54,6 +55,7 @@ from embodichain.lab.sim.atomic_actions import (
     MoveEndEffectorCfg,
     MoveHeldObjectCfg,
     MoveJointsCfg,
+    ObjectSemantics,
     PickUpCfg,
     PlaceCfg,
     WorldState,
@@ -1699,7 +1701,7 @@ def test_coordinated_pickment_world_y_limit_uses_in_cone_ik_fallback() -> None:
     ) == pytest.approx(30.0, abs=1e-3)
 
 
-def test_coordinated_sequence_ik_scopes_multi_env_precheck_to_env_zero() -> None:
+def test_coordinated_sequence_ik_scopes_precheck_to_requested_env() -> None:
     env = SimpleNamespace(num_envs=4)
     requested_env_ids = []
 
@@ -1717,11 +1719,108 @@ def test_coordinated_sequence_ik_scopes_multi_env_precheck_to_env_zero() -> None
         poses,
         is_left=True,
         qpos_seed=torch.zeros(1, 2),
+        env_id=2,
     )
 
     assert success is True
     assert qpos.flatten().tolist() == pytest.approx([0.1, 0.2])
-    assert requested_env_ids == [[0], [0]]
+    assert requested_env_ids == [[2], [2]]
+
+
+def test_coordinated_grasp_precheck_covers_motion_keyframes() -> None:
+    object_initial_pose = torch.eye(4)
+    object_target_pose = torch.eye(4)
+    object_target_pose[0, 3] = 0.3
+
+    sequence = atom_actions._coordinated_grasp_ik_sequence(
+        object_initial_pose=object_initial_pose,
+        object_target_pose=object_target_pose,
+        object_to_eef=torch.eye(4),
+        pre_grasp_distance=0.1,
+        lift_height=0.1,
+        sample_interval=120,
+        hand_interp_steps=10,
+        hold_steps=20,
+        object_motion_keyframes=6,
+    )
+
+    assert len(sequence) == 14
+    assert sequence[0][:3, 3].tolist() == pytest.approx([0.0, 0.0, -0.1])
+    assert sequence[1][:3, 3].tolist() == pytest.approx([0.0, 0.0, 0.0])
+    assert sequence[2][:3, 3].tolist() == pytest.approx([0.0, 0.0, 0.0])
+    assert sequence[7][:3, 3].tolist() == pytest.approx([0.0, 0.0, 0.1])
+    assert sequence[8][:3, 3].tolist() == pytest.approx([0.0, 0.0, 0.1])
+    assert sequence[-1][:3, 3].tolist() == pytest.approx([0.3, 0.0, 0.0])
+
+
+def test_coordinated_grasp_selection_is_per_environment() -> None:
+    device = torch.device("cpu")
+    env = SimpleNamespace(robot=SimpleNamespace(device=device))
+    env.get_current_qpos_agent = lambda: (
+        torch.zeros(2, 2),
+        torch.zeros(2, 2),
+    )
+    left_xpos = torch.eye(4).unsqueeze(0).repeat(2, 1, 1)
+    right_xpos = left_xpos.clone()
+    left_xpos[:, 1, 3] = 0.4
+    right_xpos[:, 1, 3] = -0.4
+    env.get_current_xpos_agent = lambda: (left_xpos, right_xpos)
+    requested_env_ids = []
+
+    def fake_get_arm_ik(target_xpos, is_left, qpos_seed=None, env_ids=None):
+        del target_xpos, is_left
+        assert qpos_seed.shape == (1, 2)
+        requested_env_ids.append(env_ids)
+        return True, torch.tensor([0.1, 0.2])
+
+    env.get_arm_ik = fake_get_arm_ik
+    initial_poses = torch.eye(4).unsqueeze(0).repeat(2, 1, 1)
+    yaw = torch.deg2rad(torch.tensor(35.0))
+    initial_poses[1, 0, 0] = torch.cos(yaw)
+    initial_poses[1, 0, 1] = -torch.sin(yaw)
+    initial_poses[1, 1, 0] = torch.sin(yaw)
+    initial_poses[1, 1, 1] = torch.cos(yaw)
+    target_poses = initial_poses.clone()
+    target_poses[:, 0, 3] += 0.2
+    vertices = torch.tensor(
+        [
+            [-0.25, -0.15, 0.0],
+            [0.25, -0.15, 0.0],
+            [-0.25, 0.15, 0.0],
+            [0.25, 0.15, 0.0],
+            [-0.25, -0.15, 0.08],
+            [0.25, -0.15, 0.08],
+            [-0.25, 0.15, 0.08],
+            [0.25, 0.15, 0.08],
+        ]
+    )
+    semantics = ObjectSemantics(
+        affordance=AntipodalAffordance(),
+        geometry={"mesh_vertices": vertices},
+        label="plastic_bowl",
+    )
+
+    left_object_to_eef, right_object_to_eef = (
+        atom_actions._default_coordinated_object_to_eef(
+            semantics,
+            device,
+            initial_poses,
+            object_target_pose=target_poses,
+            max_grasp_separation_angle_to_world_y_degrees=60.0,
+            env=env,
+        )
+    )
+
+    assert left_object_to_eef.shape == (2, 4, 4)
+    assert right_object_to_eef.shape == (2, 4, 4)
+    assert not torch.allclose(left_object_to_eef[0], left_object_to_eef[1])
+    assert {env_ids[0] for env_ids in requested_env_ids} == {0, 1}
+    for env_id in range(2):
+        left_world = initial_poses[env_id] @ left_object_to_eef[env_id]
+        right_world = initial_poses[env_id] @ right_object_to_eef[env_id]
+        separation = left_world[:2, 3] - right_world[:2, 3]
+        separation /= torch.linalg.norm(separation)
+        assert abs(float(separation[1])) == pytest.approx(1.0, abs=1e-4)
 
 
 def test_coordinated_grasp_selector_uses_feasible_tcp_roll_variant() -> None:
@@ -1786,15 +1885,7 @@ def test_coordinated_grasp_selector_uses_feasible_tcp_roll_variant() -> None:
             object_initial_pose=object_pose,
         )
     )
-    assert ik_orientations == [
-        (True, 1.0),
-        (True, 1.0),
-        (True, 1.0),
-        (False, 1.0),
-        (False, -1.0),
-        (False, -1.0),
-        (False, -1.0),
-    ]
+    assert ik_orientations == ([(True, 1.0)] * 8 + [(False, 1.0)] + [(False, -1.0)] * 8)
 
 
 def test_coordinated_pickment_world_y_limit_rejects_ik_infeasible_cone(

--- a/tests/sim/atomic_actions/test_actions.py
+++ b/tests/sim/atomic_actions/test_actions.py
@@ -1359,7 +1359,7 @@ class TestCoordinatedPickmentAction:
             ),
             state,
         )
-        assert result.success is True
+        assert result.success_all
         assert result.trajectory.shape == (NUM_ENVS, 30, DUAL_TOTAL_DOF)
         assert torch.allclose(
             result.trajectory[:, -1, action.left_hand_joint_ids],
@@ -1374,6 +1374,62 @@ class TestCoordinatedPickmentAction:
             CoordinatedHeldObjectState,
         )
         assert result.next_state.held_object is None
+
+    def test_execute_preserves_successful_environments_after_partial_ik_failure(self):
+        cfg = CoordinatedPickmentCfg(
+            left_hand_open_qpos=_hand_open(),
+            left_hand_close_qpos=_hand_close(),
+            right_hand_open_qpos=_hand_open(),
+            right_hand_close_qpos=_hand_close(),
+            sample_interval=30,
+            hand_interp_steps=4,
+            hold_steps=2,
+            object_motion_keyframes=3,
+        )
+        action = CoordinatedPickment(self.mg, cfg)
+        original_compute_ik = self.mg.robot.compute_ik
+
+        def fail_second_env_during_move(
+            pose=None, name=None, joint_seed=None, qpos_seed=None
+        ):
+            success, qpos = original_compute_ik(
+                pose=pose,
+                name=name,
+                joint_seed=joint_seed,
+                qpos_seed=qpos_seed,
+            )
+            if name == "right_arm" and float(pose[1, 0, 3]) > 0.15:
+                success = success.clone()
+                success[1] = False
+            return success, qpos
+
+        self.mg.robot.compute_ik = fail_second_env_during_move
+        target_pose = torch.eye(4)
+        target_pose[0, 3] = 0.3
+        state = WorldState(last_qpos=torch.zeros(NUM_ENVS, DUAL_TOTAL_DOF))
+        semantics = ObjectSemantics(
+            affordance=AntipodalAffordance(), geometry={}, label="tray"
+        )
+
+        result = action.execute(
+            CoordinatedPickmentTarget(
+                object_target_pose=target_pose,
+                object_semantics=semantics,
+                left_object_to_eef=torch.eye(4),
+                right_object_to_eef=torch.eye(4),
+                object_initial_pose=torch.eye(4),
+            ),
+            state,
+        )
+
+        assert result.success.tolist() == [True, False]
+        assert result.trajectory.shape == (NUM_ENVS, 30, DUAL_TOTAL_DOF)
+        assert not torch.allclose(result.trajectory[0], state.last_qpos[0])
+        assert torch.allclose(
+            result.trajectory[1],
+            state.last_qpos[1].unsqueeze(0).repeat(30, 1),
+        )
+        assert torch.allclose(result.next_state.last_qpos[1], state.last_qpos[1])
 
     def test_execute_preserves_batched_object_to_eef_transforms(self):
         cfg = CoordinatedPickmentCfg(


### PR DESCRIPTION
## Description

This PR fixes multi-environment dual-arm `CoordinatedPickment` IK failures on Franka robots.

The runtime now selects grasp candidates and TCP-roll variants independently for each environment using that environment's object poses, joint seeds, and IK scope. IK prechecks cover the actual approach, lift, and move keyframes instead of only endpoint poses. The atomic action also preserves a per-environment success mask so one failed environment no longer invalidates every environment in the batch.

Dependencies: None.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (existing functionality will not work without user modification)
- [ ] Documentation update

## Validation

- Coordinated runtime tests: 25 passed
- CoordinatedPickment atomic-action tests: 4 passed
- Live Franka `task1_0` run with 4 parallel environments: 4/4 succeeded
- Black and `git diff --check` pass for all changed files

## Checklist

- [x] Changed Python files are formatted with Black
- [x] Tests prove the fix is effective
- [x] No dependency updates are required
- [x] No public API documentation changes are required