### PR TITLE
Fix dataset manager reset guard

### DIFF
--- a/embodichain/lab/gym/envs/embodied_env.py
+++ b/embodichain/lab/gym/envs/embodied_env.py
@@ -566,7 +566,10 @@ class EmbodiedEnv(BaseEnv):
         if self.cfg.rewards:
             self.reward_manager.reset(env_ids=env_ids)
 
-        if self.cfg.dataset:
+        # Dataset saving can be disabled while the dataset configuration remains
+        # present.  In that mode no DatasetManager is created in __init__, so
+        # reset must not dereference the optional manager.
+        if self.cfg.dataset and self.dataset_manager is not None:
             self.dataset_manager.reset(env_ids=env_ids)
 
     def _infer_rollout_buffer_mode(self, rollout_buffer: TensorDict) -> str:


### PR DESCRIPTION
## Description

This PR prevents `EmbodiedEnv.reset()` from dereferencing `dataset_manager` when a dataset configuration is present but dataset saving is disabled.

This keeps resets working in configurations where no `DatasetManager` is initialized.

Dependencies: None.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (existing functionality will not work without user modification)
- [ ] Documentation update

## Screenshots

Not applicable.

## Checklist

- [ ] I have run the `black .` command to format the code base.
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Dependencies have been updated, if applicable.

Validation: `black --check embodichain/lab/gym/envs/embodied_env.py` and `python -m compileall -q embodichain/lab/gym/envs/embodied_env.py` both passed.