### PR TITLE
Add rigid-object gizmo window control

### DIFF
--- a/docs/source/features/interaction/index.rst
+++ b/docs/source/features/interaction/index.rst
@@ -7,5 +7,5 @@ The Interactive Simulation module provides tools and interfaces for interacting 
    :maxdepth: 2
 
    Window interaction <window.md>
+   Rigid-object gizmo implementation <rigid_object_gizmo_implementation.md>
    Asset preview <preview_asset.md>
-   

--- a/docs/source/features/interaction/rigid_object_gizmo_implementation.md
+++ b/docs/source/features/interaction/rigid_object_gizmo_implementation.md
@@ -1,0 +1,568 @@
+# Rigid-object window gizmo: current implementation and DexSim migration guide
+
+## 1. Document purpose
+
+This document describes the current EmbodiChain implementation of window-driven
+gizmo control for rigid objects and proposes a migration boundary for moving the
+feature into DexSim.
+
+The intended audience is the DexSim implementer who will replace the current
+Python orchestration with an engine-level input controller.
+
+Implementation snapshot:
+
+- EmbodiChain branch: `feat/rigid-object-window-gizmo`
+- EmbodiChain implementation commit: `38f0b67b`
+- EmbodiChain pull request: `DexForce/EmbodiChain#420`
+- DexSim source inspected from branch `dev`, commit `69a51b104`
+- Document date: 2026-07-22
+
+## 2. User-visible behavior
+
+The current feature provides the following interaction:
+
+1. The user left-clicks a rigid object in the main viewer. DexSim performs the
+   raycast and caches the selected object.
+2. The user presses `G`.
+3. If the selected object is an eligible EmbodiChain `RigidObject`, its original
+   body type is saved and the object is changed to kinematic.
+4. A transform gizmo is created and attached to the rigid object.
+5. Dragging the gizmo updates the rigid object's transform.
+6. Pressing `G` again removes the active gizmo and restores the object's original
+   body type.
+
+The second `G` press always exits the active interaction. It does not depend on
+the current raycast selection, which may have changed after the gizmo was
+enabled.
+
+The same cleanup and body-type restoration also run when:
+
+- `SimulationManager.disable_gizmo(uid)` is called;
+- the viewer window is closed; or
+- the simulation is destroyed.
+
+Current eligibility rules:
+
+| Condition | Result |
+|---|---|
+| Dynamic rigid object | Accepted; temporarily changed to kinematic |
+| Kinematic rigid object | Accepted; remains kinematic |
+| Static rigid object | Rejected |
+| Robot, sensor, light, plane, or unregistered DexSim object | Rejected |
+| `num_envs != 1` | Rejected |
+| Object already has a non-window-owned gizmo | Rejected |
+
+## 3. Current component layout
+
+| Component | Location | Responsibility |
+|---|---|---|
+| `WindowGizmoCfg` | `embodichain/lab/sim/cfg.py` | Enables or disables default `G` hotkey registration |
+| `SimulationManagerCfg.window_gizmo` | `embodichain/lab/sim/sim_manager.py` | Exposes the interaction configuration |
+| `_WindowGizmoState` | `embodichain/lab/sim/sim_manager.py` | Stores active EmbodiChain UID and original body type |
+| `enable_window_gizmo_hotkey()` | `embodichain/lab/sim/sim_manager.py` | Creates the Python `ObjectManipulator`, enables selection caching, and handles `G` |
+| `_resolve_selected_rigid_object_uid()` | `embodichain/lab/sim/sim_manager.py` | Maps the DexSim raycast object back to an EmbodiChain rigid object |
+| `toggle_selected_rigid_object_gizmo()` | `embodichain/lab/sim/sim_manager.py` | Implements the enter/exit state machine and rollback |
+| `enable_gizmo()` / `disable_gizmo()` | `embodichain/lab/sim/sim_manager.py` | Owns high-level gizmo instances and the shared DexSim drag controller |
+| `Gizmo` | `embodichain/lab/sim/objects/gizmo.py` | Wraps native DexSim gizmos for rigid objects, robots, and cameras |
+| `Gizmo.destroy()` | `embodichain/lab/sim/objects/gizmo.py` | Detaches callbacks/parents, removes proxies, and calls `Arena.remove_gizmo()` |
+| `ObjectManipulator` | DexSim `DFObjectManipulator.hpp` | Receives raycast selection and optionally caches the last valid hit |
+| `GizmoController` | DexSim `DFGizmoController.*` | Handles mouse dragging of gizmo axes and rotation rings |
+| `IGizmo` / `GizmoX` | DexSim `DFGizmo.*` | Follows a target node and flushes gizmo transforms to it |
+| `Arena` | DexSim `Arena.*` | Creates, stores, and removes native gizmos |
+
+## 4. Current runtime state
+
+EmbodiChain keeps one window-owned gizmo state per `SimulationManager`:
+
+```python
+@dataclass
+class _WindowGizmoState:
+    uid: str
+    original_body_type: str
+```
+
+Related manager fields are:
+
+```python
+self._window_gizmo_hotkey_enabled: bool
+self._window_gizmo_input_control: ObjectManipulator | None
+self._window_gizmo_state: _WindowGizmoState | None
+self._gizmos: dict[str, Gizmo]
+self._gizmo_controller: GizmoController | None
+```
+
+There can be only one window-owned rigid-object gizmo at a time. The generic
+`_gizmos` registry may also contain manually enabled robot, camera, or rigid
+object gizmos.
+
+## 5. End-to-end event flow
+
+### 5.1 Registration
+
+When `SimulationManager` creates or opens a non-headless window:
+
+1. `SimulationManagerCfg.window_gizmo.enable_hotkey` is read.
+2. `enable_window_gizmo_hotkey()` creates a Python subclass of DexSim
+   `ObjectManipulator`.
+3. `enable_selection_cache(True)` is called on the manipulator.
+4. The manipulator is registered with `Windows.add_input_control()`.
+
+Registration is idempotent. If `_window_gizmo_input_control` already exists, no
+second controller is added.
+
+### 5.2 Raycast selection
+
+DexSim performs a surface raycast on left mouse down. For each registered
+`ObjectManipulator`, the view calls `Select(camera, result)`.
+
+With selection caching enabled, `ObjectManipulator::Select()` updates the
+cached result only when the new result contains an object. Clicking empty space
+therefore does not clear the last valid object selection.
+
+The Python hotkey handler later reads:
+
+```python
+self.selected_object
+```
+
+This value is a DexSim `IObject`, not an EmbodiChain `RigidObject`.
+
+### 5.3 First `G` press: enter gizmo control
+
+The Python `WindowGizmoEvent.on_key_down()` calls:
+
+```python
+sim.toggle_selected_rigid_object_gizmo(self.selected_object)
+```
+
+The manager then performs the following operations in order:
+
+1. Confirm there is no active window-owned gizmo.
+2. Require a non-null raycast selection.
+3. Require `num_envs == 1`.
+4. Read `selected_object.get_user_id()`.
+5. Iterate all registered `RigidObject._entities` and compare entity user IDs.
+6. Reject a selection that cannot be mapped to an EmbodiChain rigid object.
+7. Reject static objects.
+8. Reject objects that already have another gizmo.
+9. Save `rigid_object.body_type`.
+10. Call `rigid_object.set_body_type("kinematic")`.
+11. Call `SimulationManager.enable_gizmo(uid)`.
+12. If gizmo creation fails, restore the saved body type immediately.
+13. On success, store `_WindowGizmoState(uid, original_body_type)`.
+
+The object becomes kinematic before the gizmo is enabled. This ordering prevents
+physics from competing with direct transform updates while the object is being
+dragged.
+
+### 5.4 Gizmo creation and dragging
+
+For a rigid object, the EmbodiChain `Gizmo` wrapper:
+
+1. calls `Arena.create_gizmo(axis_options, ring_options)`;
+2. obtains the first rigid-object entity node with `target._entities[0].node`;
+3. calls native `gizmo.follow(target_node)`; and
+4. installs a Python local-pose callback that calls
+   `node.set_transform(local_pose, flag)`.
+
+The callback is functionally equivalent to DexSim's native
+`GizmoX::DefaultTransformFlushCallback()`, which already calls
+`target->SetTransform(transform, flag)`. The Python callback is therefore not
+required after this feature is migrated into DexSim.
+
+`SimulationManager.enable_gizmo()` also creates one shared native
+`GizmoController` and registers it with the window. That controller performs
+axis/plane translation and ring rotation based on mouse raycasts.
+
+### 5.5 Second `G` press: exit gizmo control
+
+If `_window_gizmo_state` exists, the toggle method ignores the current selection
+and calls `disable_gizmo(active_uid)`.
+
+`disable_gizmo()`:
+
+1. removes the wrapper from `SimulationManager._gizmos`;
+2. calls `Gizmo.destroy()`; and
+3. restores the original body type in a `finally` path.
+
+`Gizmo.destroy()` performs the native resource cleanup:
+
+1. clear the transform callback;
+2. detach the gizmo from its target or proxy;
+3. remove a robot/camera proxy actor when present;
+4. call `Arena.remove_gizmo(native_gizmo)`; and
+5. release Python references.
+
+Calling `Arena.remove_gizmo()` is essential. Detaching the node alone is not
+sufficient because `Arena::gizmos_` holds a strong reference. Without explicit
+removal, the gizmo remains in the scene and continues to render.
+
+### 5.6 Window and simulation cleanup
+
+`SimulationManager.close_window()` disables the active window-owned gizmo before
+closing the DexSim window. It then clears the Python input-control references.
+
+`SimulationManager._deferred_destroy()` also disables the active window-owned
+gizmo before removing the remaining generic gizmos and destroying the world.
+
+## 6. State machine and invariants
+
+The current logical state machine is:
+
+```text
+IDLE
+  | G + eligible cached selection
+  v
+ACTIVATING
+  | set kinematic + create/follow gizmo succeeds
+  v
+ACTIVE
+  | G, disable_gizmo(), close_window(), or destroy()
+  v
+DEACTIVATING
+  | remove gizmo + restore original actor type
+  v
+IDLE
+
+ACTIVATING -- any failure --> rollback actor type --> IDLE
+```
+
+Required invariants:
+
+1. `ACTIVE` implies the target is dynamic-capable and currently kinematic.
+2. The original actor type is captured before any mutation.
+3. Every exit path attempts actor-type restoration.
+4. Gizmo creation failure leaves no native gizmo and restores the actor type.
+5. The second `G` exits the active target instead of switching to a newly
+   selected target.
+6. Native gizmo destruction must call `Arena.remove_gizmo()`.
+7. A manually created gizmo is never adopted as a window-owned gizmo.
+
+## 7. Existing DexSim capabilities used by the feature
+
+DexSim already exposes nearly all primitives needed for a native implementation:
+
+| Capability | Existing DexSim API |
+|---|---|
+| Viewer key callbacks | `DF::InputControl::OnKeyDown()` / `OnKeyUp()` |
+| Surface selection | View raycast plus `ObjectManipulator::Select()` |
+| Cached last valid selection | `ObjectManipulator::EnableSelectionCache()` |
+| Selected scene object | `ObjectManipulator::GetSelectedObject()` |
+| Actor-type query | `IObject::GetActorType()` |
+| Runtime dynamic/kinematic switch | `IObject::SetActorType()` |
+| Gizmo creation | `Arena::CreateGizmo()` |
+| Direct target following | `IGizmo::Follow(INodeRef)` |
+| Default transform propagation | `GizmoX::DefaultTransformFlushCallback()` |
+| Gizmo dragging | `GizmoController` |
+| Gizmo removal | `Arena::RemoveGizmo()` |
+| Python exposure | pybind classes for `ObjectManipulator`, `GizmoController`, `IObject`, `Gizmo`, and `Arena` |
+
+The main missing piece is an engine-owned controller that coordinates these
+existing APIs into one interaction lifecycle.
+
+## 8. Current limitations and migration opportunities
+
+### 8.1 EmbodiChain UID reverse lookup
+
+The raycast result is already the native object that must be manipulated, but
+the current Python code converts it to an EmbodiChain UID by scanning every
+`RigidObject` entity.
+
+This lookup is:
+
+- unnecessary in DexSim;
+- dependent on EmbodiChain private field `_entities`;
+- linear in the number of registered entities; and
+- the reason non-EmbodiChain native rigid objects are rejected.
+
+A DexSim implementation should retain the selected `IObjectRef` directly.
+
+### 8.2 Single-environment restriction
+
+The current feature rejects `num_envs != 1` because the generic EmbodiChain
+`Gizmo` wrapper always follows `target._entities[0]` and its constructor enforces
+single-world use.
+
+DexSim selection identifies one concrete `IObject`, so an engine-level controller
+can support whichever arena object was actually clicked. The migration can
+remove this restriction unless the renderer has a separate multi-view limitation.
+
+### 8.3 Python callback and render-thread boundary
+
+The hotkey is implemented by a Python override of `ObjectManipulator.on_key_down`.
+DexSim warms the pybind override cache when adding the control, but key handling
+still crosses into Python.
+
+A native controller avoids the GIL boundary and keeps selection, actor mutation,
+gizmo creation, and cleanup on the engine side.
+
+### 8.4 Key-repeat behavior
+
+The current implementation toggles on every `on_key_down` callback. If a window
+backend emits repeated key-down events while `G` is held, the interaction can
+toggle more than once.
+
+The DexSim controller should use an edge guard:
+
+- ignore `OnKeyDown(G)` while `g_key_down_` is already true;
+- set `g_key_down_ = true` on the first key down; and
+- clear it in `OnKeyUp(G)`.
+
+### 8.5 Stale selection and target removal
+
+The cached raycast result contains a strong/reference-counted object handle. The
+native implementation must define behavior when the selected or active object is
+removed from its arena.
+
+Recommended behavior:
+
+- validate that the selected object still belongs to a live scene before enter;
+- automatically deactivate if the active object is removed; and
+- never let selection caching keep a removed scene object alive indefinitely.
+
+### 8.6 Controller ownership
+
+EmbodiChain currently keeps separate references for the hotkey
+`ObjectManipulator` and the drag `GizmoController`. Closing the window clears the
+Python references, while the window/view owns the active registration.
+
+DexSim should make ownership explicit. A controller registered with a window
+must be removed before controller destruction, and controller teardown must
+deactivate any active gizmo and restore the target actor type.
+
+## 9. Recommended DexSim design
+
+### 9.1 Preferred abstraction
+
+Add a native controller dedicated to object-level gizmo interaction, for
+example:
+
+```cpp
+class ObjectGizmoController : public ObjectManipulator {
+public:
+    ObjectGizmoController(Arena* arena,
+                          InputKey hotkey = KEY_SCANCODE_G);
+
+    void OnKeyDown(int key) override;
+    void OnKeyUp(int key) override;
+
+    bool Activate(IObjectRef object);
+    void Deactivate();
+    bool IsActive() const;
+    IObjectRef ActiveObject() const;
+
+private:
+    Arena* arena_ = nullptr;
+    InputKey hotkey_ = KEY_SCANCODE_G;
+    bool hotkey_down_ = false;
+    IObjectRef active_object_;
+    IPhysicBody::ActorType original_actor_type_ =
+            IPhysicBody::ActorType::ACTOR_NONE;
+    IGizmoRef active_gizmo_;
+    GizmoController drag_controller_;
+};
+```
+
+The exact ownership of `GizmoController` may instead remain at the window/world
+level if one shared drag controller is preferred. The important design point is
+that the hotkey controller owns the activation state and cleanup contract.
+
+Avoid adding the toggle logic directly to the existing `GizmoController` unless
+that class is intentionally expanded from a drag-only controller into a complete
+selection-and-lifecycle controller.
+
+### 9.2 Activation algorithm
+
+Recommended native activation logic:
+
+```text
+Activate(selected):
+    if active:
+        return false
+    if selected is null or no longer belongs to a live scene:
+        return false
+
+    original = selected.GetActorType()
+    if original not in {DYNAMIC, KINEMATIC}:
+        return false
+
+    selected.SetActorType(KINEMATIC)
+    try:
+        gizmo = arena.CreateGizmo(options)
+        gizmo.Follow(selected as INode)
+        commit active_object, original_type, and gizmo
+        return true
+    on failure:
+        remove partially created gizmo if present
+        selected.SetActorType(original)
+        return false
+```
+
+Because `GizmoX` has a native default transform callback, a rigid-object
+implementation does not need to install a Python callback.
+
+### 9.3 Deactivation algorithm
+
+Recommended native deactivation logic:
+
+```text
+Deactivate():
+    move active state into local variables
+    clear controller active state to prevent re-entrancy
+
+    detach gizmo target
+    arena.RemoveGizmo(gizmo)
+
+    always attempt:
+        object.SetActorType(original_type)
+```
+
+Actor restoration must be guaranteed even if gizmo removal fails. In C++, use a
+scope guard or an equivalent no-fail cleanup structure.
+
+### 9.4 Eligibility policy
+
+At the DexSim layer, the default policy should accept any selected `IObject`
+whose actor type is dynamic or kinematic. Static, soft, cloth, and objects with
+no physical body should be rejected.
+
+If applications need filtering, prefer engine-native options that do not require
+a Python callback on the render thread, such as:
+
+- selectable layer mask;
+- actor-type mask;
+- user-ID allow/deny set; or
+- a C++ predicate interface.
+
+### 9.5 Proposed Python binding
+
+A minimal binding could expose:
+
+```python
+controller = dexsim.engine.ObjectGizmoController(
+    arena=world.get_env(),
+    hotkey=InputKey.SCANCODE_G,
+)
+controller.enable_selection_cache(True)
+window.add_input_control(controller)
+
+controller.is_active
+controller.active_object
+controller.activate(obj)
+controller.deactivate()
+```
+
+A higher-level convenience API may additionally be provided by `World` or
+`Windows`, but the controller object should remain accessible so applications
+can configure and remove it explicitly.
+
+## 10. Migration boundary in EmbodiChain
+
+After DexSim provides the native controller, EmbodiChain should retain:
+
+- `SimulationManagerCfg.window_gizmo.enable_hotkey` as application-level policy;
+- creation and registration of the DexSim controller when the window opens;
+- generic manual `enable_gizmo()` support for robots and cameras; and
+- user-facing documentation.
+
+EmbodiChain can remove or simplify:
+
+- `_WindowGizmoState`;
+- `_resolve_selected_rigid_object_uid()`;
+- `toggle_selected_rigid_object_gizmo()`;
+- the nested Python `WindowGizmoEvent` class;
+- body-type restoration hooks inside generic `disable_gizmo()`; and
+- the rigid-object-specific Python transform callback.
+
+The EmbodiChain `Gizmo` wrapper remains useful for robot IK and camera proxy
+control. Do not remove those paths as part of the rigid-object migration.
+
+`Gizmo.destroy()` should continue to call `Arena.remove_gizmo()` for any gizmo
+still created through the EmbodiChain wrapper.
+
+## 11. Suggested migration phases
+
+### Phase 1: implement and test in DexSim
+
+1. Add the native controller and pybind API.
+2. Reuse `ObjectManipulator` selection caching.
+3. Reuse `GizmoController` for dragging.
+4. Add transactional actor-type restoration.
+5. Add explicit arena and window teardown behavior.
+6. Add an interactive example to DexSim.
+
+### Phase 2: switch EmbodiChain to the DexSim controller
+
+1. Instantiate the native controller from `SimulationManager`.
+2. Keep the existing config flag and hotkey behavior.
+3. Delete the Python selection-to-UID bridge and state machine.
+4. Keep a temporary compatibility fallback only if EmbodiChain must support an
+   older DexSim version.
+
+### Phase 3: remove compatibility code
+
+1. Require the DexSim version containing the native feature.
+2. Remove the fallback and obsolete tests.
+3. Retain cross-layer integration tests in EmbodiChain.
+
+## 12. Required DexSim test matrix
+
+The DexSim implementation should cover at least:
+
+| Scenario | Expected result |
+|---|---|
+| No cached selection, press `G` | No activation |
+| Select dynamic object, press `G` | Actor becomes kinematic; gizmo exists |
+| Press `G` again | Gizmo removed; actor returns to dynamic |
+| Select kinematic object | Actor remains kinematic after exit |
+| Select static object | Rejected without mutation |
+| Select non-physical object | Rejected without mutation |
+| Gizmo creation failure | Actor type rolled back; no active state |
+| Active object removed | Controller deactivates safely |
+| Window/controller destroyed while active | Gizmo removed and actor restored |
+| Hold `G` and receive repeated key-down events | Only one transition per key press |
+| Repeated enable/disable cycles | `Arena::GetAllGizmos()` does not grow |
+| Select object in another arena/view | Correct concrete object is controlled |
+
+EmbodiChain currently covers the Python lifecycle with:
+
+- `tests/sim/test_sim_manager.py`; and
+- `tests/sim/objects/test_gizmo.py`.
+
+The native DexSim tests should additionally assert the arena's actual gizmo
+registry and scene object lifetime rather than only using mocks.
+
+## 13. Migration acceptance criteria
+
+The migration is complete when:
+
+1. Left-click plus `G` works without a Python `ObjectManipulator` override.
+2. No EmbodiChain UID reverse lookup is needed.
+3. Dynamic and kinematic actor types are restored on every exit and failure path.
+4. The second `G` removes the native gizmo from both rendering and
+   `Arena::gizmos_`.
+5. Window, controller, object, arena, and world teardown are safe in any order.
+6. Key repeat cannot cause unintended double toggles.
+7. The feature works for a concrete selected object without the current
+   EmbodiChain `num_envs == 1` restriction, or DexSim documents why that
+   restriction remains necessary.
+8. EmbodiChain keeps only configuration/registration glue for rigid objects.
+
+## 14. Open design questions
+
+Before implementation, decide:
+
+1. Should the new controller own a private `GizmoController`, or should the
+   window/world provide one shared drag controller?
+2. Should `ObjectGizmoController` be registered explicitly by applications, or
+   enabled by a `Windows`/`WorldConfig` option?
+3. How should the controller observe active-object removal?
+4. Should switching selection while active be rejected, or should a single `G`
+   atomically transfer control to the new selection? The current contract
+   requires an explicit exit first.
+5. Should dynamic velocity be preserved and restored after a kinematic editing
+   session, or should the object resume with zero velocity? The current feature
+   restores only actor type.
+6. Which selection filters are needed without introducing a Python callback on
+   the render thread?
+

