### PR TITLE
Add tone mapping configuration to RenderCfg

### DIFF
--- a/docs/source/overview/sim/sim_manager.md
+++ b/docs/source/overview/sim/sim_manager.md
@@ -65,8 +65,13 @@ The {class}`~cfg.RenderCfg` class controls the rendering backend and quality set
 | Parameter | Type | Default | Description |
 | :--- | :--- | :--- | :--- |
 | `renderer` | `str` | `"auto"` | Renderer backend to use. Options are `'auto'` (pick a default based on the detected GPU), `'hybrid'` (ray tracing for shadows/reflections + rasterization), `'fast-rt'` (full ray tracing), and `'rt'` (offline ray-traced renderer for maximum visual fidelity). |
-| `enable_denoiser` | `bool` | `True` | Whether to enable denoising. Only valid when `renderer` is `'hybrid'`, `'fast-rt'` or `'rt'`. |
-| `spp` | `int` | `64` | Samples per pixel for ray tracing rendering. Only valid when `renderer` is `'hybrid'`, `'fast-rt'` or `'rt'` and `enable_denoiser` is `False`. |
+| `spp` | `int` | `1` | Samples per pixel for ray-traced rendering. Must be at least 1. |
+| `tone_mapping_enabled` | `bool` | `False` | Whether to map HDR RGB output with the modified Reinhard curve. |
+| `tone_mapping_exposure` | `float` | `1.0` | Non-negative fixed linear exposure multiplier applied before tone mapping. |
+
+Ray-traced output always uses DexSim's default OptiX denoiser. Tone mapping
+affects RGB output only; depth, segmentation masks, normals, and position
+buffers remain unchanged.
 
 #### Automatic Renderer Selection
 
