### PR TITLE
feat(dataset): preserve depth and mask camera frames

### DIFF
--- a/docs/source/overview/gym/dataset_functors.md
+++ b/docs/source/overview/gym/dataset_functors.md
@@ -44,7 +44,7 @@ The ``LeRobotRecorder`` functor enables recording robot learning episodes in the
 - Records observation-action pairs during episodes
 - Converts data to LeRobot format automatically
 - Saves episodes when they complete
-- Supports vision sensors (camera images)
+- Supports RGB, depth, and segmentation-mask camera observations
 - Supports robot state (qpos, qvel, qf)
 - Supports custom observation features
 - Auto-incrementing dataset naming
@@ -81,6 +81,14 @@ The LeRobotRecorder saves the following data for each frame:
 - ``action``: Applied action
 - ``observation.images.{sensor_name}``: Camera images (if sensors present)
 - ``observation.images.{sensor_name}_right``: Right camera images (for stereo cameras)
+- ``observation.depth.{sensor_name}``: Native numeric depth arrays
+- ``observation.depth.{sensor_name}_right``: Right-camera depth arrays
+- ``observation.mask.{sensor_name}``: Native numeric segmentation-mask arrays
+- ``observation.mask.{sensor_name}_right``: Right-camera segmentation-mask arrays
+
+Depth and mask features keep the dtype and shape declared by the sensor
+observation space. They are stored as numeric LeRobot array features rather than
+images, so enabling ``use_videos`` affects only the RGB image features.
 
 ### Dataset Recording vs Video Recording
 

--- a/docs/source/tutorial/data_generation.rst
+++ b/docs/source/tutorial/data_generation.rst
@@ -83,7 +83,14 @@ Important parameters are:
 - **env.control_parts**: Controlled robot parts in the environment.
 
 
-In the current implementation, ``LeRobotRecorder`` stores robot state and action features following LeRobot official format: ``observation.state`` for joint positions, ``action`` for applied actions, and ``observation.images.{sensor_name}`` for camera images.
+``LeRobotRecorder`` stores robot state and action features following the LeRobot
+format: ``observation.state`` for joint positions, ``action`` for applied
+actions, and ``observation.images.{sensor_name}`` for RGB camera images. When a
+camera also produces depth or segmentation data, the recorder preserves those
+numeric arrays under ``observation.depth.{sensor_name}`` and
+``observation.mask.{sensor_name}``. Stereo-camera keys use the ``_right``
+suffix. Depth and mask arrays retain their source dtype and shape; the
+``use_videos`` option applies only to RGB images.
 
 Step 2: Prepare the Action Configuration
 ----------------------------------------

--- a/embodichain/lab/gym/envs/managers/datasets.py
+++ b/embodichain/lab/gym/envs/managers/datasets.py
@@ -31,7 +31,6 @@ from tensordict import TensorDict
 from embodichain.utils import logger
 from embodichain.data.constants import EMBODICHAIN_DEFAULT_DATASET_ROOT
 from embodichain.data.enum import LeRobotKey
-from embodichain.lab.gym.utils.misc import is_stereocam
 from embodichain.lab.sim.sensors import Camera, ContactSensor
 from .manager_base import Functor
 from .cfg import DatasetFunctorCfg
@@ -502,18 +501,18 @@ class LeRobotRecorder(Functor):
                 sensor = self._env.get_sensor(sensor_name)
 
                 if isinstance(sensor, Camera):
-                    is_stereo = is_stereocam(sensor)
+                    for frame_name in value:
+                        if (
+                            frame_name not in CAMERA_IMAGE_FRAMES
+                            and frame_name not in CAMERA_AUXILIARY_FRAMES
+                        ):
+                            continue
 
