### PR TITLE
Improve toolkit documentation

### DIFF
--- a/docs/source/api_reference/embodichain/embodichain.toolkits.rst
+++ b/docs/source/api_reference/embodichain/embodichain.toolkits.rst
@@ -1,12 +1,16 @@
 embodichain.toolkits
 ====================
 
+The :mod:`embodichain.toolkits` package contains asset-preparation and
+manipulation utilities that can be used independently of the simulation loop.
+
 .. automodule:: embodichain.toolkits
 
    .. rubric:: Submodules
 
    .. autosummary::
 
+      acd
       graspkit
       urdf_assembly
 
@@ -85,7 +89,7 @@ ConvexCollisionChecker
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autoclass:: ConvexCollisionChecker
-   :members: query, query_batch
+   :members: query, query_batch_points
    :show-inheritance:
 
 ConvexCollisionCheckerCfg
@@ -96,8 +100,20 @@ ConvexCollisionCheckerCfg
    :show-inheritance:
 
 
-URDF Assembly Tool
--------------------
+URDF Convex Decomposition
+-------------------------
+
+The :mod:`embodichain.toolkits.acd.urdf_modifider` module converts concave URDF
+collision meshes into CoACD-generated convex hulls. The high-level function can
+also scale the model and recompute inertial properties.
+
+.. currentmodule:: embodichain.toolkits.acd.urdf_modifider
+
+.. autofunction:: generate_urdf_collision_convexes
+
+
+URDF Assembly
+-------------
 
 .. automodule:: embodichain.toolkits.urdf_assembly
    :members:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -36,6 +36,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
     "sphinx.ext.napoleon",
+    "sphinx.ext.todo",
     "sphinx.ext.viewcode",
     "sphinx_autodoc_typehints",  # optional, shows type hints
     "sphinx_design",

--- a/docs/source/features/toolkits/convex_decomposition.md
+++ b/docs/source/features/toolkits/convex_decomposition.md
@@ -1,74 +1,112 @@
-# URDF Convex Decomposition Tool
+# URDF Convex Decomposition
 
-The URDF Convex Decomposition Tool is a utility within EmbodiChain designed to automatically process URDF models for simulation. It handles the decomposition of complex visual meshes into convex collision geometries and provides capabilities for model scaling and inertia recomputation.
+The URDF convex decomposition toolkit prepares mesh-based robot models for
+physics simulation. It processes each URDF link, decomposes its collision mesh
+into convex hulls with CoACD, writes the generated meshes beside the source
+asset, and updates a copy of the URDF to reference them.
 
-## Key Features
+If a link has no collision geometry, the toolkit uses its visual mesh and
+creates a collision element with the same origin. Primitive geometries and
+links without usable meshes are left unchanged.
 
-- **Automated Convex Decomposition**: Uses the CoACD algorithm to decompose concave meshes into multiple convex hulls, essential for stable physics simulation.
-- **URDF Modification**: Automatically generates a new URDF file linking to the newly created convex collision meshes.
-- **Inertia Handling**: Supports recomputing inertial properties (mass, center of mass, inertia tensor) based on the geometry.
-- **Model Scaling**: Allows for scaling the entire robot model (geometry, joints, origins) by specified factors.
+## Capabilities
 
-## Method 1: Python API Usage
+- **Convex collision generation** — decomposes concave meshes into a
+  configurable number of convex hulls for more stable collision detection.
+- **URDF rewriting** — stores generated meshes under `Collision/` and updates
+  the output URDF without replacing the source URDF.
+- **Inertia recomputation** — optionally calculates mass, center of mass, and
+  inertia from the generated collision mesh at unit density.
+- **Model scaling** — optionally scales mesh geometry, link and joint origins,
+  mass, and prismatic-joint limits.
 
-The tool provides a high-level function `generate_urdf_collision_convexes` for programmatic access. This is recommended for integrating the decomposition process into larger pipelines or scripts.
+```{note}
+Mesh paths are resolved relative to the input URDF directory. Keep the
+generated `Collision/` and `Scale/` directories together with the output URDF
+when moving the processed asset.
+```
 
-**Parameters:**
+## Python API
 
-- `urdf_path`: Path to the input URDF file.
-- `output_urdf_name`: Filename for the output URDF.
-- `max_convex_hull_num`: Maximum number of convex hulls to generate per mesh (default: 16).
-- `recompute_inertia`: Whether to recalculate inertial properties (default: False).
-- `scale`: Optional numpy array `[x, y, z]` to scale the model.
+Use `generate_urdf_collision_convexes` when integrating asset preprocessing
+into a Python pipeline.
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `urdf_path` | `str` | required | Path to the source URDF. |
+| `output_urdf_name` | `str` | required | Name of the output URDF, written in the source URDF directory. |
+| `max_convex_hull_num` | `int` | `16` | Maximum hull count passed to CoACD for each mesh. |
+| `recompute_inertia` | `bool` | `False` | Recompute inertial properties from collision geometry. |
+| `scale` | sequence of 3 floats or `None` | `None` | Per-axis scale factors `[x, y, z]`. |
 
 ```python
-from embodichain.toolkits.acd.urdf_modifider import generate_urdf_collision_convexes
 import numpy as np
 
-# Example: Decompose and Scale
+from embodichain.toolkits.acd.urdf_modifider import (
+    generate_urdf_collision_convexes,
+)
+
 generate_urdf_collision_convexes(
     urdf_path="./assets/robot.urdf",
     output_urdf_name="robot_processed.urdf",
     max_convex_hull_num=16,
     recompute_inertia=True,
-    scale=np.array([1.0, 1.0, 1.0])
+    scale=np.array([1.0, 1.0, 1.0]),
 )
-print("Convex decomposition and inertia update completed.")
 ```
 
-## Method 2: Command Line Interface (CLI)
+## Command-Line Interface
 