@@ -96,9 +101,10 @@ from embodichain.lab.sim.cfg import RenderCfg
 
 sim_config = SimulationManagerCfg(
     render_cfg=RenderCfg(
-        renderer="fast-rt",    # Use full ray tracing (overrides auto-selection)
-        enable_denoiser=True,  # Enable denoising
-        spp=64,                # Samples per pixel (used when denoiser is off)
+        renderer="fast-rt",         # Override automatic renderer selection
+        spp=4,                      # Render four samples per pixel
+        tone_mapping_enabled=True,  # Convert HDR RGB to display-referred RGB
+        tone_mapping_exposure=1.0,  # Fixed exposure for reproducible frames
     )
 )
 ```

--- a/embodichain/lab/sim/cfg.py
+++ b/embodichain/lab/sim/cfg.py
@@ -15,9 +15,12 @@
 # ----------------------------------------------------------------------------
 
 from __future__ import annotations
+
 import enum
 import json
 import os
+
+import dexsim
 import numpy as np
 import torch
 
@@ -25,7 +28,9 @@ from typing import Sequence, Dict, Literal, List, Any, Optional
 from dataclasses import field, MISSING
 
 from dexsim.types import (
+    DenoiserType,
     Renderer,
+    ToneMappingType,
     PhysicalAttr,
     ActorType,
     AxisArrowType,
@@ -71,7 +76,23 @@ class RenderCfg:
     spp: int = 1
     """Samples per pixel for ray tracing rendering. This parameter is only valid when renderer is 'hybrid', 'fast-rt' or 'rt'."""
 
-    def to_dexsim_flags(self):
+    tone_mapping_enabled: bool = False
+    """Whether to map HDR RGB output with the modified Reinhard curve."""
+
+    tone_mapping_exposure: float = 1.0
+    """Fixed linear exposure multiplier applied before tone mapping."""
+
+    def __post_init__(self) -> None:
+        """Validate rendering parameters."""
+        if self.spp < 1:
+            logger.log_error("RenderCfg.spp must be at least 1.", ValueError)
+        if self.tone_mapping_exposure < 0.0:
+            logger.log_error(
+                "RenderCfg.tone_mapping_exposure must be non-negative.", ValueError
+            )
+
+    def to_dexsim_flags(self) -> Renderer:
+        """Convert the renderer name to DexSim's renderer enum."""
         if self.renderer == "hybrid":
             return Renderer.HYBRID
         elif self.renderer == "fast-rt":
@@ -90,6 +111,24 @@ class RenderCfg:
             logger.log_error(
                 f"Invalid renderer type '{self.renderer}' specified. Must be one of 'auto', 'hybrid', 'fast-rt', or 'rt'."
             )
+
+    def apply_to_dexsim_config(self, world_config: dexsim.WorldConfig) -> None:
+        """Apply rendering settings to a DexSim world configuration.
+
+        Args:
+            world_config: DexSim world configuration to update in place.
+        """
+        world_config.renderer = self.to_dexsim_flags()
+        world_config.raytrace_config.render_iterations_per_frame = self.spp
+        world_config.raytrace_config.open_denoise = True
+        world_config.raytrace_config.denoiser_type = DenoiserType.OPTIX
+        world_config.postprocess_config.tone_mapping_enabled = self.tone_mapping_enabled
+        world_config.postprocess_config.tone_mapping_type = (
+            ToneMappingType.MODIFIED_REINHARD
+        )
+        world_config.postprocess_config.tone_mapping_exposure = (
+            self.tone_mapping_exposure
+        )
 
 
 @configclass

--- a/embodichain/lab/sim/sim_manager.py
+++ b/embodichain/lab/sim/sim_manager.py
@@ -480,10 +480,7 @@ class SimulationManager:
             )
             sim_config.render_cfg.renderer = resolved_renderer
 
-        world_config.renderer = sim_config.render_cfg.to_dexsim_flags()
-        world_config.raytrace_config.render_iterations_per_frame = (
-            sim_config.render_cfg.spp
-        )
+        sim_config.render_cfg.apply_to_dexsim_config(world_config)
 
         if type(sim_config.sim_device) is str:
             self.device = torch.device(sim_config.sim_device)

--- a/tests/sim/test_cfg.py
+++ b/tests/sim/test_cfg.py
@@ -1,0 +1,88 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import dexsim
+import pytest
+
+from dexsim.types import DenoiserType, Renderer, ToneMappingType
+
+from embodichain.lab.sim.cfg import RenderCfg
+
+
+def test_render_cfg_applies_default_denoiser() -> None:
+    """Rendering always uses the default OptiX denoiser."""
+    world_config = dexsim.WorldConfig()
+
+    RenderCfg(renderer="hybrid").apply_to_dexsim_config(world_config)
+
+    assert world_config.raytrace_config.open_denoise is True
+    assert world_config.raytrace_config.denoiser_type == DenoiserType.OPTIX
+
+
+def test_render_cfg_does_not_expose_denoiser_options() -> None:
+    """Denoiser implementation details are not part of EmbodiChain's API."""
+    render_cfg = RenderCfg()
+
+    assert not hasattr(render_cfg, "denoiser_enabled")
+    assert not hasattr(render_cfg, "denoiser_type")
+
+
+def test_render_cfg_applies_tone_mapping_and_fixed_exposure() -> None:
+    """Tone mapping forwards its curve and fixed exposure to DexSim."""
+    expected_exposure = 1.25
+    world_config = dexsim.WorldConfig()
+    render_cfg = RenderCfg(
+        renderer="rt",
+        tone_mapping_enabled=True,
+        tone_mapping_exposure=expected_exposure,
+    )
+
+    render_cfg.apply_to_dexsim_config(world_config)
+
+    assert world_config.postprocess_config.tone_mapping_enabled is True
+    assert (
+        world_config.postprocess_config.tone_mapping_type
+        == ToneMappingType.MODIFIED_REINHARD
+    )
+    assert world_config.postprocess_config.tone_mapping_exposure == expected_exposure
+
+
+def test_render_cfg_applies_renderer_and_sample_count() -> None:
+    """The consolidated conversion preserves existing renderer settings."""
+    expected_spp = 8
+    world_config = dexsim.WorldConfig()
+
+    RenderCfg(renderer="fast-rt", spp=expected_spp).apply_to_dexsim_config(world_config)
+
+    assert world_config.renderer == Renderer.FASTRT
+    assert world_config.raytrace_config.render_iterations_per_frame == expected_spp
+
+
+@pytest.mark.parametrize(
+    ("field_name", "invalid_value"),
+    [
+        ("tone_mapping_exposure", -0.1),
+        ("spp", 0),
+    ],
+)
+def test_render_cfg_rejects_invalid_image_processing_settings(
+    field_name: str, invalid_value: object
+) -> None:
+    """Invalid image-processing values fail at configuration construction."""
+    with pytest.raises(ValueError):
+        RenderCfg(**{field_name: invalid_value})


### PR DESCRIPTION
# Description

This PR exposes modified Reinhard tone mapping and fixed exposure through RenderCfg, applies the settings to the DexSim WorldConfig, and documents and tests the behavior. OptiX denoising remains always enabled and is intentionally not exposed as user configuration.

The change gives visual-policy and synthetic-data workflows an explicit, reproducible HDR-to-display mapping while keeping the denoiser API simple.

Dependencies: no new package dependencies. Uses the existing DexSim PostProcessConfig API.

Issue: N/A

## Type of change

- Enhancement (non-breaking change which improves an existing functionality)
- Documentation update

## Screenshots

Not applicable; this is a rendering configuration API change.

## Checklist

- [x] I have run the black . command to format the code base.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my feature works.
- [x] Dependencies have been updated, if applicable.

## Validation

- Black check: passed (467 files unchanged).
- Targeted simulation tests: 12 passed.
- Documentation build: succeeded with 548 pre-existing warnings.
- Full test suite: 703 passed and 99 skipped; 3 unrelated failures and 1 teardown error remain because PushCubeRL and CartPoleRL are not registered in the current test environment.