-                    color_data = obs["sensor"][sensor_name]["color"]
-                    color_img = color_data[:, :, :3].cpu()
-                    frame[f"{LeRobotKey.OBS_IMAGES.value}.{sensor_name}"] = color_img
-
-                    if is_stereo:
-                        color_right_data = obs["sensor"][sensor_name]["color_right"]
-                        color_right_img = color_right_data[:, :, :3].cpu()
-                        frame[f"{LeRobotKey.OBS_IMAGES.value}.{sensor_name}_right"] = (
-                            color_right_img
-                        )
+                        feature_key = self._camera_feature_key(sensor_name, frame_name)
+                        frame_data = obs["sensor"][sensor_name][frame_name]
+                        if frame_name in CAMERA_IMAGE_FRAMES:
+                            frame_data = frame_data[:, :, :3]
+                        frame[feature_key] = frame_data.cpu()
                 elif isinstance(sensor, ContactSensor):
                     for frame_name in value.keys():
                         frame[f"{sensor_name}.{frame_name}"] = obs["sensor"][

--- a/embodichain/lab/gym/envs/managers/datasets.py
+++ b/embodichain/lab/gym/envs/managers/datasets.py
@@ -36,6 +36,17 @@ from embodichain.lab.sim.sensors import Camera, ContactSensor
 from .manager_base import Functor
 from .cfg import DatasetFunctorCfg
 
+CAMERA_IMAGE_FRAMES = {
+    "color": "",
+    "color_right": "_right",
+}
+CAMERA_AUXILIARY_FRAMES = {
+    "depth",
+    "depth_right",
+    "mask",
+    "mask_right",
+}
+
 if TYPE_CHECKING:
     from embodichain.lab.gym.envs import EmbodiedEnv
 
@@ -308,29 +319,33 @@ class LeRobotRecorder(Functor):
                 sensor = self._env.get_sensor(sensor_name)
 
                 if isinstance(sensor, Camera):
-                    is_stereo = is_stereocam(sensor)
-
                     for frame_name, space in value.items():
-                        # TODO: Support depth (uint16) and mask (also uint16 or uint8)
-                        if frame_name not in ["color", "color_right"]:
-                            logger.log_error(
-                                f"Only support 'color' frame for vision sensors, but got '{frame_name}' in sensor '{sensor_name}'"
+                        if frame_name in CAMERA_IMAGE_FRAMES:
+                            feature_key = self._camera_feature_key(
+                                sensor_name, frame_name
                             )
-
-                        features[f"{LeRobotKey.OBS_IMAGES.value}.{sensor_name}"] = {
-                            "dtype": "video" if self.use_videos else "image",
-                            "shape": (sensor.cfg.height, sensor.cfg.width, 3),
-                            "names": ["height", "width", "channel"],
-                        }
-
-                        if is_stereo:
-                            features[
-                                f"{LeRobotKey.OBS_IMAGES.value}.{sensor_name}_right"
-                            ] = {
+                            features[feature_key] = {
                                 "dtype": "video" if self.use_videos else "image",
                                 "shape": (sensor.cfg.height, sensor.cfg.width, 3),
                                 "names": ["height", "width", "channel"],
                             }
+                        elif frame_name in CAMERA_AUXILIARY_FRAMES:
+                            feature_key = self._camera_feature_key(
+                                sensor_name, frame_name
+                            )
+                            features[feature_key] = {
+                                "dtype": str(space.dtype),
+                                "shape": space.shape,
+                                "names": (
+                                    ["height", "width"]
+                                    if len(space.shape) == 2
+                                    else ["height", "width", "channel"]
+                                ),
+                            }
+                        else:
+                            logger.log_warning(
+                                f"Unsupported camera frame '{frame_name}' in sensor '{sensor_name}'"
+                            )
                 elif isinstance(sensor, ContactSensor):
                     for frame_name, space in value.items():
                         features[f"{sensor_name}.{frame_name}"] = {
@@ -357,6 +372,31 @@ class LeRobotRecorder(Functor):
 
         self._modify_feature_names(features)
         return features
+
+    @staticmethod
+    def _camera_feature_key(sensor_name: str, frame_name: str) -> str:
+        """Return the LeRobot feature key for a camera frame.
+
+        Args:
+            sensor_name: Camera sensor identifier.
+            frame_name: Camera frame name from the observation space.
+
+        Returns:
+            A LeRobot-compatible feature key.
+
+        Raises:
+            ValueError: If the frame is not a supported image, depth, or mask frame.
+        """
+        if frame_name in CAMERA_IMAGE_FRAMES:
+            suffix = CAMERA_IMAGE_FRAMES[frame_name]
+            return f"{LeRobotKey.OBS_IMAGES.value}.{sensor_name}{suffix}"
+
+        if frame_name in CAMERA_AUXILIARY_FRAMES:
+            modality, _, side = frame_name.partition("_")
+            suffix = f"_{side}" if side else ""
+            return f"{LeRobotKey.OBS_PREFIX.value}{modality}.{sensor_name}{suffix}"
+
+        raise ValueError(f"Unsupported camera frame: {frame_name}")
 
     def _add_nested_features(
         self, features: Dict, key: str, space: gym.spaces.Dict

--- a/tests/gym/envs/managers/test_dataset_functors.py
+++ b/tests/gym/envs/managers/test_dataset_functors.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import numpy as np
 import pytest
 import torch
 
@@ -278,6 +279,116 @@ class TestLeRobotRecorderFeatures:
 
         # Check camera feature exists (use LeRobot standard key format)
         assert f"{LeRobotKey.OBS_IMAGES.value}.camera" in features
+
+    @patch("embodichain.lab.gym.envs.managers.datasets.LeRobotDataset")
+    def test_build_features_with_depth_and_mask(self, mock_lerobot_dataset):
+        """Test that depth and mask keep their numeric shape and dtype."""
+        env = MockEnvForDataset(num_joints=6)
+        env.single_observation_space["sensor"]["camera"].update(
+            {
+                "depth": Mock(dtype=np.dtype("float32"), shape=(480, 640)),
+                "depth_right": Mock(dtype=np.dtype("float32"), shape=(480, 640)),
+                "mask": Mock(dtype=np.dtype("int32"), shape=(480, 640)),
+                "mask_right": Mock(dtype=np.dtype("int32"), shape=(480, 640)),
+            }
+        )
+
+        mock_dataset_instance = Mock()
+        mock_dataset_instance.meta = Mock()
+        mock_dataset_instance.meta.info = {"fps": 30}
+        mock_lerobot_dataset.create.return_value = mock_dataset_instance
+
+        cfg = MockFunctorCfg(
+            params={
+                "save_path": "/tmp/test_dataset",
+                "robot_meta": {"robot_type": "test_robot", "control_freq": 30},
+                "instruction": {"lang": "test task"},
+                "extra": {"task_description": "test"},
+                "use_videos": False,
+            }
+        )
+
+        original_isinstance = isinstance
+
+        def mock_isinstance(obj, class_or_tuple):
+            if isinstance(obj, MockSensor):
+                if class_or_tuple is Camera or (
+                    isinstance(class_or_tuple, tuple) and Camera in class_or_tuple
+                ):
+                    return True
+            return original_isinstance(obj, class_or_tuple)
+
+        with patch(
+            "embodichain.lab.gym.envs.managers.datasets.isinstance",
+            side_effect=mock_isinstance,
+        ):
+            recorder = LeRobotRecorder(cfg, env)
+            features = recorder._build_features()
+
+        assert features["observation.depth.camera"] == {
+            "dtype": "float32",
+            "shape": (480, 640),
+            "names": ["height", "width"],
+        }
+        assert features["observation.mask.camera"] == {
+            "dtype": "int32",
+            "shape": (480, 640),
+            "names": ["height", "width"],
+        }
+        assert features["observation.depth.camera_right"] == {
+            "dtype": "float32",
+            "shape": (480, 640),
+            "names": ["height", "width"],
+        }
+        assert features["observation.mask.camera_right"] == {
+            "dtype": "int32",
+            "shape": (480, 640),
+            "names": ["height", "width"],
+        }
+
+    @patch("embodichain.lab.gym.envs.managers.datasets.LeRobotDataset")
+    def test_build_features_ignores_unsupported_camera_frame(
+        self, mock_lerobot_dataset
+    ):
+        """Test that unsupported camera data does not create an invalid feature."""
+        env = MockEnvForDataset(num_joints=6)
+        env.single_observation_space["sensor"]["camera"]["normal"] = Mock(
+            dtype=np.dtype("float32"), shape=(480, 640, 3)
+        )
+
+        mock_dataset_instance = Mock()
+        mock_dataset_instance.meta = Mock()
+        mock_dataset_instance.meta.info = {"fps": 30}
+        mock_lerobot_dataset.create.return_value = mock_dataset_instance
+
+        cfg = MockFunctorCfg(
+            params={
+                "save_path": "/tmp/test_dataset",
+                "robot_meta": {"robot_type": "test_robot", "control_freq": 30},
+                "instruction": {"lang": "test task"},
+                "extra": {"task_description": "test"},
+                "use_videos": False,
+            }
+        )
+
+        original_isinstance = isinstance
+
+        def mock_isinstance(obj, class_or_tuple):
+            if isinstance(obj, MockSensor):
+                if class_or_tuple is Camera or (
+                    isinstance(class_or_tuple, tuple) and Camera in class_or_tuple
+                ):
+                    return True
+            return original_isinstance(obj, class_or_tuple)
+
+        with patch(
+            "embodichain.lab.gym.envs.managers.datasets.isinstance",
+            side_effect=mock_isinstance,
+        ):
+            recorder = LeRobotRecorder(cfg, env)
+            features = recorder._build_features()
+
+        assert "observation.normal.camera" not in features
 
 
 @pytest.mark.skipif(not LEROBOT_AVAILABLE, reason="LeRobot not installed")

--- a/tests/gym/envs/managers/test_dataset_functors.py
+++ b/tests/gym/envs/managers/test_dataset_functors.py
@@ -21,6 +21,7 @@ import numpy as np
 import pytest
 import torch
 
+from tensordict import TensorDict
 from unittest.mock import MagicMock, Mock, patch
 
 # Skip all tests if LeRobot is not available
@@ -418,8 +419,6 @@ class TestLeRobotRecorderFrameConversion:
         recorder = LeRobotRecorder(cfg, env)
 
         # Create mock observation
-        from tensordict import TensorDict
-
         obs = TensorDict(
             {
                 "robot": {
@@ -441,6 +440,73 @@ class TestLeRobotRecorderFrameConversion:
         assert frame["task"] == "test_task"
         assert LeRobotKey.OBS_STATE.value in frame
         assert LeRobotKey.ACTION.value in frame
+
+    @patch("embodichain.lab.gym.envs.managers.datasets.LeRobotDataset")
+    def test_convert_frame_with_depth_and_mask(self, mock_lerobot_dataset):
+        """Test that camera auxiliary frames are added under numeric feature keys."""
+        env = MockEnvForDataset(num_joints=6)
+        env.single_observation_space["sensor"]["camera"].update(
+            {
+                "depth": Mock(dtype=np.dtype("float32"), shape=(480, 640)),
+                "mask": Mock(dtype=np.dtype("int32"), shape=(480, 640)),
+            }
+        )
+
+        mock_dataset_instance = Mock()
+        mock_dataset_instance.meta = Mock()
+        mock_dataset_instance.meta.info = {"fps": 30}
+        mock_lerobot_dataset.create.return_value = mock_dataset_instance
+
+        cfg = MockFunctorCfg(
+            params={
+                "save_path": "/tmp/test_dataset",
+                "robot_meta": {"robot_type": "test_robot", "control_freq": 30},
+                "instruction": {"lang": "test task"},
+                "extra": {"task_description": "test"},
+                "use_videos": False,
+            }
+        )
+
+        original_isinstance = isinstance
+
+        def mock_isinstance(obj, class_or_tuple):
+            if isinstance(obj, MockSensor):
+                if class_or_tuple is Camera or (
+                    isinstance(class_or_tuple, tuple) and Camera in class_or_tuple
+                ):
+                    return True
+            return original_isinstance(obj, class_or_tuple)
+
+        with patch(
+            "embodichain.lab.gym.envs.managers.datasets.isinstance",
+            side_effect=mock_isinstance,
+        ):
+            recorder = LeRobotRecorder(cfg, env)
+            depth = torch.arange(480 * 640, dtype=torch.float32).reshape(480, 640)
+            mask = torch.arange(480 * 640, dtype=torch.int32).reshape(480, 640)
+            obs = TensorDict(
+                {
+                    "robot": {
+                        "qpos": torch.zeros(6),
+                        "qvel": torch.zeros(6),
+                        "qf": torch.zeros(6),
+                    },
+                    "sensor": {
+                        "camera": {
+                            "color": torch.zeros(480, 640, 4, dtype=torch.uint8),
+                            "depth": depth,
+                            "mask": mask,
+                        }
+                    },
+                },
+                batch_size=[],
+            )
+            frame = recorder._convert_frame_to_lerobot(obs, torch.zeros(6), "test_task")
+
+        assert torch.equal(frame["observation.depth.camera"], depth)
+        assert torch.equal(frame["observation.mask.camera"], mask)
+        assert frame["observation.depth.camera"].dtype == torch.float32
+        assert frame["observation.mask.camera"].dtype == torch.int32
 
 
 class TestDatasetFunctorCfg:


### PR DESCRIPTION
# Description

`LeRobotRecorder` currently exports RGB frames but drops camera depth and
segmentation-mask observations. This makes the generated dataset incomplete for
policies that consume geometry or semantic labels.

This PR adds first-class numeric LeRobot features for those modalities:

- `observation.depth.<sensor>` and `observation.mask.<sensor>`
- `<sensor>_right` variants for stereo-camera frames
- source dtype and shape preservation (for example, `float32` depth and `int32`
  masks)
- RGB-only image/video handling, so auxiliary arrays are never passed through a
  lossy image codec
- a warning and clean skip for camera frame types that the recorder does not
  support

The implementation derives both the feature schema and each recorded frame from
the observation-space frame names. It also removes the separate stereo-camera
branch, ensuring that schemas and frame conversion use the same key mapping.

No new runtime dependency is introduced.

## Type of change

- Enhancement (non-breaking change which improves existing functionality)
- Documentation update

## Screenshots

Not applicable; this change affects structured dataset output.

## Validation

- `11 passed` for `tests/gym/envs/managers/test_dataset_functors.py` in an
  isolated Python 3.10 environment with LeRobot 0.4.4. The test module was
  executed through a minimal import harness because the repository's top-level
  pytest configuration imports the simulation engine before test collection.
- `black --check --target-version py310
  embodichain/lab/gym/envs/managers/datasets.py
  tests/gym/envs/managers/test_dataset_functors.py`
- `python -m py_compile` for both changed Python files
- `git diff --check`

The complete repository test suite could not be collected locally on this
development host:

- macOS 26.5.1 (arm64)
- Python 3.10.20
- pip 26.1.2 and uv 0.11.7

Following the repository installation guide, I retried with:

```shell
python -m pip install dexsim_engine==0.4.3 \
  --extra-index-url http://pyp.open3dv.site:2345/simple/ \
  --trusted-host pyp.open3dv.site -v
```

The DexForce index contains CPython 3.10 and 3.11 wheels for
`manylinux_2_31_x86_64`, but no macOS arm64 wheel. pip therefore filters all
published files and reports:

```text
ERROR: Could not find a version that satisfies the requirement dexsim_engine==0.4.3 (from versions: none)
ERROR: No matching distribution found for dexsim_engine==0.4.3
```

This is a local platform-wheel limitation, not an absence of version 0.4.3 from
the DexForce index. The Linux x86_64 CI run remains the authoritative full-suite
check.

## Checklist

- [x] Changed Python files pass Black's check
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove the enhancement works
- [x] No dependency update is required
