### PR TITLE
Simplify default scene lighting

### DIFF
--- a/embodichain/lab/sim/sim_manager.py
+++ b/embodichain/lab/sim/sim_manager.py
@@ -728,18 +728,7 @@ class SimulationManager:
         pointing downward along the -Z axis.
         """
         # Environment emission light
-        self.set_emission_light([1.0, 1.0, 1.0], 120.0)
-
-        # Directional light as global scene light
-        dir_light_cfg = LightCfg(
-            uid="default_global_light",
-            light_type="sun",
-            intensity=8.0,
-            direction=(0.0, 0.0, -1.0),
-            color=(1.0, 0.95, 0.85),
-            enable_shadow=True,
-        )
-        self.add_light(dir_light_cfg)
+        self.set_emission_light([1.0, 1.0, 1.0], 100.0)
 
     def set_default_background(self) -> None:
         """Set default background."""

--- a/scripts/tutorials/gym/modular_env.py
+++ b/scripts/tutorials/gym/modular_env.py
@@ -69,24 +69,10 @@ class ExampleEventCfg:
         },
     )
 
-    randomize_light: EventCfg = EventCfg(
-        func=rand.randomize_light,
-        mode="interval",
-        interval_step=5,
-        params={
-            "entity_cfg": SceneEntityCfg(
-                uid="point",
-            ),
-            "position_range": [[-0.5, -0.5, 2], [0.5, 0.5, 2]],
-            "color_range": [[0.6, 0.6, 0.6], [1, 1, 1]],
-            "intensity_range": [10.0, 30.0],
-        },
-    )
-
     randomize_table_mat: EventCfg = EventCfg(
         func=rand.randomize_visual_material,
         mode="interval",
-        interval_step=10,
+        interval_step=25,
         params={
             "entity_cfg": SceneEntityCfg(
                 uid="table",
@@ -138,18 +124,6 @@ class ExampleCfg(EmbodiedEnvCfg):
             ),
         )
     ]
-
-    light: EmbodiedEnvCfg.EnvLightCfg = EmbodiedEnvCfg.EnvLightCfg(
-        direct=[
-            LightCfg(
-                uid="point",
-                light_type="point",
-                color=(1.0, 1.0, 1.0),
-                intensity=20.0,
-                init_pos=(0, 0, 2),
-            )
-        ]
-    )
 
     background: List[RigidObjectCfg] = [
         RigidObjectCfg(
@@ -221,14 +195,14 @@ if __name__ == "__main__":
             render_cfg=RenderCfg(renderer=args.renderer),
             headless=args.headless,
             sim_device=args.device,
-            num_envs=args.num_envs,
-        )
+        ),
+        num_envs=args.num_envs,
     )
 
     # Create the Gym environment
     env = gym.make("ModularEnv-v1", cfg=env_cfg)
 
-    while True:
+    for i in range(5):
         obs, info = env.reset()
 
         for i in range(100):


### PR DESCRIPTION
## Description

This PR simplifies default simulation lighting and updates the modular Gym tutorial for more predictable, finite runs.

The default scene now uses a lower-intensity environment emission light without an additional directional light. The tutorial no longer configures or randomizes a point light, randomizes table materials less frequently, and exits after five episodes.

Dependencies: None.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which improves an existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (existing functionality will not work without user modification)
- [ ] Documentation update

## Screenshots

Not applicable.

## Checklist

- [x] I have run the `black .` command to format the code base.
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Dependencies have been updated, if applicable.