--- a/docs/source/features/interaction/window.md
+++ b/docs/source/features/interaction/window.md
@@ -39,10 +39,13 @@ In ORBIT mode, plain `W/A/S/D/Q/E` does not move the view. Hold **Left Ctrl** wh
 |-------|-----------|
 | **Viewer recording (toggle)** | Press **`r`** to **start** recording what the interactive viewer shows, and press **`r`** again to **stop** and save as MP4 videos. Recording uses a hidden camera that follows the live viewer camera pose, so the exported videos match the on-screen view. Useful for debugging and recording demos. |
 | **Print camera pose** | Press **`p`** to print the current viewer pose as an executable `window.set_look_at(...)` call. |
+| **Rigid-object gizmo (toggle)** | Left-click a rigid object, then press **`g`** to enable its gizmo. Press **`g`** again to disable the gizmo. |
 
 Recording hotkey registration is controlled by `SimConfig.window_record.enable_hotkey` (enabled by default). You can also call `SimulationManager.start_window_record()`, `stop_window_record()`, or `toggle_window_record()` programmatically.
 
 The camera-pose hotkey is controlled by `SimulationManagerCfg.window_camera_pose.enable_hotkey` and prints look-at form by default. Set `SimulationManagerCfg.window_camera_pose.convert_to_look_at=False` to print the raw 4x4 pose matrix instead. The same output can be requested programmatically with `SimulationManager.print_window_camera_pose()`.