-The tool can also be run directly from the terminal, which is useful for quick batch processing or standalone usage.
-
-**Command Structure:**
+Run the module directly for one-off or batch asset preparation:
 
 ```bash
 python -m embodichain.toolkits.acd.urdf_modifider [OPTIONS]
 ```
 
-### Argument Descriptions
+### Options
 
 | Argument | Type | Default | Description |
-|----------|------|---------|-------------|
-| `--urdf_path` | str | Required | Path to the source URDF file. |
-| `--output_urdf_name` | str | `articulation_acd.urdf` | Name of the generated URDF file. |
-| `--max_convex_hull_num` | int | 8 | Maximum number of convex hulls for decomposition. |
-| `--recompute_inertia` | flag | False | If present, recomputes inertia based on mesh geometry. |
-| `--scale` | float | None | Scale factors (x y z). Example: `--scale 1.5 1.5 1.5`. |
+|---|---|---|---|
+| `--urdf_path` | `str` | required | Path to the source URDF. |
+| `--output_urdf_name` | `str` | `articulation_acd.urdf` | Name of the generated URDF. |
+| `--max_convex_hull_num` | `int` | `8` | Maximum hull count for each mesh. |
+| `--recompute_inertia` | flag | disabled | Recompute inertia from generated collision geometry. |
+| `--scale` | 3 floats | `None` | Per-axis scale factors, for example `--scale 1.5 1.5 1.5`. |
 
-**Example Usage:**
+The Python API and CLI intentionally have different default hull limits: `16`
+for the function and `8` for the CLI.
+
+### Examples
 
 ```bash
-# Basic decomposition
+# Generate convex collision meshes.
 python -m embodichain.toolkits.acd.urdf_modifider \
     --urdf_path ./assets/my_robot.urdf \
     --output_urdf_name my_robot_convex.urdf \
     --max_convex_hull_num 16
 
-# Decomposition with scaling and inertia recomputation
+# Scale the model and recompute inertia.
 python -m embodichain.toolkits.acd.urdf_modifider \
     --urdf_path ./assets/my_robot.urdf \
     --output_urdf_name my_robot_scaled.urdf \
     --recompute_inertia \
     --scale 0.5 0.5 0.5
 ```
+
+## Output Layout
+
+For an input at `assets/robot.urdf`, the toolkit writes generated files relative
+to `assets/`:
+
+```text
+assets/
+├── robot.urdf
+├── robot_processed.urdf
+├── Collision/
+│   └── *_auto_convex.obj
+└── Scale/                  # Created only when --scale is used.
+```
+
+Review the generated URDF before simulation, especially when using non-uniform
+scaling or inertia recomputation. The inertia calculation assumes unit mesh
+density, and non-watertight geometry may produce inaccurate values.

--- a/docs/source/features/toolkits/grasp_generator.rst
+++ b/docs/source/features/toolkits/grasp_generator.rst
@@ -1,12 +1,31 @@
-Generating and Executing Robot Grasps
-======================================
+Parallel-Gripper Grasp Generation
+=================================
 
 .. currentmodule:: embodichain.lab.sim
 
-This tutorial demonstrates how to generate antipodal grasp poses for a target object and execute a full grasp trajectory with a robot arm. It covers scene initialization, robot and object creation, interactive grasp region annotation, grasp pose computation, and trajectory execution in the simulation loop.
+The GraspKit toolkit generates feasible grasp poses for parallel-jaw grippers
+from a target object's triangle mesh. It supports programmatic antipodal
+sampling, browser-based grasp-region annotation, collision filtering, candidate
+ranking, and on-disk caching of sampled contact pairs.
 
-The Code
-~~~~~~~~
+This page also demonstrates how to execute a generated pose with a robot arm. It
+covers scene initialization, robot and object creation, grasp pose computation,
+and trajectory execution in the simulation loop.
+
+Processing Pipeline
+-------------------
+
+Grasp generation has three stages:
+
+1. Sample surface points and find antipodal contact pairs on the full mesh or an
+   annotated region.
+2. Construct 6-DoF grasp frames that align the gripper opening axis with each
+   contact pair and respect the requested approach direction.
+3. Remove candidates that collide with the object or ground, rank the remaining
+   poses, and return the best candidates with their required opening lengths.
+
+Tutorial Source
+---------------
 
 The tutorial corresponds to the ``grasp_generator.py`` script in the ``scripts/tutorials/grasp`` directory.
 
@@ -18,11 +37,11 @@ The tutorial corresponds to the ``grasp_generator.py`` script in the ``scripts/t
       :linenos:
 
 
-The Code Explained
-~~~~~~~~~~~~~~~~~~
+Tutorial Walkthrough
+--------------------
 
 Configuring the simulation
---------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Command-line arguments are parsed with ``argparse`` to select the number of parallel environments, the compute device, and optional rendering features such as renderer backend and headless mode.
 
@@ -39,7 +58,7 @@ The parsed arguments are passed to ``initialize_simulation``, which builds a :cl
    :end-at: return sim
 
 Creating a robot and a target object
-------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A UR10 arm with a parallel-jaw gripper is created via :meth:`SimulationManager.add_robot`. The gripper URDF and drive properties are configured so that the arm joints and finger joints can be controlled independently.
 
@@ -52,11 +71,11 @@ The target object (a mug) is loaded as a :class:`objects.RigidObject` from a PLY
 
 .. literalinclude:: ../../../../scripts/tutorials/grasp/grasp_generator.py
    :language: python
-   :start-at: def create_mug(sim: SimulationManager):
+   :start-at: def create_obj(sim: SimulationManager):
    :end-at: return mug
 
 Annotating and computing grasp poses
--------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Grasp generation is performed by :class:`~embodichain.toolkits.graspkit.pg_grasp.GraspGenerator`, which runs an antipodal sampler on the object mesh. The mesh data (vertices and triangles) is extracted from the :class:`objects.RigidObject` via its accessor methods. A :class:`~embodichain.toolkits.graspkit.pg_grasp.GraspGeneratorCfg` controls sampler parameters (sample count, gripper jaw limits) and the interactive annotation workflow:
 
