### PR TITLE
Fix Hugging Face repository identifiers

### DIFF
--- a/embodichain/data/assets/planner_assets.py
+++ b/embodichain/data/assets/planner_assets.py
@@ -28,7 +28,7 @@ __all__ = ["download_neural_planner_checkpoint"]
 
 
 def download_neural_planner_checkpoint(
-    repo_id: str = "dexforce/neural_motion_generator",
+    repo_id: str = "DexForceAI/neural_motion_generator",
     filename: str = "franka/franka.pt",
     token: str | None = None,
     endpoint: str = _HF_ENDPOINT,
@@ -83,7 +83,7 @@ def download_neural_planner_checkpoint(
             f"Failed to download '{filename}' from '{repo_id}'.\n"
             "The repository is gated and requires an authenticated HuggingFace account.\n"
             "To fix this:\n"
-            "  1. Accept the model license at https://huggingface.co/dexforce/neural_motion_generator\n"
+            "  1. Accept the model license at https://huggingface.co/DexForceAI/neural_motion_generator\n"
             "  2. Create an access token at https://huggingface.co/settings/tokens\n"
             "  3. Export the token:  export HF_TOKEN=<your_token>\n"
             "     or run:            huggingface-cli login\n"

--- a/embodichain/data/assets/solver_assets.py
+++ b/embodichain/data/assets/solver_assets.py
@@ -24,9 +24,11 @@ from huggingface_hub import hf_hub_download
 # default to the canonical endpoint and rely on the system proxy when needed.
 _HF_ENDPOINT = "https://huggingface.co"
 
+__all__ = ["download_neural_ik_checkpoint"]
+
 
 def download_neural_ik_checkpoint(
-    repo_id: str = "dexforce/neural_ik_solver",
+    repo_id: str = "DexForceAI/neural_ik_solver",
     filename: str = "franka.pt",
     token: str | None = None,
     endpoint: str = _HF_ENDPOINT,
@@ -81,7 +83,7 @@ def download_neural_ik_checkpoint(
             f"Failed to download '{filename}' from '{repo_id}'.\n"
             "The repository is gated and requires an authenticated HuggingFace account.\n"
             "To fix this:\n"
-            "  1. Accept the model license at https://huggingface.co/dexforce/neural_ik_solver\n"
+            "  1. Accept the model license at https://huggingface.co/DexForceAI/neural_ik_solver\n"
             "  2. Create an access token at https://huggingface.co/settings/tokens\n"
             "  3. Export the token:  export HF_TOKEN=<your_token>\n"
             "     or run:            huggingface-cli login\n"

--- a/embodichain/data/constants.py
+++ b/embodichain/data/constants.py
@@ -13,13 +13,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ----------------------------------------------------------------------------
+from __future__ import annotations
 
 
 import os
 from pathlib import Path
 
+__all__ = [
+    "EMBODICHAIN_DOWNLOAD_PREFIX",
+    "EMBODICHAIN_DEFAULT_DATA_ROOT",
+    "EMBODICHAIN_DEFAULT_DATASET_ROOT",
+    "EMBODICHAIN_DEFAULT_DATABASE_ROOT",
+]
+
 EMBODICHAIN_DOWNLOAD_PREFIX = (
-    "https://hf-mirror.com/datasets/dexforce/embodichain_data/resolve/main/"
+    "https://hf-mirror.com/datasets/DexForceAI/embodichain_data/resolve/main/"
 )
 EMBODICHAIN_DEFAULT_DATA_ROOT = os.environ.get(
     "EMBODICHAIN_DATA_ROOT", str(Path.home() / ".cache" / "embodichain_data")


### PR DESCRIPTION
## Description

This PR migrates EmbodiChain data and neural-model download defaults from the legacy `dexforce` Hugging Face namespace to `DexForceAI`.

It updates the dataset download prefix, neural motion-generator and IK-solver repository IDs, and the corresponding authentication guidance URLs. This keeps default downloads working after the Hugging Face organization migration.

Dependencies: None.

Issue reference: None.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (existing functionality will not work without user modification)
- [ ] Documentation update

## Screenshots

Not applicable.

## Checklist

- [x] I have run the `black .` command to format the code base.
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Dependencies have been updated, if applicable.

Validation: `git diff --check` and Python compilation of the updated modules passed.