+
+The rigid-object gizmo hotkey is controlled by `SimulationManagerCfg.window_gizmo.enable_hotkey` and is enabled by default. Gizmo control supports one environment and dynamic or kinematic rigid objects. A dynamic object is temporarily changed to kinematic while its gizmo is active, then restored to its original body type when `g` is pressed again, the gizmo is disabled programmatically, the window closes, or the simulation is destroyed. Static objects are not modified.
 
 ## Customizing Window Events
 

--- a/docs/source/tutorial/gizmo.rst
+++ b/docs/source/tutorial/gizmo.rst
@@ -169,6 +169,15 @@ Gizmo lifecycle is managed by SimulationManager:
 
 There is no need to manually create or destroy Gizmo instances. All resources are managed by SimulationManager.
 
+Window Control for Rigid Objects
+--------------------------------
+
+In a single-environment simulation, left-click a dynamic or kinematic rigid
+object in the viewer and press ``G`` to enable its gizmo. Press ``G`` again to
+exit. Dynamic objects are made kinematic while they are controlled and return
+to their original body type when the gizmo is disabled. Static objects are not
+eligible for window gizmo control.
+
 Available Gizmo Methods
 -----------------------
 

--- a/embodichain/lab/sim/cfg.py
+++ b/embodichain/lab/sim/cfg.py
@@ -43,6 +43,35 @@ from embodichain.utils.utility import key_in_nested_dict
 
 from .shapes import ShapeCfg, MeshCfg
 