@@ -64,7 +83,9 @@ Grasp generation is performed by :class:`~embodichain.toolkits.graspkit.pg_grasp
 2. Use *Rect Select Region* to highlight the area of the object that should be grasped.
 3. Click *Confirm Selection* to finalize the region.
 
-After annotation, antipodal point pairs are cached to disk and automatically reused unless user call `GraspGenerator.annotate()`.
+After annotation, antipodal point pairs are cached to disk and automatically
+reused. Call :meth:`~embodichain.toolkits.graspkit.pg_grasp.GraspGenerator.annotate`
+again to select a new region.
 
 For each environment, a grasp pose is computed by calling :meth:`~embodichain.toolkits.graspkit.pg_grasp.GraspGenerator.get_grasp_poses` with the object pose and desired approach direction. The result is a ``(4, 4)`` homogeneous transformation matrix representing the grasp frame in world coordinates. Set ``visualize=True`` to open an Open3D window showing the selected grasp on the object.
 
@@ -76,7 +97,7 @@ The approach direction is the unit vector along which the gripper approaches the
    :end-at: logger.log_info(f"Get grasp pose cost time: {cost_time:.2f} seconds")
 
 Building and executing the grasp trajectory
--------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Once a grasp pose is obtained, a waypoint trajectory is built that moves the arm from its rest configuration to an approach pose (offset above the grasp), down to the grasp pose, closes the fingers, lifts, and returns. The trajectory is interpolated for smooth motion and executed step-by-step in the simulation loop.
 
@@ -85,8 +106,11 @@ Once a grasp pose is obtained, a waypoint trajectory is built that moves the arm
    :start-at: def get_grasp_traj(sim: SimulationManager
    :end-at: return interp_trajectory
 
-Configuring GraspGeneratorCfg
-------------------------------
+Configuration
+-------------
+
+GraspGeneratorCfg
+~~~~~~~~~~~~~~~~~
 
 :class:`~embodichain.toolkits.graspkit.pg_grasp.GraspGeneratorCfg` controls the overall grasp annotation workflow. The key parameters are listed below.
 
@@ -107,14 +131,23 @@ Configuring GraspGeneratorCfg
      - ``AntipodalSamplerCfg()``
      - Nested configuration for the antipodal point sampler. See the table below for its parameters.
    * - ``max_deviation_angle``
-     - ``π / 12``
+     - ``π / 6``
      - Maximum allowed angle (in radians) between the specified approach direction and the axis connecting an antipodal point pair. Pairs that deviate more than this threshold are discarded.
+   * - ``n_deviated_approach_directions``
+     - ``4``
+     - Number of evenly deviated approach directions considered while sampling grasp poses.
+   * - ``n_top_grasps``
+     - ``50``
+     - Maximum number of top-ranked grasp poses returned after filtering and scoring.
    * - ``is_partial_annotate``
-     - ``True``
+     - ``False``
      - When ``True``, the annotator allows selecting a partial region of the mesh for grasp sampling. If ``False``, the entire mesh is used.
    * - ``is_filter_ground_collision``
      - ``True``
      - Whether to filter out grasp poses that would cause the gripper to  collide.
+
+AntipodalSamplerCfg
+~~~~~~~~~~~~~~~~~~~
 
 The ``antipodal_sampler_cfg`` field accepts an :class:`~embodichain.toolkits.graspkit.pg_grasp.AntipodalSamplerCfg` instance, which controls how antipodal point pairs are sampled on the mesh surface.
 
@@ -138,8 +171,8 @@ The ``antipodal_sampler_cfg`` field accepts an :class:`~embodichain.toolkits.gra
      - ``0.001``
      - Minimum allowed distance (in metres) between an antipodal pair. Pairs closer together than this value are discarded to avoid degenerate or self-intersecting grasps.
 
-Configuring GripperCollisionCfg
--------------------------------
+GripperCollisionCfg
+~~~~~~~~~~~~~~~~~~~
 
 :class:`~embodichain.toolkits.graspkit.pg_grasp.GripperCollisionCfg` models the geometry of a parallel-jaw gripper as a point cloud and is used to filter out grasp candidates that would collide with the object. All length parameters are in metres.
 
@@ -176,8 +209,8 @@ Configuring GripperCollisionCfg
      - Extra clearance added to the gripper open length during collision checking to account for pose uncertainty or mesh inaccuracies.
 
 
-The Code Execution
-~~~~~~~~~~~~~~~~~~
+Running the Tutorial
+--------------------
 
 To run the script, execute the following command from the project root:
 
@@ -197,7 +230,7 @@ After confirming the grasp region in the browser, the script will compute a gras
 
 
 Grasp Annotation CLI
-~~~~~~~~~~~~~~~~~~~~
+--------------------
 
 EmbodiChain provides a dedicated CLI for interactively annotating grasp regions on a mesh and caching the resulting antipodal point pairs, without requiring a full simulation environment.
 
@@ -219,7 +252,7 @@ Common options::
        --viser_port 15531 \
        --n_sample 20000 \
        --max_length 0.1 \
-       --min_length 0.001 \
+       --min_length 0.001
 
 .. list-table:: CLI options
    :header-rows: 1

--- a/docs/source/features/toolkits/index.rst
+++ b/docs/source/features/toolkits/index.rst
@@ -1,11 +1,50 @@
-ToolKits
-======================
+Toolkits
+========
 
