### PR TITLE
Fix stacking anchors to use robot-view world X

### DIFF
--- a/embodichain/gen_sim/action_agent_pipeline/generation/stacking_spec.py
+++ b/embodichain/gen_sim/action_agent_pipeline/generation/stacking_spec.py
@@ -39,7 +39,6 @@ from embodichain.gen_sim.action_agent_pipeline.generation.mesh_bounds import (
     _iter_generated_scene_object_configs,
     _mesh_config_local_zmin_after_rotation,
     _mesh_config_world_xy_center,
-    _mesh_config_world_xy_axes,
     _mesh_config_world_xy_bounds,
     _mesh_config_world_z_bounds,
 )
@@ -467,12 +466,12 @@ def _generated_stacking_anchor_xy(
         return center
 
     table_bounds = _mesh_config_world_xy_bounds(table_config)
-    local_front, _ = _mesh_config_world_xy_axes(table_config)
-    local_back = [-local_front[0], -local_front[1]]
+    robot_front = [1.0, 0.0]
+    robot_back = [-1.0, 0.0]
     directions = (
         [0.0, 0.0],
-        local_back,
-        local_front,
+        robot_back,
+        robot_front,
     )
     obstacle_bounds = []
     for config in object_configs.values():
@@ -498,8 +497,8 @@ def _generated_stacking_anchor_xy(
             continue
         return candidate
     fallback = [
-        round(center[0] + _ANCHOR_OFFSET * local_back[0], 6),
-        round(center[1] + _ANCHOR_OFFSET * local_back[1], 6),
+        round(center[0] + _ANCHOR_OFFSET * robot_back[0], 6),
+        round(center[1] + _ANCHOR_OFFSET * robot_back[1], 6),
     ]
     log_warning(
         "No clear stacking anchor found at the table center, back, or front; "

--- a/embodichain/gen_sim/action_agent_pipeline/generation/stacking_spec.py
+++ b/embodichain/gen_sim/action_agent_pipeline/generation/stacking_spec.py
@@ -52,6 +52,7 @@ from embodichain.gen_sim.action_agent_pipeline.generation.scene_objects import (
     _arm_side_for_position,
     _pick_table,
 )
+from embodichain.utils.logger import log_warning
 
 __all__ = [
     "_build_stacking_spec_with_llm",
@@ -466,13 +467,12 @@ def _generated_stacking_anchor_xy(
         return center
 
     table_bounds = _mesh_config_world_xy_bounds(table_config)
-    local_front, local_left = _mesh_config_world_xy_axes(table_config)
+    local_front, _ = _mesh_config_world_xy_axes(table_config)
+    local_back = [-local_front[0], -local_front[1]]
     directions = (
         [0.0, 0.0],
+        local_back,
         local_front,
-        [-local_front[0], -local_front[1]],
-        [-local_left[0], -local_left[1]],
-        local_left,
     )
     obstacle_bounds = []
     for config in object_configs.values():
@@ -497,11 +497,15 @@ def _generated_stacking_anchor_xy(
         ):
             continue
         return candidate
-    raise ValueError(
-        "Unable to find an unoccupied stacking anchor at the table center or "
-        f"its {_ANCHOR_OFFSET:g} m front/left/right/back offsets with "
-        f"{_ANCHOR_CLEARANCE_RADIUS:g} m obstacle clearance."
+    fallback = [
+        round(center[0] + _ANCHOR_OFFSET * local_back[0], 6),
+        round(center[1] + _ANCHOR_OFFSET * local_back[1], 6),
+    ]
+    log_warning(
+        "No clear stacking anchor found at the table center, back, or front; "
+        f"forcing the table-back point {fallback}."
     )
+    return fallback
 
 
 def _xy_point_in_bounds(

--- a/tests/gen_sim/action_agent_pipeline/test_stacking_spec.py
+++ b/tests/gen_sim/action_agent_pipeline/test_stacking_spec.py
@@ -244,34 +244,29 @@ def test_object_anchored_nested_stack_centers_each_inner_container() -> None:
     ("blocked_count", "expected_direction"),
     [
         (0, [0.0, 0.0]),
-        (1, [0.0, -1.0]),
-        (2, [0.0, 1.0]),
-        (3, [0.0, -1.0]),
+        (1, [-1.0, 0.0]),
+        (2, [1.0, 0.0]),
+        (3, [-1.0, 0.0]),
     ],
 )
-def test_stacking_anchor_uses_fixed_table_axis_candidate_order(
+def test_stacking_anchor_uses_robot_view_world_x_candidate_order(
     monkeypatch: pytest.MonkeyPatch,
     blocked_count: int,
     expected_direction: list[float],
 ) -> None:
-    table = {"uid": "table"}
+    table = {"uid": "table", "init_rot": [0.0, 0.0, -90.0]}
     obstacle = {"uid": "cup"}
     offset = stacking_spec._ANCHOR_OFFSET
     candidate_order = (
         [0.0, 0.0],
-        [0.0, -offset],
-        [0.0, offset],
+        [-offset, 0.0],
+        [offset, 0.0],
     )
     blocked = candidate_order[:blocked_count]
     monkeypatch.setattr(
         stacking_spec,
         "_mesh_config_world_xy_center",
         lambda config: [0.0, 0.0],
-    )
-    monkeypatch.setattr(
-        stacking_spec,
-        "_mesh_config_world_xy_axes",
-        lambda config: ([0.0, 1.0], [-1.0, 0.0]),
     )
     monkeypatch.setattr(
         stacking_spec,
@@ -307,11 +302,6 @@ def test_stacking_anchor_treats_task_objects_as_obstacles(
         stacking_spec,
         "_mesh_config_world_xy_center",
         lambda config: [0.0, 0.0],
-    )
-    monkeypatch.setattr(
-        stacking_spec,
-        "_mesh_config_world_xy_axes",
-        lambda config: ([1.0, 0.0], [0.0, 1.0]),
     )
     monkeypatch.setattr(
         stacking_spec,
@@ -351,11 +341,6 @@ def test_stacking_anchor_falls_back_to_back_without_clearance(
         stacking_spec,
         "_mesh_config_world_xy_center",
         lambda config: [0.0, 0.0],
-    )
-    monkeypatch.setattr(
-        stacking_spec,
-        "_mesh_config_world_xy_axes",
-        lambda config: ([1.0, 0.0], [0.0, 1.0]),
     )
     monkeypatch.setattr(
         stacking_spec,

--- a/tests/gen_sim/action_agent_pipeline/test_stacking_spec.py
+++ b/tests/gen_sim/action_agent_pipeline/test_stacking_spec.py
@@ -244,10 +244,9 @@ def test_object_anchored_nested_stack_centers_each_inner_container() -> None:
     ("blocked_count", "expected_direction"),
     [
         (0, [0.0, 0.0]),
-        (1, [0.0, 1.0]),
-        (2, [0.0, -1.0]),
-        (3, [1.0, 0.0]),
-        (4, [-1.0, 0.0]),
+        (1, [0.0, -1.0]),
+        (2, [0.0, 1.0]),
+        (3, [0.0, -1.0]),
     ],
 )
 def test_stacking_anchor_uses_fixed_table_axis_candidate_order(
@@ -260,10 +259,8 @@ def test_stacking_anchor_uses_fixed_table_axis_candidate_order(
     offset = stacking_spec._ANCHOR_OFFSET
     candidate_order = (
         [0.0, 0.0],
-        [0.0, offset],
         [0.0, -offset],
-        [offset, 0.0],
-        [-offset, 0.0],
+        [0.0, offset],
     )
     blocked = candidate_order[:blocked_count]
     monkeypatch.setattr(
@@ -332,7 +329,7 @@ def test_stacking_anchor_treats_task_objects_as_obstacles(
         object_configs={"table": table, "cube": task_object},
     )
 
-    assert anchor == pytest.approx([stacking_spec._ANCHOR_OFFSET, 0.0])
+    assert anchor == pytest.approx([-stacking_spec._ANCHOR_OFFSET, 0.0])
 
 
 def test_stacking_anchor_uses_bounds_clearance_not_point_occupancy() -> None:
@@ -344,7 +341,7 @@ def test_stacking_anchor_uses_bounds_clearance_not_point_occupancy() -> None:
     assert distance == pytest.approx(0.19)
 
 
-def test_stacking_anchor_rejects_all_candidates_without_clearance(
+def test_stacking_anchor_falls_back_to_back_without_clearance(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     table = {"uid": "table"}
@@ -373,12 +370,13 @@ def test_stacking_anchor_rejects_all_candidates_without_clearance(
         ),
     )
 
-    with pytest.raises(ValueError, match="obstacle clearance"):
-        stacking_spec._generated_stacking_anchor_xy(
-            table,
-            [0.0, 0.0],
-            object_configs={"table": table, "cube": obstacle},
-        )
+    anchor = stacking_spec._generated_stacking_anchor_xy(
+        table,
+        [0.0, 0.0],
+        object_configs={"table": table, "cube": obstacle},
+    )
+
+    assert anchor == pytest.approx([-stacking_spec._ANCHOR_OFFSET, 0.0])
 
 
 def test_relative_placements_are_ordered_by_moved_object_dependency() -> None:


### PR DESCRIPTION
## Description

This PR makes free-stack anchor selection follow the established robot-view coordinate convention instead of the table mesh's rotated local axes.

It:
- searches the table center, robot-view back (`-world X`), then robot-view front (`+world X`);
- falls back to the robot-view back point when all candidates fail clearance checks;
- removes the table-local-axis dependency that could turn front/back candidates into left/right candidates after scene rotation;
- adds regression coverage for a table rotated by `-90` degrees.

Dependencies: None.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Documentation update

## Validation

- `22 passed`: stacking unit tests plus two-block stacking config generation
- Changed files pass Black formatting checks
- `git diff --check` passes
- Replaying the reported generated scene changes the anchor from `[0.0, 0.15]` to `[-0.15, 0.0]`
- Repository-wide Black check is currently blocked by an unrelated existing formatting issue in `table_clutter_fit.py`
- Two existing mesh-center integration assertions remain inconsistent with the current branch's mesh normalization output and fail independently of this direction change

## Screenshots

Not applicable.

## Checklist

- [ ] I have run the `black .` command to format the entire code base
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove the fix is effective
- [x] Dependencies are unchanged