+__all__ = [
+    "DEFAULT_RENDERER",
+    "RenderCfg",
+    "PhysicsCfg",
+    "MarkerCfg",
+    "WindowRecordCfg",
+    "WindowCameraPoseCfg",
+    "WindowGizmoCfg",
+    "GPUMemoryCfg",
+    "RigidBodyAttributesCfg",
+    "RigidBodyAttributesOverrideCfg",
+    "LinkPhysicsOverrideCfg",
+    "link_attrs_from_dict",
+    "SoftbodyVoxelAttributesCfg",
+    "SoftbodyPhysicalAttributesCfg",
+    "ClothPhysicalAttributesCfg",
+    "JointDrivePropertiesCfg",
+    "ObjectBaseCfg",
+    "LightCfg",
+    "RigidObjectCfg",
+    "SoftObjectCfg",
+    "ClothObjectCfg",
+    "RigidObjectGroupCfg",
+    "RigidConstraintCfg",
+    "URDFCfg",
+    "ArticulationCfg",
+    "RobotCfg",
+]
+
 # Global default renderer settings for simulation.
 #
 # The sentinel value ``"auto"`` defers the choice to GPU-based auto-selection
@@ -206,6 +235,14 @@ class WindowCameraPoseCfg:
 
     convert_to_look_at: bool = True
     """Whether the hotkey prints a ``set_look_at`` call instead of a matrix."""
+
+
+@configclass
+class WindowGizmoCfg:
+    """Configuration for interactive rigid-object gizmo control."""
+
+    enable_hotkey: bool = True
+    """Whether to register the ``g`` hotkey when the window opens."""
 
 
 @configclass