+The :mod:`embodichain.toolkits` package provides standalone utilities for
+preparing robot assets and generating manipulation data. These tools complement
+the simulation APIs: they can be used in preprocessing scripts, from the
+command line, or as part of an EmbodiChain workflow.
+
+Available Toolkits
+------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 24 44 32
+
+   * - Toolkit
+     - What it does
+     - Typical use
+   * - :doc:`URDF Convex Decomposition <convex_decomposition>`
+     - Decomposes concave URDF meshes into convex collision hulls, with
+       optional model scaling and inertia recomputation.
+     - Prepare imported URDF assets for stable physics simulation.
+   * - :doc:`URDF Assembly <urdf_assembly>`
+     - Combines component URDFs, attaches sensors, normalizes names, and writes
+       a unified robot description.
+     - Build modular or multi-part robots such as arm-and-gripper systems.
+   * - :doc:`Parallel-Gripper Grasp Generation <grasp_generator>`
+     - Samples antipodal contacts, constructs grasp poses, and filters
+       collisions for parallel-jaw grippers.
+     - Annotate graspable regions and generate candidate grasps for manipulation.
+
+Choosing a Toolkit
+------------------
+
+Use convex decomposition when a source URDF already represents the complete
+robot but its collision meshes are unsuitable for simulation. Use URDF assembly
+when the robot is distributed across multiple component files. Use grasp
+generation after the target object's mesh is ready and a manipulation workflow
+needs feasible end-effector poses.
+
+The asset tools can be chained: preprocess component collision meshes, assemble
+the components into one URDF, and then load the resulting robot in a grasping
+task.
 
 .. toctree::
    :maxdepth: 1
 
-   convex_decomposition <convex_decomposition.md>
-   urdf_assembly <urdf_assembly.md>
-   grasp_generator
-   
+   URDF Convex Decomposition <convex_decomposition>
+   URDF Assembly <urdf_assembly>
+   Parallel-Gripper Grasp Generation <grasp_generator>

--- a/docs/source/features/toolkits/urdf_assembly.md
+++ b/docs/source/features/toolkits/urdf_assembly.md
@@ -1,234 +1,154 @@
-# URDF Assembly Tool
+# URDF Assembly
 
-The URDF Assembly Tool is a modular system for building and assembling Unified Robot Description Format (URDF) files for robotic systems. It enables users to combine individual robot components (chassis, arms, legs, sensors, etc.) into a complete robot description.
+The URDF assembly toolkit builds one robot description from multiple component
+URDFs. It is intended for modular robots whose chassis, arms, end effectors, or
+sensors are maintained as separate assets.
 
-## Overview
+During assembly, the toolkit loads each component, copies its links, joints, and
+meshes into a unified layout, creates fixed joints between compatible
+components, attaches sensors, normalizes names, and writes the merged URDF. A
+content signature avoids rebuilding an unchanged assembly.
 
-The tool provides a programmatic way to:
+## Capabilities
 
-- **Add robot components**: Import URDF files for different robot parts (chassis, legs, torso, head, arms, hands)
-- **Attach sensors**: Add sensors (camera, lidar, IMU, GPS, force/torque) to specific components
-- **Merge URDFs**: Combine multiple component URDFs into a single unified robot description
-- **Apply transformations**: Position and orient components using 4x4 transformation matrices
-- **Validate assemblies**: Ensure URDF integrity and format compliance
-- **Cache assemblies**: Use signature checking to skip redundant processing
+- **Component assembly** — combines common robot parts such as a chassis,
+  torso, arms, and hands.
+- **Automatic connections** — creates fixed joints from built-in parent-child
+  rules and applies optional 4×4 transforms.
+- **Sensor attachment** — inserts sensor URDFs or XML elements at a selected
+  component link.
+- **Name management** — adds per-component prefixes and applies a consistent
+  casing policy to links and joints.
+- **Asset collection** — copies referenced meshes and related material assets
+  into the output layout.
+- **Incremental rebuilds** — hashes component files and assembly settings so an
+  up-to-date output can be reused.
+
+## Internal Modules
+
+The public entry point is `URDFAssemblyManager`. Its work is divided among the
+following submodules:
+
+| Module | Responsibility |
+|---|---|
+| `urdf_assembly_manager.py` | Coordinates registration, connection generation, merging, and output. |
+| `component.py` | Loads component URDFs, applies prefixes, and manages component registries. |
+| `connection.py` | Creates fixed joints according to connection rules and component transforms. |
+| `sensor.py` | Registers sensor attachments and merges their links and joints. |
+| `mesh.py` | Resolves and copies mesh, material, and texture assets. |
+| `name_normalizer.py` | Applies link and joint casing policies. |
+| `file_writer.py` | Formats and writes the assembled URDF. |
+| `signature.py` | Calculates and checks assembly signatures. |
+| `logging_utils.py` | Provides assembly-specific logging. |
+
+Most applications should use `URDFAssemblyManager` or
+`embodichain.lab.sim.cfg.URDFCfg` instead of calling these internal helpers
+directly.
 
 ## Quick Start
 
 ```python
-from pathlib import Path
 import numpy as np
+
 from embodichain.toolkits.urdf_assembly import URDFAssemblyManager
 
-# Initialize the assembly manager
 manager = URDFAssemblyManager()
 
-# Add robot components
 manager.add_component(
-    component_type="chassis",
-    urdf_path="path/to/chassis.urdf",
+    component_type="arm",
+    urdf_path="assets/arm.urdf",
+)
+manager.add_component(
+    component_type="hand",
+    urdf_path="assets/hand.urdf",
+    transform=np.eye(4),
 )
 
-manager.add_component(
-    component_type="torso",
-    urdf_path="path/to/torso.urdf",
-    transform=np.eye(4)  # 4x4 transformation matrix
-)
+manager.merge_urdfs(output_path="build/arm_with_hand.urdf")
+```
+
+`add_component()` returns `False` and logs an error if registration fails.
+Check its return value in asset-processing pipelines before calling
+`merge_urdfs()`.
+
+## Component Assembly
+
+### Supported Component Types
+
+The manager recognizes these component roles:
+
+| Component | Purpose |
+|---|---|
+| `chassis` | Mobile base or central platform. |
+| `legs` | Legged locomotion system. |
+| `torso` | Main body between the base and upper-body components. |
+| `head` | Head or upper sensor structure. |
+| `left_arm`, `right_arm` | Side-specific manipulators. |
+| `left_hand`, `right_hand` | Side-specific end effectors. |
+| `arm` | Single manipulator without a side designation. |
+| `hand` | Single end effector without a side designation. |
+
+For a chassis, the optional `wheel_type` parameter accepts `omni`,
+`differential`, or `tracked`. Referenced meshes can use STL, OBJ, PLY, DAE, or
+GLB formats.
+
+### Connection Rules
+
+The manager connects registered components using built-in parent-child rules:
+
+- `chassis` → `legs` → `torso`
+- `chassis` → `torso`
+- `torso` → `head`
+- `torso` or `chassis` → side-specific arms
+- `left_arm` → `left_hand`
+- `right_arm` → `right_hand`
+- `arm` → `hand`
+
+Components without a matching parent are attached to the assembly base link.
+The `transform` passed to `add_component()` controls the fixed joint that
+attaches that component. It must be a 4×4 homogeneous transformation matrix.
+
+```python
+hand_transform = np.eye(4)
+hand_transform[2, 3] = 0.05
 
 manager.add_component(
-    component_type="left_arm",
-    urdf_path="path/to/arm.urdf"
+    component_type="hand",
+    urdf_path="assets/hand.urdf",
+    transform=hand_transform,
 )
+```
 