--- a/embodichain/lab/sim/objects/gizmo.py
+++ b/embodichain/lab/sim/objects/gizmo.py
@@ -17,6 +17,8 @@
 Gizmo: A reusable controller for interactive manipulation of simulation elements (object, robot, camera, etc.)
 """
 
+from __future__ import annotations
+
 import numpy as np
 import torch
 import dexsim
@@ -41,6 +43,8 @@ from dexsim.types import (
 )
 
 from embodichain.lab.sim.utility.gizmo_utils import create_gizmo_callback
+
+__all__ = ["Gizmo", "GizmoCfg"]
 
 
 @configclass
@@ -501,13 +505,15 @@ class Gizmo:
             # Other target types
             pass
 
-    def destroy(self):
+    def destroy(self) -> None:
         """Clean up gizmo resources and release references."""
+        gizmo = getattr(self, "_gizmo", None)
+
         # Clear transform callback first to avoid bad_function_call
-        if hasattr(self, "_gizmo") and self._gizmo and hasattr(self._gizmo, "node"):
+        if gizmo is not None and hasattr(gizmo, "node"):
             try:
                 # Clear transform callback before any other cleanup
-                self._gizmo.node.set_flush_transform_callback(None)
+                gizmo.node.set_flush_transform_callback(None)
                 logger.log_info("Cleared gizmo transform callback")
             except Exception as e:
                 logger.log_warning(f"Failed to clear gizmo callback: {e}")
@@ -516,12 +522,8 @@ class Gizmo:
         if hasattr(self, "_proxy_cube") and self._proxy_cube:
             try:
                 # Detach gizmo from proxy cube first
-                if (
-                    hasattr(self, "_gizmo")
-                    and self._gizmo
-                    and hasattr(self._gizmo, "node")
-                ):
-                    self._gizmo.detach_parent()
+                if gizmo is not None and hasattr(gizmo, "node"):
+                    gizmo.detach_parent()
                 # Then remove the proxy cube
                 self._env.remove_actor(self._proxy_cube)
                 logger.log_info("Successfully removed proxy cube from environment")
@@ -530,16 +532,26 @@ class Gizmo:
             self._proxy_cube = None
 
         # Final gizmo cleanup
-        if hasattr(self, "_gizmo") and self._gizmo and hasattr(self._gizmo, "node"):
+        if gizmo is not None and hasattr(gizmo, "node"):
             try:
                 # Ensure detach_parent is called if not done above
                 if self._target_type in ["robot", "camera"]:
                     pass  # Already detached above
                 else:
-                    self._gizmo.node.detach_parent()
+                    gizmo.node.detach_parent()
                 logger.log_info("Successfully cleaned up gizmo node")
             except Exception as e:
                 logger.log_warning(f"Failed to cleanup gizmo node: {e}")
+
+        # Detaching only removes the parent relationship. The arena keeps a
+        # strong reference to every created gizmo until remove_gizmo() is
+        # called, so explicitly remove it from the scene as well.
+        if gizmo is not None:
+            try:
+                self._env.remove_gizmo(gizmo)
+                logger.log_info("Successfully removed gizmo from environment")
+            except Exception as e:
+                logger.log_warning(f"Failed to remove gizmo from environment: {e}")
 
         # Clear pending transform
         if hasattr(self, "_pending_target_transform"):

--- a/embodichain/lab/sim/sim_manager.py
+++ b/embodichain/lab/sim/sim_manager.py
@@ -81,6 +81,7 @@ from embodichain.lab.sim.cfg import (
     GPUMemoryCfg,
     WindowRecordCfg,
     WindowCameraPoseCfg,
+    WindowGizmoCfg,
     LightCfg,
     RigidObjectCfg,
     SoftObjectCfg,
@@ -159,6 +160,9 @@ class SimulationManagerCfg:
     window_camera_pose: WindowCameraPoseCfg = field(default_factory=WindowCameraPoseCfg)
     """Interactive viewer camera-pose printing settings."""
 
+    window_gizmo: WindowGizmoCfg = field(default_factory=WindowGizmoCfg)
+    """Interactive rigid-object gizmo settings."""
+
 
 @dataclass
 class _WindowRecordState:
@@ -179,6 +183,14 @@ class _WindowRecordState:
     capture_from_sim_update: bool = False
     task_status: int = TASK_RETURN.TASK_LOOP
     loop_handle: object | None = None
+
+
+@dataclass
+class _WindowGizmoState:
+    """State captured while a rigid object is controlled from the window."""
+
+    uid: str
+    original_body_type: str
 
 
 class SimulationManager:
@@ -271,6 +283,9 @@ class SimulationManager:
             else None
         )
         self._window_camera_pose_input_control: ObjectManipulator | None = None
+        self._window_gizmo_hotkey_enabled = sim_config.window_gizmo.enable_hotkey
+        self._window_gizmo_input_control: ObjectManipulator | None = None
+        self._window_gizmo_state: _WindowGizmoState | None = None
 
         self._world.set_delta_time(sim_config.physics_dt)
         self._world.show_coordinate_axis(False)
@@ -291,6 +306,7 @@ class SimulationManager:
 
         # gizmo management
         self._gizmos: Dict[str, object] = dict()  # Store active gizmos
+        self._gizmo_controller: GizmoController | None = None
 
         # marker management
         self._markers: Dict[str, MeshObject] = dict()
@@ -326,6 +342,8 @@ class SimulationManager:
 
         if sim_config.headless is False:
             self._window = self._world.get_windows()
+            if self._window_gizmo_hotkey_enabled:
+                self.enable_window_gizmo_hotkey()
 
     @classmethod
     def get_instance(cls, instance_id: int = 0) -> SimulationManager:
@@ -634,16 +652,25 @@ class SimulationManager:
             and self._window_camera_pose_input_control is None
         ):
             self.enable_window_camera_pose_hotkey(**self._window_camera_pose_hotkey_cfg)
+        if (
+            self._window_gizmo_hotkey_enabled
+            and self._window_gizmo_input_control is None
+        ):
+            self.enable_window_gizmo_hotkey()
         self.is_window_opened = True
 
     def close_window(self) -> None:
         """Close the simulation window."""
+        if self._window_gizmo_state is not None:
+            self.disable_gizmo(self._window_gizmo_state.uid)
         if self.is_window_recording():
             self.stop_window_record()
         self._world.close_window()
         self._window = None
         self._window_record_input_control = None
         self._window_camera_pose_input_control = None
+        self._window_gizmo_input_control = None
+        self._gizmo_controller = None
         self.is_window_opened = False
 
     def _build_multiple_arenas(self, num: int, space: float | None = None) -> None:
@@ -1625,7 +1652,7 @@ class SimulationManager:
 
     def enable_gizmo(
         self, uid: str, control_part: str | None = None, gizmo_cfg: object = None
-    ) -> Gizmo:
+    ) -> Gizmo | None:
         """Enable gizmo control for any simulation object (Robot, RigidObject, Camera, etc.).
 
         Args:
@@ -1641,7 +1668,7 @@ class SimulationManager:
             logger.log_warning(
                 f"Gizmo for '{uid}' with control_part '{control_part}' already exists."
             )
-            return
+            return self._gizmos[gizmo_key]
 
         # Search for target object in different collections
         target = None
@@ -1658,37 +1685,50 @@ class SimulationManager:
             object_type = "sensor"
 
         else:
-            logger.log_error(
+            logger.log_warning(
                 f"Object with uid '{uid}' not found in any collection (robots, rigid_objects, sensors, articulations)."
             )
-            return
+            return None
 
+        gizmo = None
         try:
             gizmo = Gizmo(target, gizmo_cfg, control_part)
-            self._gizmos[gizmo_key] = gizmo
-            logger.log_info(
-                f"Gizmo enabled for {object_type} '{uid}' with control_part '{control_part}'"
-            )
 
             # Initialize GizmoController if not already done.
-            if not hasattr(self, "_gizmo_controller") or self._gizmo_controller is None:
+            if self._gizmo_controller is None:
                 window = (
                     self._world.get_windows()
                     if hasattr(self._world, "get_windows")
                     else None
                 )
-                self._gizmo_controller = GizmoController()
-                window.add_input_control(self._gizmo_controller)
+                if window is None:
+                    raise RuntimeError("No simulation window is available.")
+                gizmo_controller = GizmoController()
+                window.add_input_control(gizmo_controller)
+                self._gizmo_controller = gizmo_controller
+
+            self._gizmos[gizmo_key] = gizmo
+            logger.log_info(
+                f"Gizmo enabled for {object_type} '{uid}' with control_part '{control_part}'"
+            )
 
         except Exception as e:
-            logger.log_error(
+            if gizmo is not None:
+                try:
+                    gizmo.destroy()
+                except Exception as cleanup_error:
+                    logger.log_warning(
+                        f"Failed to clean up gizmo for '{uid}' after creation failed: {cleanup_error}"
+                    )
+            logger.log_warning(
                 f"Failed to create gizmo for {object_type} '{uid}' with control_part '{control_part}': {e}"
             )
+            return None
 
         return gizmo
 
     def disable_gizmo(self, uid: str, control_part: str | None = None) -> None:
-        """Disable and remove gizmo for a robot.
+        """Disable and remove a gizmo.
 
         Args:
             uid (str): Object UID to disable gizmo for
@@ -1698,31 +1738,152 @@ class SimulationManager:
         gizmo_key = f"{uid}:{control_part}" if control_part else uid
 
         if gizmo_key not in self._gizmos:
-            from embodichain.utils import logger
-
             logger.log_warning(
                 f"No gizmo found for '{uid}' with control_part '{control_part}'."
             )
+            self._restore_window_gizmo_body_type(uid, control_part)
             return
 
         try:
-            gizmo = self._gizmos[gizmo_key]
+            gizmo = self._gizmos.pop(gizmo_key)
             if gizmo is not None:
                 gizmo.destroy()
-            del self._gizmos[gizmo_key]
-
-            from embodichain.utils import logger
 
             logger.log_info(
                 f"Gizmo disabled for '{uid}' with control_part '{control_part}'"
             )
 
         except Exception as e:
-            from embodichain.utils import logger
-
-            logger.log_error(
+            logger.log_warning(
                 f"Failed to disable gizmo for '{uid}' with control_part '{control_part}': {e}"
             )
+        finally:
+            self._restore_window_gizmo_body_type(uid, control_part)
+
+    def _restore_window_gizmo_body_type(
+        self, uid: str, control_part: str | None = None
+    ) -> None:
+        """Restore physics state owned by the window gizmo interaction."""
+        state = self._window_gizmo_state
+        if state is None or control_part is not None or state.uid != uid:
+            return
+
+        rigid_object = self._rigid_objects.get(uid)
+        if rigid_object is None:
+            self._window_gizmo_state = None
+            logger.log_warning(
+                f"Cannot restore body type for removed rigid object '{uid}'."
+            )
+            return
+
+        try:
+            rigid_object.set_body_type(state.original_body_type)
+            self._window_gizmo_state = None
+            logger.log_info(
+                f"Restored rigid object '{uid}' to body type '{state.original_body_type}'."
+            )
+        except Exception as e:
+            logger.log_warning(
+                f"Failed to restore body type '{state.original_body_type}' for rigid object '{uid}': {e}"
+            )
+
+    def _resolve_selected_rigid_object_uid(self, selected_object: object) -> str | None:
+        """Resolve a raycast-selected DexSim object to a rigid-object UID."""
+        get_user_id = getattr(selected_object, "get_user_id", None)
+        if get_user_id is None:
+            return None
+
+        try:
+            selected_user_id = int(get_user_id())
+        except (TypeError, ValueError, RuntimeError):
+            return None
+
+        for uid, rigid_object in self._rigid_objects.items():
+            for entity in rigid_object._entities:
+                try:
+                    if int(entity.get_user_id()) == selected_user_id:
+                        return uid
+                except (TypeError, ValueError, RuntimeError):
+                    continue
+        return None
+
+    def toggle_selected_rigid_object_gizmo(
+        self, selected_object: object | None
+    ) -> bool:
+        """Toggle gizmo control for the rigid object selected by window raycast.
+
+        The first call enables a gizmo for the selected object after temporarily
+        making it kinematic. The next call disables that gizmo and restores the
+        object's original body type, regardless of the current selection.
+
+        Args:
+            selected_object: DexSim object retained by an
+                :class:`ObjectManipulator` raycast selection.
+
+        Returns:
+            Whether the window-controlled gizmo is active after the call.
+        """
+        if self._window_gizmo_state is not None:
+            self.disable_gizmo(self._window_gizmo_state.uid)
+            return False
+
+        if selected_object is None:
+            logger.log_warning(
+                "No rigid object selected. Left-click a rigid object before pressing 'g'."
+            )
+            return False
+
+        if self.num_envs != 1:
+            logger.log_warning(
+                "Window gizmo control is only supported when num_envs=1."
+            )
+            return False
+
+        uid = self._resolve_selected_rigid_object_uid(selected_object)
+        if uid is None:
+            logger.log_warning(
+                "The raycast selection is not a registered rigid object."
+            )
+            return False
+
+        rigid_object = self._rigid_objects[uid]
+        if rigid_object.body_type == "static":
+            logger.log_warning(
+                f"Static rigid object '{uid}' cannot be controlled by a gizmo."
+            )
+            return False
+        if self.has_gizmo(uid):
+            logger.log_warning(
+                f"Rigid object '{uid}' already has a gizmo that is not owned by the window hotkey."
+            )
+            return False
+
+        original_body_type = rigid_object.body_type
+        try:
+            rigid_object.set_body_type("kinematic")
+            gizmo = self.enable_gizmo(uid)
+            if gizmo is None or not self.has_gizmo(uid):
+                rigid_object.set_body_type(original_body_type)
+                return False
+        except Exception as e:
+            try:
+                rigid_object.set_body_type(original_body_type)
+            except Exception as restore_error:
+                logger.log_warning(
+                    f"Failed to restore rigid object '{uid}' after gizmo enable failed: {restore_error}"
+                )
+            logger.log_warning(
+                f"Failed to enable window gizmo for rigid object '{uid}': {e}"
+            )
+            return False
+
+        self._window_gizmo_state = _WindowGizmoState(
+            uid=uid, original_body_type=original_body_type
+        )
+        logger.log_info(
+            f"Window gizmo enabled for rigid object '{uid}'. Press 'g' again to exit."
+        )
+        return True
 
     def get_gizmo(self, uid: str, control_part: str | None = None) -> object:
         """Get gizmo instance for a robot.
@@ -2552,6 +2713,40 @@ class SimulationManager:
         )
         return True
 
+    def enable_window_gizmo_hotkey(self) -> bool:
+        """Register ``g`` to toggle gizmo control for a raycast-selected object.
+
+        Returns:
+            Whether the control is registered on an available window.
+        """
+        self._window_gizmo_hotkey_enabled = True
+        if self._window is None:
+            logger.log_warning(
+                "No simulation window available yet. The rigid-object gizmo "
+                "hotkey will be registered after `open_window()`."
+            )
+            return False
+        if self._window_gizmo_input_control is not None:
+            return True
+
+        from dexsim.types import InputKey
+
+        sim = self
+
+        class WindowGizmoEvent(ObjectManipulator):
+            def on_key_down(self, key):
+                if key == InputKey.SCANCODE_G.value:
+                    sim.toggle_selected_rigid_object_gizmo(self.selected_object)
+
+        self._window_gizmo_input_control = WindowGizmoEvent()
+        self._window_gizmo_input_control.enable_selection_cache(True)
+        self._window.add_input_control(self._window_gizmo_input_control)
+        logger.log_info(
+            "Rigid-object gizmo hotkey registered. Left-click an object and "
+            "press 'g' to enter or exit gizmo control."
+        )
+        return True
+
     def create_visual_material(self, cfg: VisualMaterialCfg) -> VisualMaterial:
         """Create a visual material with given configuration.
 
@@ -2696,6 +2891,9 @@ class SimulationManager:
 
     def _deferred_destroy(self) -> None:
         """Destroy all simulated assets and release resources."""
+        if self._window_gizmo_state is not None:
+            self.disable_gizmo(self._window_gizmo_state.uid)
+
         # Clean up all gizmos before destroying the simulation
         for uid in list(self._gizmos.keys()):
             self.disable_gizmo(uid)

--- a/tests/sim/objects/test_gizmo.py
+++ b/tests/sim/objects/test_gizmo.py
@@ -1,0 +1,68 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+from __future__ import annotations
+
+from embodichain.lab.sim.objects.gizmo import Gizmo
+
+
+class FakeGizmoNode:
+    """Node stub that records callback and parent cleanup."""
+
+    def __init__(self) -> None:
+        self.callback = object()
+        self.detached = False
+
+    def set_flush_transform_callback(self, callback: object | None) -> None:
+        self.callback = callback
+
+    def detach_parent(self) -> None:
+        self.detached = True
+
+
+class FakeDexSimGizmo:
+    """DexSim gizmo stub with a detachable scene node."""
+
+    def __init__(self) -> None:
+        self.node = FakeGizmoNode()
+
+
+class FakeArena:
+    """Arena stub that records explicit gizmo removal."""
+
+    def __init__(self) -> None:
+        self.removed_gizmo: object | None = None
+
+    def remove_gizmo(self, gizmo: object) -> None:
+        self.removed_gizmo = gizmo
+
+
+def test_destroy_removes_gizmo_from_arena() -> None:
+    """Destroy must release DexSim's arena-owned gizmo reference."""
+    arena = FakeArena()
+    dexsim_gizmo = FakeDexSimGizmo()
+    gizmo = object.__new__(Gizmo)
+    gizmo._env = arena
+    gizmo._gizmo = dexsim_gizmo
+    gizmo._target_type = "rigidobject"
+    gizmo.target = object()
+
+    gizmo.destroy()
+
+    assert arena.removed_gizmo is dexsim_gizmo
+    assert dexsim_gizmo.node.detached is True
+    assert dexsim_gizmo.node.callback is None
+    assert gizmo._gizmo is None

--- a/tests/sim/test_sim_manager.py
+++ b/tests/sim/test_sim_manager.py
@@ -73,9 +73,13 @@ class FakeWorld:
 
     def __init__(self) -> None:
         self.thread_runtime = FakeThreadRuntime()
+        self.window_closed = False
 
     def thread_rt(self) -> FakeThreadRuntime:
         return self.thread_runtime
+
+    def close_window(self) -> None:
+        self.window_closed = True
 
 
 class FakeEnv:
@@ -90,6 +94,49 @@ class FakeEnv:
         return camera
 
 
+class FakeWindow:
+    """Window stub that records registered input controls."""
+
+    def __init__(self) -> None:
+        self.controls: list[object] = []
+
+    def add_input_control(self, control: object) -> None:
+        self.controls.append(control)
+
+
+class FakeRigidEntity:
+    """DexSim entity stub identified by its raycast user ID."""
+
+    def __init__(self, user_id: int) -> None:
+        self._user_id = user_id
+
+    def get_user_id(self) -> int:
+        return self._user_id
+
+
+class FakeRigidObject:
+    """Rigid-object stub that records runtime body-type transitions."""
+
+    def __init__(self, body_type: str, user_id: int) -> None:
+        self.body_type = body_type
+        self._entities = [FakeRigidEntity(user_id)]
+        self.body_type_history: list[str] = []
+
+    def set_body_type(self, body_type: str) -> None:
+        self.body_type = body_type
+        self.body_type_history.append(body_type)
+
+
+class FakeGizmo:
+    """Gizmo stub that exposes whether cleanup ran."""
+
+    def __init__(self) -> None:
+        self.destroyed = False
+
+    def destroy(self) -> None:
+        self.destroyed = True
+
+
 def _make_sim_manager(window: object | None = None) -> SimulationManager:
     """Create a minimally initialized simulation manager for recorder tests."""
     sim = object.__new__(SimulationManager)
@@ -99,9 +146,37 @@ def _make_sim_manager(window: object | None = None) -> SimulationManager:
     sim._window_record_state = None
     sim._window_record_camera = None
     sim._window_record_save_threads = []
+    sim._window_record_input_control = None
+    sim._window_camera_pose_input_control = None
+    sim._window_gizmo_hotkey_enabled = True
+    sim._window_gizmo_input_control = None
+    sim._window_gizmo_state = None
+    sim._gizmo_controller = None
+    sim._gizmos = {}
+    sim._rigid_objects = {}
+    sim._robots = {}
+    sim._sensors = {}
+    sim._arenas = []
     sim._env = FakeEnv()
     sim._world = FakeWorld()
+    sim.is_window_opened = window is not None
     return sim
+
+
+def _add_fake_rigid_object(
+    sim: SimulationManager, body_type: str = "dynamic", user_id: int = 17
+) -> FakeRigidObject:
+    """Add one fake rigid object and replace gizmo creation with a stub."""
+    rigid_object = FakeRigidObject(body_type=body_type, user_id=user_id)
+    sim._rigid_objects["cube"] = rigid_object
+
+    def enable_fake_gizmo(uid: str, *args, **kwargs) -> FakeGizmo:
+        gizmo = FakeGizmo()
+        sim._gizmos[uid] = gizmo
+        return gizmo
+
+    sim.enable_gizmo = enable_fake_gizmo
+    return rigid_object
 
 
 def test_window_camera_pose_to_look_at_uses_dexsim_world_up() -> None:
@@ -195,3 +270,105 @@ def test_stop_window_record_waits_for_background_export(monkeypatch) -> None:
     assert save_call["frame_count"] == 1
     assert save_call["save_kwargs"] == {"fps": 5}
     assert sim._window_record_save_threads == []
+
+
+def test_window_gizmo_toggles_dynamic_object_and_restores_body_type() -> None:
+    sim = _make_sim_manager()
+    rigid_object = _add_fake_rigid_object(sim)
+    selected_object = FakeRigidEntity(user_id=17)
+
+    assert sim.toggle_selected_rigid_object_gizmo(selected_object) is True
+    assert rigid_object.body_type == "kinematic"
+    assert sim.has_gizmo("cube") is True
+
+    gizmo = sim.get_gizmo("cube")
+    assert sim.toggle_selected_rigid_object_gizmo(None) is False
+    assert rigid_object.body_type == "dynamic"
+    assert sim.has_gizmo("cube") is False
+    assert gizmo.destroyed is True
+
+
+def test_window_gizmo_preserves_original_kinematic_body_type() -> None:
+    sim = _make_sim_manager()
+    rigid_object = _add_fake_rigid_object(sim, body_type="kinematic")
+
+    assert sim.toggle_selected_rigid_object_gizmo(FakeRigidEntity(17)) is True
+    sim.disable_gizmo("cube")
+
+    assert rigid_object.body_type == "kinematic"
+    assert rigid_object.body_type_history == ["kinematic", "kinematic"]
+
+
+def test_window_gizmo_rejects_missing_unregistered_and_static_selections() -> None:
+    sim = _make_sim_manager()
+    rigid_object = _add_fake_rigid_object(sim, body_type="static")
+
+    assert sim.toggle_selected_rigid_object_gizmo(None) is False
+    assert sim.toggle_selected_rigid_object_gizmo(FakeRigidEntity(99)) is False
+    assert sim.toggle_selected_rigid_object_gizmo(FakeRigidEntity(17)) is False
+
+    assert rigid_object.body_type == "static"
+    assert rigid_object.body_type_history == []
+    assert sim._window_gizmo_state is None
+
+
+def test_window_gizmo_rolls_back_body_type_when_enable_fails() -> None:
+    sim = _make_sim_manager()
+    rigid_object = _add_fake_rigid_object(sim)
+    sim.enable_gizmo = lambda uid, *args, **kwargs: None
+
+    assert sim.toggle_selected_rigid_object_gizmo(FakeRigidEntity(17)) is False
+
+    assert rigid_object.body_type == "dynamic"
+    assert rigid_object.body_type_history == ["kinematic", "dynamic"]
+    assert sim._window_gizmo_state is None
+
+
+def test_enable_gizmo_returns_none_when_creation_fails(monkeypatch) -> None:
+    import embodichain.lab.sim.sim_manager as sim_manager_module
+
+    sim = _make_sim_manager()
+    _add_fake_rigid_object(sim)
+    del sim.enable_gizmo
+
+    class FailingGizmo:
+        def __init__(self, *args, **kwargs) -> None:
+            raise RuntimeError("gizmo creation failed")
+
+    monkeypatch.setattr(sim_manager_module, "Gizmo", FailingGizmo)
+
+    assert sim.enable_gizmo("cube") is None
+    assert sim.has_gizmo("cube") is False
+
+
+def test_close_window_disables_gizmo_and_restores_body_type() -> None:
+    sim = _make_sim_manager(window=FakeWindow())
+    rigid_object = _add_fake_rigid_object(sim)
+    assert sim.toggle_selected_rigid_object_gizmo(FakeRigidEntity(17)) is True
+
+    sim.close_window()
+
+    assert rigid_object.body_type == "dynamic"
+    assert sim.has_gizmo("cube") is False
+    assert sim._window_gizmo_state is None
+    assert sim._world.window_closed is True
+
+
+def test_window_gizmo_hotkey_registration_is_idempotent(monkeypatch) -> None:
+    from dexsim.types import InputKey
+
+    window = FakeWindow()
+    sim = _make_sim_manager(window=window)
+    toggle_calls: list[object | None] = []
+    monkeypatch.setattr(
+        sim,
+        "toggle_selected_rigid_object_gizmo",
+        lambda selected: toggle_calls.append(selected),
+    )
+
+    assert sim.enable_window_gizmo_hotkey() is True
+    assert sim.enable_window_gizmo_hotkey() is True
+    assert len(window.controls) == 1
+
+    window.controls[0].on_key_down(InputKey.SCANCODE_G.value)
+    assert toggle_calls == [None]


### PR DESCRIPTION
## Description

This PR adds a default viewer interaction for manipulating raycast-selected rigid objects with a gizmo. Left-clicking an eligible rigid object and pressing `G` enables gizmo control; pressing `G` again exits.

Dynamic objects are temporarily switched to kinematic while controlled and restored to their original body type on disable, window close, or simulation teardown. The change also removes destroyed gizmos from the DexSim arena so they no longer remain visible after disable.

The hotkey is enabled by default and can be configured through `SimulationManagerCfg.window_gizmo.enable_hotkey`. Static objects and multi-environment simulations are rejected safely.

Dependencies: None.

Issue: Not linked.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (existing functionality will not work without user modification)
- [ ] Documentation update

## Screenshots

Not included. The behavior is covered by automated lifecycle and cleanup tests.

## Validation

- `black .`
- `pytest -q tests/sim/objects/test_gizmo.py tests/sim/test_sim_manager.py` — 13 passed
- `pytest -q tests/` — 633 passed, 99 skipped
- `make -C docs html` — completed successfully with existing repository warnings

## Checklist

- [x] I have run the `black .` command to format the code base.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] Dependencies have been updated, if applicable. No dependency changes were required.