-# Attach sensors
+## Sensor Attachment
+
+`attach_sensor()` accepts either a path to a sensor URDF or an
+`xml.etree.ElementTree.Element`. The attachment identifies both the component
+and the link within that component.
+
+```python
 manager.attach_sensor(
     sensor_name="front_camera",
-    sensor_source="path/to/camera.urdf",
+    sensor_source="assets/camera.urdf",
     parent_component="chassis",
     parent_link="base_link",
-    transform=np.eye(4)
+    transform=np.eye(4),
 )
-
-# Merge all components into a single URDF
-manager.merge_urdfs(output_path="assembly_robot.urdf")
 ```
 
-## Supported Components
+The predefined sensor categories are `camera`, `lidar`, `imu`, `gps`, and
+`force`. Use a unique `sensor_name` for each attachment.
 
-The tool supports the following robot component types:
+## Naming Configuration
 
-| Component | Description |
-|:----------|:------------|
-| `chassis` | Base platform of the robot |
-| `legs` | Leg system for legged robots |
-| `torso` | Main body/torso section |
-| `head` | Head/upper section |
-| `left_arm` | Left arm manipulator |
-| `right_arm` | Right arm manipulator |
-| `left_hand` | Left end-effector/gripper |
-| `right_hand` | Right end-effector/gripper |
-| `arm` | Single arm (bimanual robots) |
-| `hand` | Single end-effector/gripper |
+### Component Prefixes
 
-### Wheel Types
+Prefixes prevent duplicate link and joint names when two components originate
+from the same URDF. The default side-specific prefixes are `left_` and
+`right_`; the other component types have no prefix.
 
-For chassis components, the following wheel types are supported:
-
-- `omni`: Omnidirectional wheels
-- `differential`: Differential drive
-- `tracked`: Tracked locomotion
-
-## Supported Sensors
-
-The following sensor types can be attached to robot components:
-
-| Sensor | Description |
-|:-------|:------------|
-| `camera` | RGB/depth cameras |
-| `lidar` | 2D/3D LIDAR sensors |
-| `imu` | Inertial measurement units |
-| `gps` | GPS receivers |
-| `force` | Force/torque sensors |
-
-## Connection Rules
-
-The tool automatically generates connection rules based on available components. The default rules include:
-
-- Chassis → Legs → Torso (for legged robots)
-- Chassis → Torso (for wheeled robots)
-- Torso → Head
-- Torso → Arms → Hands
-- Chassis → Arms (when no torso exists)
-
-## Mesh Formats
-
-Supported mesh file formats for visual and collision geometries:
-
-- STL
-- OBJ
-- PLY
-- DAE
-- GLB
-
-## API Reference
-
-### URDFAssemblyManager
-
-*Located in:* `embodichain/toolkits/urdf_assembly/urdf_assembly_manager.py`
-
-The main class for managing URDF assembly operations.
-
-#### Methods
-
-##### add_component()
-
-Add a URDF component to the component registry.
+Set `component_prefix` with a list of `(component_type, prefix)` tuples:
 
 ```python
-manager.add_component(
-    component_type: str,
-    urdf_path: Union[str, Path],
-    transform: np.ndarray = None,
-    **params
-) -> bool
-```
-
-**Parameters:**
-
-- `component_type` (str): Type of component (e.g., 'chassis', 'head')
-- `urdf_path` (str or Path): Path to the component's URDF file
-- `transform` (np.ndarray, optional): 4x4 transformation matrix for positioning
-- `**params`: Additional component-specific parameters (e.g., `wheel_type` for chassis)
-
-**Returns:** `bool` - True if component added successfully
-
-##### attach_sensor()
-
-Attach a sensor to a specific component and link.
-
-```python
-manager.attach_sensor(
-    sensor_name: str,
-    sensor_source: Union[str, ET.Element],
-    parent_component: str,
-    parent_link: str,
-    transform: np.ndarray = None,
-    **kwargs
-) -> bool
-```
-
-**Parameters:**
-
-- `sensor_name` (str): Unique name for the sensor
-- `sensor_source` (str or ET.Element): Path to sensor URDF or XML element
-- `parent_component` (str): Component to attach sensor to
-- `parent_link` (str): Link within the parent component
-- `transform` (np.ndarray, optional): Sensor transformation matrix
-
-**Returns:** `bool` - True if sensor attached successfully
-
-##### merge_urdfs()
-
-Merge all registered components into a single URDF file.
-
-```python
-manager.merge_urdfs(
-    output_path: str = "./assembly_robot.urdf",
-    use_signature_check: bool = True
-) -> ET.Element
-```
-
-**Parameters:**
-
-- `output_path` (str): Path where the merged URDF will be saved
-- `use_signature_check` (bool): Whether to check signatures to avoid redundant processing
-
-**Returns:** `ET.Element` - Root element of the merged URDF
-
-##### get_component()
-
-Retrieve a registered component by type.
-
-```python
-manager.get_component(component_type: str) -> URDFComponent | None
-```
-
-##### get_attached_sensors()
-
-Get all attached sensors.
-
-```python
-manager.get_attached_sensors() -> dict
-```
-
-##### Component name prefixes (`component_prefix`)
-
-`URDFAssemblyManager` uses `component_prefix` to configure name prefixes for
-each supported component type. This attribute is a list of 2-tuples:
-
-- Form: `[(component_name, prefix), ...]`
-- The default value is:
-
-    ```python
-    [
-        ("chassis", None),
-        ("legs", None),
-        ("torso", None),
-        ("head", None),
-        ("left_arm", "left_"),
-        ("right_arm", "right_"),
-        ("left_hand", "left_"),
-        ("right_hand", "right_"),
-        ("arm", None),
-        ("hand", None),
-    ]
-    ```
-
-You can configure it in a *patch-style* manner via the property:
-
-```python
-# Only override prefixes for existing components; do not introduce
-# new component names.
 manager.component_prefix = [
     ("left_arm", "L_"),
     ("right_arm", "R_"),
@@ -237,280 +157,133 @@ manager.component_prefix = [
 ]
 ```
 
-Semantics:
+This property uses patch semantics: omitted component types keep their current
+prefix. It does not accept new component types, and an unknown type raises
+`ValueError`.
 
-- Only components that already exist in the default configuration (e.g. `chassis/torso/left_arm/...`) may be overridden; new component names are not allowed.
-- Components not listed in `new_prefixes` keep their original prefix.
-- If `new_prefixes` contains an unknown component name, a `ValueError` is raised indicating that new component types cannot be introduced.
+### Link and Joint Casing
 
-##### Name casing policy (`name_case`)
-
-`URDFAssemblyManager` supports a global name casing policy that controls how
-link and joint names are normalized during assembly. This is configured on
-the manager instance after construction:
+The `name_case` policy controls how names are normalized:
 
 ```python
-manager = URDFAssemblyManager()
 manager.name_case = {
-        "joint": "upper",  # or "lower" / "none"
-        "link": "lower",  # or "upper" / "none"
+    "joint": "upper",
+    "link": "lower",
 }
+```
 
-Semantics:
+Both `joint` and `link` keys are required. Supported modes are `upper`, `lower`,
+and `original`; `none` is retained as a legacy alias for `original`.
+`URDFAssemblyManager` defaults to uppercase joints and lowercase links.
 
-- Valid keys: `"joint"`, `"link"`.
-- Valid values: `"upper"`, `"lower"`, `"none"`.
-- Default behavior matches the legacy implementation:
-  - joints are normalized to **UPPERCASE**,
-  - links are normalized to **lowercase**.
-- This policy is propagated to the internal component and connection managers,
-    and is also included in the assembly signature. Changing `name_case` will
-    therefore force a rebuild of the assembled URDF.
+```{note}
+`URDFCfg` defaults to preserving the source casing for both links and joints.
+Set `name_case` explicitly when direct-manager and simulation-config workflows
+must produce identical names.
+```
 
-## Using with URDFCfg for Robot Creation
+Prefix and casing changes are included in the assembly signature, so they
+trigger a rebuild even when the component files are unchanged.
 
-The URDF Assembly Tool can be used directly with `URDFCfg` to create robots with multiple components in the simulation. This is the recommended approach when building robots from assembled URDF files.
+## Public API
 
-### URDFCfg Overview
+### `add_component()`
 
-The `URDFCfg` class provides a convenient way to define multi-component robots:
+Registers a component URDF:
 
 ```python
+manager.add_component(
+    component_type: str,
+    urdf_path: str | Path,
+    transform: np.ndarray | None = None,
+    **params,
+) -> bool
+```
+
+### `attach_sensor()`
+
+Registers a sensor attachment:
+
+```python
+manager.attach_sensor(
+    sensor_name: str,
+    sensor_source: str | Element,
+    parent_component: str,
+    parent_link: str,
+    transform: np.ndarray | None = None,
+    **kwargs,
+) -> bool
+```
+
+### `merge_urdfs()`
+
+Builds and writes the unified description:
+
+```python
+manager.merge_urdfs(
+    output_path: str = "./assembly_robot.urdf",
+    use_signature_check: bool = True,
+) -> Element
+```
+
+When signature checking is enabled, the manager reuses an existing output if
+the component contents, transforms, parameters, prefix configuration, casing
+policy, and output name have not changed.
+
+### Registry Access
+
+Use `get_component(component_type)` to retrieve one registered component and
+`get_attached_sensors()` to retrieve all sensor attachments.
+
+## Using `URDFCfg` in Simulation
+
+`URDFCfg` is the convenient integration point for robots created through
+`SimulationManager`. It invokes the assembly toolkit automatically when more
+than one component is configured.
+
+```python
+import numpy as np
+from scipy.spatial.transform import Rotation
+
 from embodichain.lab.sim.cfg import RobotCfg, URDFCfg
 
+hand_transform = np.eye(4)
+hand_transform[:3, :3] = Rotation.from_euler(
+    "x", 90, degrees=True
+).as_matrix()
+
 cfg = RobotCfg(
-    uid="my_robot",
+    uid="arm_with_hand",
     urdf_cfg=URDFCfg(
         components=[
             {
                 "component_type": "arm",
-                "urdf_path": "path/to/arm.urdf",
+                "urdf_path": "assets/arm.urdf",
             },
             {
                 "component_type": "hand",
-                "urdf_path": "path/to/hand.urdf",
-                "transform": hand_transform,  # 4x4 transformation matrix
+                "urdf_path": "assets/hand.urdf",
+                "transform": hand_transform,
             },
-        ]
+        ],
+        component_prefix=[("hand", "tool_")],
+        name_case={"joint": "original", "link": "original"},
     ),
-    control_parts={...},
-    drive_pros={...},
 )
 ```
 
-When using `URDFCfg` to build multi-component robots, you can pass custom
-component prefixes to the internal `URDFAssemblyManager` via
-`URDFCfg.component_prefix`. Its semantics are identical to
-`URDFAssemblyManager.component_prefix`:
+Each component dictionary requires `component_type` and `urdf_path`; `transform`
+and component-specific parameters are optional. `URDFCfg` also supports:
 
-- Each element is a `(component_name, prefix)` tuple.
-- Only prefixes for components that exist in the default configuration may be overridden; no new component names can be added.
-- Components not explicitly listed keep their original prefix.
+| Setting | Purpose |
+|---|---|
+| `sensors` | Sensor attachment configurations. |
+| `base_link_name` | Name of the assembly root link. |
+| `component_prefix` | Per-component prefix overrides. |
+| `name_case` | Link and joint casing policy. |
+| `use_signature_check` | Enables incremental assembly reuse. |
+| `fpath` | Explicit output URDF path. |
+| `fname`, `fpath_prefix` | Generated output name and parent directory. |
 
-Example:
-
-```python
-urdf_cfg = URDFCfg(
-    components=[...],
-)
-urdf_cfg.component_prefix = [
-    ("left_arm", "L_"),
-    ("right_arm", "R_"),
-]
-```
-
-### Complete Example
-
-Here's a complete example from `scripts/tutorials/sim/create_robot.py`:
-
-```python
-import numpy as np
-import torch
-from scipy.spatial.transform import Rotation as R
-
-from embodichain.lab.sim import SimulationManager, SimulationManagerCfg
-from embodichain.lab.sim.objects import Robot
-from embodichain.lab.sim.cfg import (
-    JointDrivePropertiesCfg,
-    RobotCfg,
-    URDFCfg,
-)
-from embodichain.data import get_data_path
-
-
-def create_robot(sim):
-    """Create and configure a robot with arm and hand components."""
-
-    # Get URDF paths for robot components
-    arm_urdf_path = get_data_path("Rokae/SR5/SR5.urdf")
-    hand_urdf_path = get_data_path(
-        "BrainCoHandRevo1/BrainCoLeftHand/BrainCoLeftHand.urdf"
-    )
-
-    # Define control parts - joint names can be regex patterns
-    CONTROL_PARTS = {
-        "arm": ["JOINT[1-6]"],      # Matches JOINT1, JOINT2, ..., JOINT6
-        "hand": ["LEFT_.*"],         # Matches all joints starting with LEFT_
-    }
-
-    # Define transformation for hand attachment
-    hand_transform = np.eye(4)
-    hand_transform[:3, :3] = R.from_rotvec([90, 0, 0], degrees=True).as_matrix()
-
-    # Create robot configuration
-    cfg = RobotCfg(
-        uid="sr5_with_hand",
-        urdf_cfg=URDFCfg(
-            components=[
-                {
-                    "component_type": "arm",
-                    "urdf_path": arm_urdf_path,
-                },
-                {
-                    "component_type": "hand",
-                    "urdf_path": hand_urdf_path,
-                    "transform": hand_transform,
-                },
-            ]
-        ),
-        control_parts=CONTROL_PARTS,
-        drive_pros=JointDrivePropertiesCfg(
-            stiffness={"JOINT[1-6]": 1e4, "LEFT_.*": 1e3},
-            damping={"JOINT[1-6]": 1e3, "LEFT_.*": 1e2},
-        ),
-    )
-
-    # Add robot to simulation
-    robot: Robot = sim.add_robot(cfg=cfg)
-
-    return robot
-
-
-# Initialize simulation and create robot
-sim = SimulationManager(SimulationManagerCfg(headless=True, num_envs=4))
-robot = create_robot(sim)
-print(f"Robot created with {robot.dof} joints")
-```
-
-```python
-import numpy as np
-import torch
-from scipy.spatial.transform import Rotation as R
-
-from embodichain.lab.sim import SimulationManager, SimulationManagerCfg
-from embodichain.lab.sim.objects import Robot
-from embodichain.lab.sim.cfg import (
-    JointDrivePropertiesCfg,
-    RobotCfg,
-    URDFCfg,
-)
-from embodichain.data import get_data_path
-
-
-def create_robot(sim):
-    """Create and configure a robot with arm and hand components."""
-
-    # Get URDF paths for robot components
-    arm_urdf_path = get_data_path("Rokae/SR5/SR5.urdf")
-    hand_urdf_path = get_data_path(
-        "BrainCoHandRevo1/BrainCoLeftHand/BrainCoLeftHand.urdf"
-    )
-
-    # Define transformation for hand attachment
-    hand_transform = np.eye(4)
-    hand_transform[:3, :3] = R.from_rotvec([90, 0, 0], degrees=True).as_matrix()
-
-    left_arm_base_xpos = np.eye(4)
-    left_arm_base_xpos[1, 3] = 0.3
-
-    right_arm_base_xpos = np.eye(4)
-    right_arm_base_xpos[1, 3] = -0.3
-
-    # Create robot configuration
-    cfg = RobotCfg(
-        uid="dual_sr5",
-        urdf_cfg=URDFCfg(
-            components=[
-                {
-                    "component_type": "left_arm",
-                    "urdf_path": arm_urdf_path,
-                    "transform": left_arm_base_xpos,
-                },
-                {
-                    "component_type": "right_arm",
-                    "urdf_path": arm_urdf_path,
-                    "transform": right_arm_base_xpos,
-                },
-                {
-                    "component_type": "left_hand",
-                    "urdf_path": hand_urdf_path,
-                    "transform": hand_transform,
-                },
-                {
-                    "component_type": "right_hand",
-                    "urdf_path": hand_urdf_path,
-                    "transform": hand_transform,
-                },
-            ],
-            component_prefix=[("left_arm", "L_"), ("right_arm", "R_"), ("left_hand", "left_"), ("right_hand", "right_")],
-            name_case={
-                "joint": "lower",
-                "link": "lower",
-            }
-        ),
-    )
-
-    # Add robot to simulation
-    robot: Robot = sim.add_robot(cfg=cfg)
-
-    return robot
-
-
-# Initialize simulation and create robot
-sim = SimulationManager(SimulationManagerCfg(headless=True, num_envs=4))
-robot = create_robot(sim)
-print(f"Robot created with {robot.dof} joints")
-```
-
-### Component Configuration
-
-Each component in the `components` list supports the following keys:
-
-| Key | Type | Description |
-|:-----|:-----|:------------|
-| `component_type` | str | Type of component (arm, hand, chassis, etc.) |
-| `urdf_path` | str | Path to the component's URDF file |
-| `transform` | np.ndarray | Optional 4x4 transformation matrix for positioning |
-
-### Control Parts
-
-Control parts define which joints belong to different subsystems of the robot. Joint names can be specified as:
-
-- **Exact match**: `"JOINT1"` matches only `JOINT1`
-- **Regex patterns**: `"JOINT[1-6]"` matches `JOINT1` through `JOINT6`
-- **Wildcards**: `"LEFT_.*"` matches all joints starting with `LEFT_`
-
-### Drive Properties
-
-Drive properties control the joint behavior:
-
-- `stiffness`: Position control gain (P gain) for each joint/group
-- `damping`: Velocity control gain (D gain) for each joint/group
-
-Both support regex pattern matching for convenient configuration.
-
-## File Structure
-
-```
-embodichain/toolkits/urdf_assembly/
-├── __init__.py                  # Package exports
-├── urdf_assembly_manager.py     # Main assembly manager
-├── component.py                  # Component classes and registry
-├── sensor.py                     # Sensor attachment and registry
-├── connection.py                 # Connection/joint management
-├── mesh.py                       # Mesh file handling
-├── file_writer.py                # URDF file output
-├── signature.py                  # Assembly signature checking
-├── logging_utils.py              # Logging configuration
-└── utils.py                      # Utility functions
-```
+For a runnable robot example, see
+`scripts/tutorials/sim/create_robot.py` in the repository.

--- a/embodichain/toolkits/graspkit/pg_grasp/collision_checker.py
+++ b/embodichain/toolkits/graspkit/pg_grasp/collision_checker.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
+from __future__ import annotations
+
 import trimesh
 import numpy as np
 import torch
@@ -185,17 +187,23 @@ class ConvexCollisionChecker:
         batch_points: torch.Tensor,
         collision_threshold: float = 0.0,
         is_visual: bool = False,
-    ) -> torch.Tensor:
-        """Query collision status for a batch of point clouds. The collision status is determined by checking if the signed distance from any point in the cloud to the convex hulls is less than or equal to the specified collision threshold.
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Query collision status for a batch of point clouds.
+
+        A point collides when its signed distance to any convex hull is less
+        than or equal to ``collision_threshold``.
+
         Args:
-            batch_points: [B, n_point, 3] batch of point clouds to query for collision status.
-            collision_threshold: Collision threshold in meters. A point is considered colliding if its signed distance to the hull interior is <= this threshold. This allows for a margin of error in collision checking, where a small positive threshold can be used to consider points near the surface as colliding, and a small negative threshold can be used to allow for slight penetration without considering it a collision.
-            is_visual: Whether to visualize the collision checking results for debugging purposes. If set to True, the code will generate visualizations of the query points colored by their collision status (e.g., red for colliding points and green for non-colliding points) along with the original mesh. This can help in understanding and verifying the collision checking process, especially during development and testing.
+            batch_points: Point clouds with shape ``(B, n_point, 3)``.
+            collision_threshold: Collision threshold in meters. Positive values
+                also classify points near the surface as colliding; negative
+                values allow slight penetration.
+            is_visual: Whether to visualize collision results for debugging.
+
         Returns:
-            is_point_collide: [B, n_point] boolean tensor indicating whether a point cloud is collided.
-            point_signed_distance: [B, n_point] of float. Signed distance from the point cloud to the object surface.
-                Negative means the point cloud is penetrating into the object,
-                positive means the point cloud is outside the object.
+            A tuple containing the ``(B, n_point)`` collision mask and signed
+            distances. Negative distances are inside the object; positive
+            distances are outside it.
         """
         n_batch = batch_points.shape[0]
         (


### PR DESCRIPTION
## Description

This PR improves the toolkit documentation by:

- adding an overview of the available toolkits and guidance for choosing between them;
- expanding the convex decomposition, URDF assembly, and parallel-gripper grasp generation guides;
- documenting URDF assembly submodule responsibilities and public workflows;
- normalizing page names, section titles, and heading levels;
- aligning the toolkit API reference with the implemented APIs; and
- enabling Sphinx TODO support for existing API docstrings.

The previous toolkit landing page contained only a table of contents, while the submodule pages used inconsistent structures and included stale examples and configuration values. These changes make the documentation easier to navigate and keep it aligned with the current implementation.

Dependencies: None.

Related issue: None.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (existing functionality will not work without user modification)
- [x] Documentation update

## Screenshots

Not applicable.

## Validation

- `black --check --diff --color --extend-exclude '/\.worktrees/' ./`
- `pytest -q tests/toolkits/test_batch_convex_collision.py` (`1 passed, 1 skipped`)
- targeted Sphinx dummy build for all toolkit feature and API pages (build succeeds; remaining warnings are pre-existing and outside the toolkit pages)

## Checklist

- [x] I have run the `black .` command to format the code base.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works. (No new behavior; the existing related test was run.)
- [x] Dependencies have been updated, if applicable. (No dependency changes.)
