### PR TITLE
Add async LeRobot recorder for parallel env saving

### DIFF
--- a/agent_context/MAP.yaml
+++ b/agent_context/MAP.yaml
@@ -54,6 +54,10 @@ topics:
       - action manager
       - dataset manager
       - functor cfg
+      - lerobot recorder
+      - async dataset recorder
+      - async save
+      - 数据保存
     keywords:
       - manager
       - functor
@@ -68,6 +72,13 @@ topics:
       - event
       - action
       - dataset
+      - LeRobotRecorder
+      - AsyncLeRobotRecorder
+      - recorder
+      - save
+      - async
+      - image_writer_threads
+      - finalize
     paths:
       - topics/manager-functor/manager-functor.md
     source_of_truth:
@@ -76,6 +87,9 @@ topics:
       - embodichain/lab/gym/envs/managers/observation_manager.py
       - embodichain/lab/gym/envs/managers/reward_manager.py
       - embodichain/lab/gym/envs/managers/event_manager.py
+      - embodichain/lab/gym/envs/managers/dataset_manager.py
+      - embodichain/lab/gym/envs/managers/datasets.py
+      - embodichain/lab/gym/envs/managers/async_datasets.py
     related_topics:
       - env-framework
       - randomization

--- a/agent_context/topics/manager-functor/manager-functor.md
+++ b/agent_context/topics/manager-functor/manager-functor.md
@@ -10,7 +10,7 @@
 | Reward manager + built-in functors | `managers/reward_manager.py`, `managers/rewards.py` |
 | Event manager + built-in functors | `managers/event_manager.py`, `managers/events.py` |
 | Action manager + built-in terms | `managers/action_manager.py`, `managers/actions.py` |
-| Dataset manager + built-in recorders | `managers/dataset_manager.py`, `managers/datasets.py` |
+| Dataset manager + built-in recorders | `managers/dataset_manager.py`, `managers/datasets.py`, `managers/async_datasets.py` |
 | Randomization functors (event sub-type) | `managers/randomization/` (spatial, visual, physics, geometry) |
 
 All paths relative to `embodichain/lab/gym/envs/`.
@@ -36,6 +36,37 @@ At init, the manager resolves every `FunctorCfg.func` (string → callable or cl
 | `EventManager` | `EventCfg` | `startup`, `reset`, `interval`, user-defined | `apply(mode, env_ids)` |
 | `ActionManager` | `ActionTermCfg` | `pre`, `post` | `process_actions(actions) → EnvAction` |
 | `DatasetManager` | `DatasetFunctorCfg` | `save` | `step(obs, action, done, info)` |
+
+---
+
+## Dataset Saving (LeRobot)
+
+`DatasetManager` runs in the `save` mode on `env.reset()` (`_initialize_episode`) and persists completed episodes via a recorder functor. Two recorders ship:
+
+| Recorder | File | Behavior |
+|----------|------|----------|
+| `LeRobotRecorder` | `managers/datasets.py` | Synchronous. `__call__` runs convert + `add_frame` + `save_episode` inline, blocking `env.reset()`. Default; base class for the async variant. |
+| `AsyncLeRobotRecorder` | `managers/async_datasets.py` | Subclass. `__call__` clones the rollout-buffer slice (obs+actions) to CPU, enqueues it, and returns immediately. A single daemon worker thread drains the queue and runs the same `_save_single_episode` path. `finalize()` drains then calls `dataset.finalize()`. |
+
+**Save flow**: `env.step` writes each frame into `rollout_buffer` (`_hook_after_sim_step`). On truncation the caller does `env.reset(options={"save_data": True})` -> `_initialize_episode` -> `DatasetManager.apply("save", env_ids)`. `DatasetFunctorCfg.save_failed_episodes=True` saves every env on every reset (not only successes). `env.close()` -> `dataset_manager.finalize()` flushes any remaining buffer.
+
+**Two independent speed levers** (both honor `image_writer_threads` / `image_writer_processes` in `params`, wired through to `LeRobotDataset.create()` -> lerobot `AsyncImageWriter`):
+- Opt A: `LeRobotRecorder` + `image_writer_threads=4` - per-frame PNG writes offloaded to a thread pool. ~2.5x faster, no background thread, bounded memory.
+- Opt B: `AsyncLeRobotRecorder` - whole-episode save offloaded to a worker; sim never blocks. Use for `num_envs > 1` collection.
+
+**When to use which**:
+- Single env / debug / memory-constrained -> `LeRobotRecorder` (sync).
+- Parallel collection (`num_envs > 1`) -> `AsyncLeRobotRecorder` + `image_writer_threads=4`.
+
+**Correctness invariants for the async recorder** (do not break these when editing):
+- The buffer slice is **cloned in the caller thread** before enqueue - the worker must not hold a view into `rollout_buffer` (it is cleared/reused on reset).
+- **Single worker** only - `LeRobotDataset` is not thread-safe and FIFO order must be preserved for `episode_index`.
+- `finalize()` must drain the queue before `dataset.finalize()`.
+- `__call__` accepts `**kwargs` because `DatasetManager.apply` passes `**functor_cfg.params` (includes construction-only params like `image_writer_threads`); `manager_base._resolve_common_functor_cfg` tolerates `**kwargs`.
+
+**Gotcha**: `env.close()` calls `sim.destroy()`, which exits the process without returning to Python. To finalize the dataset without killing the process, call `env.dataset_manager.finalize()` directly. Scripts running multiple envs must use one subprocess per env.
+
+Benchmark: `scripts/benchmark/data_pipeline/benchmark_lerobot_save.py` (uses the `StayStillSave-v1` env). At 4 envs x 2 eps x 100 steps / 480x640 / 800 frames: sync 57.4s -> Opt A 22.0s (2.6x) -> Opt B 56.6s total but sim unblocked -> Opt A+B 20.8s (2.8x) + sim unblocked. Sync sim-stall grows linearly with `num_envs`; async sim-stall stays near zero.
 
 ---
 

--- a/docs/source/overview/gym/dataset_functors.md
+++ b/docs/source/overview/gym/dataset_functors.md
@@ -33,6 +33,19 @@ This page covers structured dataset export. If you only need human-viewable debu
                           "data_type": "sim"},
                 "use_videos": true}}
     ```
+* - {class}`~async_datasets.AsyncLeRobotRecorder`
+  - Drop-in async variant of ``LeRobotRecorder`` for parallel data collection. Saves each completed episode on a background worker thread so ``env.reset()`` no longer blocks on disk writes. Same on-disk format and params; also honors ``image_writer_threads``.
+
+    ```json
+    {"func": "AsyncLeRobotRecorder", "mode": "save",
+     "params": {"robot_meta": {"robot_type": "CobotMagic", "control_freq": 25},
+                "instruction": {"lang": "Pour water from bottle to cup"},
+                "extra": {"scene_type": "Commercial",
+                          "task_description": "Pour water",
+                          "data_type": "sim"},
+                "use_videos": false,
+                "image_writer_threads": 4}}
+    ```
 ```
 
 ## LeRobotRecorder
@@ -68,9 +81,9 @@ The ``LeRobotRecorder`` functor enables recording robot learning episodes in the
 * - ``use_videos``
   - Whether to save videos (True) or images (False). Default: False.
 * - ``image_writer_threads``
-  - Number of threads for image writing
+  - Number of background threads for per-frame PNG writing (lerobot ``AsyncImageWriter``). When > 0, ``add_frame`` no longer blocks on ``PIL.Image.save``. Applies to both recorders. Try 4 threads per camera as a starting point.
 * - ``image_writer_processes``
-  - Number of processes for image writing
+  - Number of background processes for image writing (alternative to threads; higher spawn cost, more isolation). Use 0 to rely on threads only.
 ```
 
 ### Recorded Data
@@ -97,6 +110,46 @@ The LeRobotRecorder saves the following data for each frame:
 * - Quick qualitative inspection or demos
   - {class}`~record.record_camera_data`
   - Saves MP4 videos from a dedicated camera without creating a training dataset.
+```
+
+## Saving Strategies
+
+Saving is the part of data collection that most often bottlenecks the simulator. Each completed episode triggers a save on ``env.reset()``; with ``num_envs=N`` parallel envs truncating together, the recorder must persist N episodes worth of frames. Two independent levers control how expensive that is:
+
+1. **Per-frame image writing** — ``LeRobotRecorder`` writes each camera frame to PNG synchronously inside ``add_frame`` (``compress_level=6``). Set ``image_writer_threads`` (Opt A) to offload these writes to a thread pool.
+2. **Per-episode conversion + flush** — by default the whole convert + ``add_frame`` + ``save_episode`` loop runs inline on ``env.reset()``, blocking the sim. ``AsyncLeRobotRecorder`` (Opt B) clones the finished episode's buffer slice and runs that loop on a background worker, so ``env.reset()`` returns immediately.
+
+```{list-table} Choosing a recorder
+:header-rows: 1
+:widths: 30 70
+
+* - Situation
+  - Use
+* - Single env, or debugging / minimal memory
+  - {class}`~datasets.LeRobotRecorder` (sync). Simplest, deterministic, lowest RAM. Errors surface at the call site.
+* - Many parallel envs, sim must keep stepping
+  - {class}`~async_datasets.AsyncLeRobotRecorder` with ``image_writer_threads=4``. Saving is pipelined off the sim thread; recommended for parallel collection.
+* - Want most of the speedup without a background thread
+  - {class}`~datasets.LeRobotRecorder` with ``image_writer_threads=4``. ~2.5x faster than sync, no episode cloning, bounded memory.
+```
+
+````{tip}
+**Benchmark** (`scripts/benchmark/data_pipeline/benchmark_lerobot_save.py`, 4 envs x 2 episodes x 100 steps, 480x640, 800 frames/variant):
+
+| Variant | t_total | speedup | sim blocked? |
+|---------|---------|---------|--------------|
+| ``LeRobotRecorder`` (sync) | 57.4 s | 1.0x | yes (~55 s) |
+| + ``image_writer_threads=4`` | 22.0 s | 2.6x | yes (but faster) |
+| ``AsyncLeRobotRecorder`` | 56.6 s | ~1.0x | **no** (drain-bound at finalize) |
+| ``AsyncLeRobotRecorder`` + threads | 20.8 s | **2.8x** | **no** |
+
+The sync stall grows **linearly** with ``num_envs`` (each reset saves N envs serially). The async recorder's sim stall stays near zero regardless of ``num_envs`` — that is the main reason to prefer it for parallel collection.
+````
+
+```{attention}
+- ``AsyncLeRobotRecorder`` clones each finished episode (including camera frames) to CPU before enqueuing. For very high resolutions or many envs, monitor RSS — the worker normally keeps up, but a slow disk can let the queue grow.
+- A single background worker touches the ``LeRobotDataset`` (which is not thread-safe), so episode order is preserved FIFO. Always let ``env.close()`` / ``dataset_manager.finalize()`` run so the worker drains before the dataset is finalized.
+- ``env.close()`` calls ``sim.destroy()``, which exits the process without returning to Python. In scripts that build multiple envs, run each in its own subprocess and write results before closing.
 ```
 
 ## Usage Example
@@ -145,6 +198,30 @@ if episode_done:
 # After training completes
 dataset_manager.apply(mode="finalize")
 ```
+
+### Parallel Collection (async recorder)
+
+For ``num_envs > 1`` data collection, switch the functor to {class}`~async_datasets.AsyncLeRobotRecorder` and enable async image writing. Everything else (config structure, on-disk format, save/finalize calls) is identical:
+
+```python
+from embodichain.lab.gym.envs.managers.cfg import DatasetFunctorCfg
+
+dataset = {
+    "lerobot_recorder": DatasetFunctorCfg(
+        func="embodichain.lab.gym.envs.managers.async_datasets.AsyncLeRobotRecorder",
+        params={
+            "save_path": "/path/to/dataset/root",
+            "robot_meta": {"robot_type": "dexforce_w1", "control_freq": 30},
+            "instruction": {"lang": "pick the cube"},
+            "extra": {"scene_type": "table", "task_description": "pick_and_place"},
+            "use_videos": False,
+            "image_writer_threads": 4,   # Opt A: async per-frame PNG writes
+        },
+    ),
+}
+```
+
+The async recorder drains its background worker during ``finalize()``, so make sure ``env.close()`` (or ``dataset_manager.finalize()``) runs at the end of collection.
 
 ## Dataset Manager Modes
 

--- a/embodichain/lab/gym/envs/embodied_env.py
+++ b/embodichain/lab/gym/envs/embodied_env.py
@@ -671,7 +671,11 @@ class EmbodiedEnv(BaseEnv):
         if action_list is None:
             return None
 
-        expected_dim = int(np.prod(self.action_space.shape))
+        # Use the per-env action space, not the (batched) ``action_space`` whose
+        # shape is ``(num_envs, dim)``. Otherwise demo actions shaped
+        # ``(num_envs, dim)`` are rejected with "action dim < expected" for
+        # ``num_envs > 1`` (expected would be ``num_envs * dim``).
+        expected_dim = int(np.prod(self.single_action_space.shape))
 
         if isinstance(action_list, torch.Tensor):
             return self._normalize_demo_action_tensor(action_list, expected_dim)

--- a/embodichain/lab/gym/envs/managers/__init__.py
+++ b/embodichain/lab/gym/envs/managers/__init__.py
@@ -30,3 +30,23 @@ from .reward_manager import RewardManager
 from .action_manager import *
 from .actions import *
 from .dataset_manager import DatasetManager
+from .datasets import LeRobotRecorder
+from .async_datasets import AsyncLeRobotRecorder
+
+__all__ = [
+    "FunctorCfg",
+    "SceneEntityCfg",
+    "EventCfg",
+    "ObservationCfg",
+    "RewardCfg",
+    "ActionTermCfg",
+    "DatasetFunctorCfg",
+    "Functor",
+    "ManagerBase",
+    "EventManager",
+    "ObservationManager",
+    "RewardManager",
+    "DatasetManager",
+    "LeRobotRecorder",
+    "AsyncLeRobotRecorder",
+]

--- a/embodichain/lab/gym/envs/managers/async_datasets.py
+++ b/embodichain/lab/gym/envs/managers/async_datasets.py
@@ -1,0 +1,205 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+"""Asynchronous LeRobot recorder for parallel environments.
+
+This module provides :class:`AsyncLeRobotRecorder`, which decouples episode
+saving from the simulation loop. It is the recommended recorder when running
+many parallel environments that complete episodes together: instead of
+blocking ``env.reset()`` while episodes are converted and flushed to disk, the
+completed episode buffers are cloned and handed to a background worker thread,
+so the simulator can keep stepping.
+"""
+
+from __future__ import annotations
+
+import queue
+import threading
+from typing import TYPE_CHECKING, Dict, Optional, Union
+
+import torch
+
+from embodichain.utils import logger
+from .datasets import LeRobotRecorder
+
+if TYPE_CHECKING:
+    from embodichain.lab.gym.envs import EmbodiedEnv
+
+try:
+    from lerobot.datasets.lerobot_dataset import LeRobotDataset  # noqa: F401
+
+    LEROBOT_AVAILABLE = True
+    __all__ = ["AsyncLeRobotRecorder"]
+except ImportError:
+    LEROBOT_AVAILABLE = False
+    __all__ = []
+
+
+class AsyncLeRobotRecorder(LeRobotRecorder):
+    """LeRobot recorder that saves episodes on a background thread.
+
+    Drop-in replacement for :class:`LeRobotRecorder` selected via the dataset
+    config ``"func": "AsyncLeRobotRecorder"``. It shares the same on-disk
+    format and feature-building logic; only the *timing* of the save differs.
+
+    Why this helps parallel environments
+    -------------------------------------
+    In the synchronous recorder, :meth:`LeRobotRecorder.__call__` runs inside
+    ``env.reset()`` (via ``DatasetManager.apply``) and blocks the simulator
+    while it iterates ``add_frame`` + ``save_episode`` for every finished env.
+    With ``num_envs=N`` all finishing at once, the sim stalls for the *sum* of
+    all episodes' save time every reset.
+
+    This recorder instead, on each ``apply``:
+
+    1. Reads each env's rollout-buffer slice (``obs``/``actions``).
+    2. **Clones** the slice to CPU (detached from the live buffer).
+    3. Pushes ``(env_id, obs_clone, action_clone)`` onto a queue.
+    4. Returns immediately - the sim is free to reset and keep stepping.
+
+    A single daemon worker thread drains the queue and runs the standard
+    :meth:`LeRobotRecorder._save_single_episode` on each cloned payload.
+
+    Correctness
+    -----------
+    * **No concurrent dataset access.** ``LeRobotDataset`` is not thread-safe;
+      only the worker thread ever calls ``add_frame`` / ``save_episode`` /
+      mutates ``curr_episode``. The main thread only enqueues and, at close,
+      drains.
+    * **No buffer race.** The slice is cloned in the caller thread *before*
+      the buffer is cleared on reset, so the worker never reads memory that
+      the sim is overwriting.
+    * **Ordering.** A single worker preserves FIFO episode order, so
+      ``episode_index`` assignment is deterministic.
+    * **Drain on close.** :meth:`finalize` joins the worker before the parent
+      flushes the image writer and finalizes the dataset.
+
+    .. note::
+        The clone copies each episode's camera frames into host RAM. Memory
+        use is bounded by how far the worker falls behind (typically it keeps
+        up, since per-frame PNG write is the only heavy step and can itself be
+        offloaded via ``image_writer_threads``). For very high resolutions or
+        many envs, monitor RSS.
+
+    Args:
+        cfg: :class:`~embodichain.lab.gym.envs.managers.cfg.DatasetFunctorCfg`
+            with the same ``params`` as ``LeRobotRecorder``. The
+            ``image_writer_threads`` / ``image_writer_processes`` params are
+            honored and combine with the background worker (two levels of
+            async: episode conversion off the sim thread, PNG writes off the
+            worker thread).
+        env: The environment instance.
+    """
+
+    def __init__(self, cfg, env: EmbodiedEnv):
+        if not LEROBOT_AVAILABLE:
+            logger.log_error(
+                "LeRobot is not installed. Please install it with: pip install lerobot"
+            )
+        super().__init__(cfg, env)
+
+        # Single-worker queue. A single worker guarantees LeRobotDataset is
+        # only ever touched from one thread (it is not thread-safe) and keeps
+        # episode ordering deterministic.
+        self._save_queue: "queue.Queue[Optional[tuple]]" = queue.Queue()
+        self._worker: threading.Thread = threading.Thread(
+            target=self._worker_loop,
+            name="AsyncLeRobotRecorder-worker",
+            daemon=True,
+        )
+        self._worker.start()
+        logger.log_info(
+            "[AsyncLeRobotRecorder] Background save worker started; "
+            "episode saves will not block env.reset()."
+        )
+
+    def _worker_loop(self) -> None:
+        """Consume cloned episodes from the queue and persist them."""
+        while True:
+            item = self._save_queue.get()
+            if item is None:
+                # Sentinel: finalize() is draining. Exit the worker.
+                break
+            env_id, obs_clone, action_clone = item
+            try:
+                self._save_single_episode(env_id, obs_clone, action_clone)
+            except Exception as e:  # noqa: BLE001 - worker must not die
+                logger.log_error(
+                    f"[AsyncLeRobotRecorder] Background worker failed on "
+                    f"env {env_id}: {e}"
+                )
+
+    def __call__(
+        self,
+        env: EmbodiedEnv,
+        env_ids: Union[torch.Tensor, None],
+        save_path: Optional[str] = None,
+        robot_meta: Optional[Dict] = None,
+        instruction: Optional[str] = None,
+        extra: Optional[Dict] = None,
+        use_videos: bool = False,
+        **kwargs,
+    ) -> None:
+        """Enqueue completed episodes for background saving.
+
+        Reads each env's rollout-buffer slice, clones it to CPU (so the worker
+        is immune to buffer reuse on reset), and pushes it onto the queue. The
+        actual conversion and disk I/O happen asynchronously on the worker
+        thread. Returns immediately so ``env.reset()`` is not blocked.
+
+        Args:
+            env: The environment instance.
+            env_ids: Environment IDs to save. If None, enqueues all envs.
+            save_path: Unused at call time (honored at construction).
+            robot_meta: Unused at call time (honored at construction).
+            instruction: Unused at call time (honored at construction).
+            extra: Unused at call time (honored at construction).
+            use_videos: Unused at call time (honored at construction).
+            **kwargs: Construction-only params (e.g. ``image_writer_threads``)
+                passed through by ``DatasetManager.apply``; honored in
+                :meth:`__init__`, ignored here.
+        """
+        if env_ids is None:
+            env_ids = torch.arange(env.num_envs, device=env.device)
+        elif isinstance(env_ids, (list, range)):
+            env_ids = torch.tensor(list(env_ids), device=env.device)
+
+        if len(env_ids) == 0:
+            return
+
+        step = env.current_rollout_step
+        for env_id in env_ids.cpu().tolist():
+            obs_view = env.rollout_buffer["obs"][env_id, :step]
+            action_view = env.rollout_buffer["actions"][env_id, :step]
+            # Clone in the caller thread: the rollout buffer is cleared and
+            # reused by the next episode on reset, so the worker must not hold
+            # a view into it.
+            obs_clone = obs_view.clone().cpu()
+            action_clone = action_view.clone().cpu()
+            self._save_queue.put((env_id, obs_clone, action_clone))
+
+    def finalize(self) -> Optional[str]:
+        """Drain the background worker, then finalize the dataset.
+
+        Signals the worker to stop after finishing all queued episodes, waits
+        for it to exit, and delegates to the parent to flush any remaining
+        buffer, stop the async image writer, and finalize dataset metadata.
+        """
+        # Signal the worker to exit once the queue is drained.
+        self._save_queue.put(None)
+        self._worker.join()
+        # Parent flushes leftover episodes, stops image writer, finalizes.
+        return super().finalize()

--- a/embodichain/lab/gym/envs/managers/datasets.py
+++ b/embodichain/lab/gym/envs/managers/datasets.py
@@ -95,6 +95,15 @@ class LeRobotRecorder(Functor):
         # Experimental parameters for extra episode info saving.
         self.use_videos = params.get("use_videos", False)
 
+        # Async image writing (lerobot official AsyncImageWriter).
+        # When > 0, per-frame PNG writes are offloaded to a thread/process pool
+        # so add_frame() no longer blocks on PIL.Image.save(). This is the
+        # single biggest lever for saving throughput with camera sensors.
+        # Threads share the process (cheap, GIL-released by PIL C path);
+        # processes add isolation at a higher spawn cost.
+        self.image_writer_threads = int(params.get("image_writer_threads", 0))
+        self.image_writer_processes = int(params.get("image_writer_processes", 0))
+
         # LeRobot dataset instance
         self.dataset: Optional[LeRobotDataset] = None
         self.dataset_full_path: Optional[Path] = None
@@ -122,6 +131,7 @@ class LeRobotRecorder(Functor):
         instruction: Optional[str] = None,
         extra: Optional[Dict] = None,
         use_videos: bool = False,
+        **kwargs,
     ) -> None:
         """Main entry point for the recorder functor.
 
@@ -131,6 +141,15 @@ class LeRobotRecorder(Functor):
         Args:
             env: The environment instance.
             env_ids: Environment IDs to save. If None, attempts to save all environments.
+            save_path: Unused at call time (honored at construction).
+            robot_meta: Unused at call time (honored at construction).
+            instruction: Unused at call time (honored at construction).
+            extra: Unused at call time (honored at construction).
+            use_videos: Unused at call time (honored at construction).
+            **kwargs: Construction-only params (e.g. ``image_writer_threads``,
+                ``image_writer_processes``, ``save_path``) passed through by
+                ``DatasetManager.apply`` via ``**functor_cfg.params``. They are
+                read in :meth:`__init__` and ignored here.
         """
         # If env_ids is None, check all environments for completed episodes
         if env_ids is None:
@@ -146,55 +165,85 @@ class LeRobotRecorder(Functor):
         self,
         env_ids: torch.Tensor,
     ) -> None:
-        """Save completed episodes for specified environments."""
-        task = self.instruction.get("lang", "unknown_task")
+        """Save completed episodes for specified environments.
 
-        # Process each environment
+        This reads each env's slice from the rollout buffer and delegates to
+        :meth:`_save_single_episode`. The slice read happens in the caller
+        thread so that subclasses (e.g. :class:`AsyncLeRobotRecorder`) can
+        clone the slice and defer the actual conversion/disk-write to a
+        background worker without racing the buffer reuse on reset.
+        """
+        step = self._env.current_rollout_step
         for env_id in env_ids.cpu().tolist():
-            # Get buffer for this environment (already contains single-env data)
-            obs_list = self._env.rollout_buffer["obs"][
-                env_id, : self._env.current_rollout_step
-            ]
-            action_list = self._env.rollout_buffer["actions"][
-                env_id, : self._env.current_rollout_step
-            ]
+            obs_list = self._env.rollout_buffer["obs"][env_id, :step]
+            action_list = self._env.rollout_buffer["actions"][env_id, :step]
+            self._save_single_episode(env_id, obs_list, action_list)
 
-            if len(obs_list) == 0:
-                logger.log_warning(f"No episode data to save for env {env_id}")
-                continue
+    def _save_single_episode(
+        self,
+        env_id: int,
+        obs_list: Any,
+        action_list: Any,
+    ) -> bool:
+        """Convert and persist one episode already sliced from the buffer.
 
-            # Align obs and action
-            if len(obs_list) > len(action_list):
-                obs_list = obs_list[:-1]
+        This operates purely on the provided ``obs_list`` / ``action_list``
+        (which may be live buffer views or detached clones) and never touches
+        ``self._env.rollout_buffer`` or ``self._env.current_rollout_step``,
+        so it is safe to call from a background thread on cloned data.
 
-            # Update metadata
-            extra_info = self.extra.copy() if self.extra else {}
-            fps = self.dataset.meta.info.get("fps", 30)
-            current_episode_time = len(obs_list) / fps if fps > 0 else 0
+        Args:
+            env_id: Environment id (used for logging only).
+            obs_list: Per-frame observations for the episode.
+            action_list: Per-frame actions for the episode.
 
-            episode_extra_info = extra_info.copy()
-            self.total_time += current_episode_time
-            episode_extra_info["total_time"] = self.total_time
+        Returns:
+            True if the episode was saved successfully, False otherwise.
+        """
+        task = (
+            self.instruction.get("lang", "unknown_task")
+            if self.instruction
+            else "unknown_task"
+        )
 
-            try:
-                for obs, action in tqdm.tqdm(
-                    zip(obs_list, action_list),
-                    total=len(obs_list),
-                    desc=f"Converting env {env_id} episode to LeRobot format",
-                ):
-                    frame = self._convert_frame_to_lerobot(obs, action, task)
-                    self.dataset.add_frame(frame)
+        if len(obs_list) == 0:
+            logger.log_warning(f"No episode data to save for env {env_id}")
+            return False
 
-                self.dataset.save_episode()
+        # Align obs and action (obs may be one longer than action)
+        if len(obs_list) > len(action_list):
+            obs_list = obs_list[:-1]
 
-                logger.log_info(
-                    f"[LeRobotRecorder] Saved dataset to: {self.dataset_path}\n"
-                    f"  Episode {self.curr_episode} (env {env_id}): {len(obs_list)} frames"
-                )
+        # Update metadata
+        extra_info = self.extra.copy() if self.extra else {}
+        fps = self.dataset.meta.info.get("fps", 30)
+        current_episode_time = len(obs_list) / fps if fps > 0 else 0
 
-                self.curr_episode += 1
-            except Exception as e:
-                logger.log_error(f"Failed to save episode {env_id}: {e}")
+        episode_extra_info = extra_info.copy()
+        self.total_time += current_episode_time
+        episode_extra_info["total_time"] = self.total_time
+
+        try:
+            for obs, action in tqdm.tqdm(
+                zip(obs_list, action_list),
+                total=len(obs_list),
+                desc=f"Converting env {env_id} episode to LeRobot format",
+            ):
+                frame = self._convert_frame_to_lerobot(obs, action, task)
+                self.dataset.add_frame(frame)
+
+            self.dataset.save_episode()
+
+            logger.log_info(
+                f"[LeRobotRecorder] Saved dataset to: {self.dataset_path}\n"
+                f"  Episode {self.curr_episode} (env {env_id}): {len(obs_list)} frames"
+            )
+
+            self.curr_episode += 1
+            return True
+        except Exception as e:
+            logger.log_error(f"Failed to save episode {env_id}: {e}")
+            return False
 
     def finalize(self) -> Optional[str]:
         """Finalize the dataset."""
@@ -205,6 +254,10 @@ class LeRobotRecorder(Functor):
 
         try:
             if self.dataset is not None:
+                # Flush + stop the async image writer (if enabled) so every
+                # queued PNG write lands on disk before metadata is finalized.
+                if self.dataset.image_writer is not None:
+                    self.dataset.stop_image_writer()
                 self.dataset.finalize()
                 logger.log_info(
                     f"[LeRobotRecorder] Dataset finalized successfully\n"
@@ -263,6 +316,8 @@ class LeRobotRecorder(Functor):
             features=features,
             use_videos=self.use_videos,
             metadata_buffer_size=1,
+            image_writer_processes=self.image_writer_processes,
+            image_writer_threads=self.image_writer_threads,
         )
         logger.log_info(f"Created LeRobot dataset at: {self.dataset_full_path}")
 

--- a/embodichain/lab/gym/envs/managers/manager_base.py
+++ b/embodichain/lab/gym/envs/managers/manager_base.py
@@ -343,16 +343,35 @@ class ManagerBase(ABC):
         # check statically if the functor's arguments are matched by params
         functor_params = list(functor_cfg.params.keys())
         args = inspect.signature(func_static).parameters
+        # A functor that declares **kwargs explicitly opts into accepting
+        # arbitrary extra params (e.g. construction-only params such as
+        # ``image_writer_threads`` that are read in ``__init__`` but not used
+        # in ``__call__``). In that case the strict received-vs-expected check
+        # below does not apply, and VAR_KEYWORD/VAR_POSITIONAL are excluded
+        # from the positional arg count so they don't trip ``len(args)``.
+        has_var_keyword = any(
+            p.kind == inspect.Parameter.VAR_KEYWORD for p in args.values()
+        )
+        _var_kinds = (
+            inspect.Parameter.VAR_KEYWORD,
+            inspect.Parameter.VAR_POSITIONAL,
+        )
         args_with_defaults = [
-            arg for arg in args if args[arg].default is not inspect.Parameter.empty
+            arg
+            for arg in args
+            if args[arg].default is not inspect.Parameter.empty
+            and args[arg].kind not in _var_kinds
         ]
         args_without_defaults = [
-            arg for arg in args if args[arg].default is inspect.Parameter.empty
+            arg
+            for arg in args
+            if args[arg].default is inspect.Parameter.empty
+            and args[arg].kind not in _var_kinds
         ]
         args = args_without_defaults + args_with_defaults
         # ignore first two arguments for env and env_ids
         # Think: Check for cases when kwargs are set inside the function?
-        if len(args) > min_argc:
+        if len(args) > min_argc and not has_var_keyword:
             if set(args[min_argc:]) != set(functor_params + args_with_defaults):
                 raise ValueError(
                     f"The functor '{functor_name}' expects mandatory parameters: {args_without_defaults[min_argc:]}"

--- a/embodichain/lab/gym/utils/gym_utils.py
+++ b/embodichain/lab/gym/utils/gym_utils.py
@@ -786,8 +786,9 @@ def add_env_launcher_args_to_parser(parser: argparse.ArgumentParser) -> None:
     """
     parser.add_argument(
         "--num_envs",
-        help="The number of environments to run in parallel.",
-        default=1,
+        help="The number of environments to run in parallel. "
+        "If not given, falls back to the gym config's `num_envs` (default 1).",
+        default=None,
         type=int,
     )
     parser.add_argument(
@@ -873,7 +874,8 @@ def merge_args_with_gym_config(args: argparse.Namespace, gym_config: dict) -> di
         dict: The merged gym configuration dictionary.
     """
     merged_config = deepcopy(gym_config)
-    merged_config["num_envs"] = args.num_envs
+    if args.num_envs is not None:
+        merged_config["num_envs"] = args.num_envs
     merged_config["device"] = args.device
     merged_config["headless"] = args.headless
     merged_config["renderer"] = args.renderer

--- a/embodichain/lab/gym/utils/gym_utils.py
+++ b/embodichain/lab/gym/utils/gym_utils.py
@@ -37,6 +37,7 @@ from dexsim.utility import log_debug, log_error
 DEFAULT_MANAGER_MODULES = [
     "embodichain.lab.gym.envs.managers.actions",
     "embodichain.lab.gym.envs.managers.datasets",
+    "embodichain.lab.gym.envs.managers.async_datasets",
     "embodichain.lab.gym.envs.managers.randomization",
     "embodichain.lab.gym.envs.managers.record",
     "embodichain.lab.gym.envs.managers.events",

--- a/embodichain/lab/scripts/run_env.py
+++ b/embodichain/lab/scripts/run_env.py
@@ -116,19 +116,30 @@ def main(args, env, gym_config):
     log_info("Start offline data generation.", color="green")
     # TODO: Support multiple trajectories per episode generation.
     num_traj = 1
-    for i in range(gym_config.get("max_episodes", 1)):
-        generate_function(
-            env,
-            num_traj,
-            i,
-            save_path=getattr(args, "save_path", ""),
-            save_video=getattr(args, "save_video", False),
-            debug_mode=getattr(args, "debug_mode", False),
-            regenerate=getattr(args, "regenerate", False),
-        )
+    try:
+        for i in range(gym_config.get("max_episodes", 1)):
+            generate_function(
+                env,
+                num_traj,
+                i,
+                save_path=getattr(args, "save_path", ""),
+                save_video=getattr(args, "save_video", False),
+                debug_mode=getattr(args, "debug_mode", False),
+                regenerate=getattr(args, "regenerate", False),
+            )
 
-    # Final reset.
-    _, _ = env.reset()
+        # Final reset (saves the last completed episode).
+        _, _ = env.reset()
+    finally:
+        # Drain the dataset recorder and finalize the LeRobot dataset before
+        # the process exits. This is REQUIRED for AsyncLeRobotRecorder: its
+        # background worker only *enqueues* episodes during reset, so without
+        # close() the worker is killed at exit and no data reaches disk.
+        # env.close() -> dataset_manager.finalize() drains the worker + flushes
+        # meta/stats, then sim.destroy() tears down the sim. sim.destroy() exits
+        # the process without returning, so this MUST be the last thing main()
+        # does.
+        env.close()
 
 
 def preview(env: gymnasium.Env) -> None:

--- a/embodichain_tasks/configs/gym/special/stay_still_save_async_ur10.json
+++ b/embodichain_tasks/configs/gym/special/stay_still_save_async_ur10.json
@@ -1,0 +1,84 @@
+{
+    "id": "StayStillSave-v1",
+    "max_episodes": 4,
+    "num_envs": 4,
+    "env": {
+        "dataset": {
+            "lerobot": {
+                "func": "AsyncLeRobotRecorder",
+                "mode": "save",
+                "save_failed_episodes": true,
+                "params": {
+                    "save_path": "/tmp/embodichain_async_demo",
+                    "robot_meta": {
+                        "robot_type": "UR10",
+                        "control_freq": 25
+                    },
+                    "instruction": {
+                        "lang": "Hold still while recording"
+                    },
+                    "extra": {
+                        "scene_type": "benchmark",
+                        "task_description": "stay still",
+                        "data_type": "sim"
+                    },
+                    "use_videos": false,
+                    "image_writer_threads": 4,
+                    "image_writer_processes": 0
+                }
+            }
+        }
+    },
+    "robot": {
+        "uid": "UR10",
+        "fpath": "UniversalRobots/UR10/UR10.urdf",
+        "init_pos": [0.0, 0.0, 0.7775],
+        "init_qpos": [1.57079, -1.57079, 1.57079, -1.57079, -1.57079, -3.14159]
+    },
+    "sensor": [
+        {
+            "sensor_type": "Camera",
+            "uid": "cam_high",
+            "width": 640,
+            "height": 480,
+            "intrinsics": [488.1665344238281, 488.1665344238281, 320.0, 240.0],
+            "extrinsics": {
+                "eye": [1, 0, 3],
+                "target": [0, 0, 1]
+            }
+        }
+    ],
+    "light": {
+        "direct": [
+            {
+                "uid": "light_1",
+                "light_type": "point",
+                "color": [1.0, 1.0, 1.0],
+                "intensity": 50.0,
+                "init_pos": [2, 0, 2],
+                "radius": 10.0
+            }
+        ]
+    },
+    "background": [
+        {
+            "uid": "table",
+            "shape": {
+                "shape_type": "Mesh",
+                "fpath": "CircleTableSimple/circle_table_simple.ply",
+                "compute_uv": true
+            },
+            "attrs": {
+                "mass": 10.0,
+                "static_friction": 0.95,
+                "dynamic_friction": 0.9,
+                "restitution": 0.01
+            },
+            "body_scale": [1, 1, 1],
+            "body_type": "kinematic",
+            "init_pos": [0.8, 0.0, 0.825],
+            "init_rot": [0, 90, 0]
+        }
+    ],
+    "rigid_object": []
+}

--- a/embodichain_tasks/configs/gym/special/stay_still_save_async_ur10.json
+++ b/embodichain_tasks/configs/gym/special/stay_still_save_async_ur10.json
@@ -9,7 +9,6 @@
                 "mode": "save",
                 "save_failed_episodes": true,
                 "params": {
-                    "save_path": "/tmp/embodichain_async_demo",
                     "robot_meta": {
                         "robot_type": "UR10",
                         "control_freq": 25
@@ -22,7 +21,7 @@
                         "task_description": "stay still",
                         "data_type": "sim"
                     },
-                    "use_videos": false,
+                    "use_videos": true,
                     "image_writer_threads": 4,
                     "image_writer_processes": 0
                 }

--- a/embodichain_tasks/configs/gym/special/stay_still_save_ur10.json
+++ b/embodichain_tasks/configs/gym/special/stay_still_save_ur10.json
@@ -1,0 +1,79 @@
+{
+    "id": "StayStillSave-v1",
+    "max_episodes": 1,
+    "env": {
+        "dataset": {
+            "lerobot": {
+                "func": "LeRobotRecorder",
+                "mode": "save",
+                "params": {
+                    "robot_meta": {
+                        "robot_type": "UR10",
+                        "control_freq": 25
+                    },
+                    "instruction": {
+                        "lang": "Hold still while recording"
+                    },
+                    "extra": {
+                        "scene_type": "benchmark",
+                        "task_description": "stay still",
+                        "data_type": "sim"
+                    },
+                    "use_videos": false
+                }
+            }
+        }
+    },
+    "robot": {
+        "uid": "UR10",
+        "fpath": "UniversalRobots/UR10/UR10.urdf",
+        "init_pos": [0.0, 0.0, 0.7775],
+        "init_qpos": [1.57079, -1.57079, 1.57079, -1.57079, -1.57079, -3.14159]
+    },
+    "sensor": [
+        {
+            "sensor_type": "Camera",
+            "uid": "cam_high",
+            "width": 640,
+            "height": 480,
+            "intrinsics": [488.1665344238281, 488.1665344238281, 320.0, 240.0],
+            "extrinsics": {
+                "eye": [1, 0, 3],
+                "target": [0, 0, 1]
+            }
+        }
+    ],
+    "light": {
+        "direct": [
+            {
+                "uid": "light_1",
+                "light_type": "point",
+                "color": [1.0, 1.0, 1.0],
+                "intensity": 50.0,
+                "init_pos": [2, 0, 2],
+                "radius": 10.0
+            }
+        ]
+    },
+    "background": [
+        {
+            "uid": "table",
+            "shape": {
+                "shape_type": "Mesh",
+                "fpath": "CircleTableSimple/circle_table_simple.ply",
+                "compute_uv": true
+            },
+            "attrs": {
+                "mass": 10.0,
+                "static_friction": 0.95,
+                "dynamic_friction": 0.9,
+                "restitution": 0.01
+            },
+            "body_scale": [1, 1, 1],
+            "body_type": "kinematic",
+            "init_pos": [0.8, 0.0, 0.825],
+            "init_rot": [0, 90, 0]
+        }
+    ],
+    "rigid_object": []
+}

--- a/embodichain_tasks/embodichain_tasks/special/stay_still_save.py
+++ b/embodichain_tasks/embodichain_tasks/special/stay_still_save.py
@@ -1,0 +1,77 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+"""Stay-still task environment for benchmarking LeRobot data saving.
+
+This environment is intentionally cheap on the physics side - the robot holds
+its initial configuration for the whole episode - so that the wall-clock cost
+of a rollout is dominated by data saving rather than simulation. It is the
+test fixture used by ``scripts/benchmark/data_pipeline/benchmark_lerobot_save.py``.
+
+A camera sensor (``cam_high``) is attached so each frame carries a real RGB
+image, which is what makes per-frame ``add_frame`` / PNG writing expensive and
+exercises the async-saving optimizations.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from embodichain.lab.gym.envs import EmbodiedEnv, EmbodiedEnvCfg
+from embodichain.lab.gym.utils.registration import register_env
+from embodichain.utils import logger
+
+__all__ = ["StayStillSaveEnv"]
+
+
+@register_env("StayStillSave-v1", max_episode_steps=100)
+class StayStillSaveEnv(EmbodiedEnv):
+    """Robot holds still for 100 steps while a camera records.
+
+    The demo action list is the initial joint configuration repeated for
+    ``num_steps`` frames, so the robot does not move. Episode length is fixed
+    at 100 steps via the ``register_env`` ``max_episode_steps`` argument and
+    truncates automatically.
+
+    The camera sensor, robot, scene and LeRobot dataset are configured through
+    the gym config JSON (see
+    ``embodichain_tasks/configs/gym/special/stay_still_save_ur10.json``).
+    """
+
+    def __init__(self, cfg: EmbodiedEnvCfg = None, **kwargs):
+        if cfg is None:
+            cfg = EmbodiedEnvCfg()
+        super().__init__(cfg, **kwargs)
+
+    def create_demo_action_list(self, *args, **kwargs):
+        """Return 100 hold-still actions (initial qpos repeated).
+
+        Returns:
+            list[torch.Tensor]: One action per step, each shaped
+            ``(num_envs, num_active_joints)``.
+        """
+        num_steps = 100
+
+        # Initial pose, repeated for every step. The robot stays still.
+        init_pose = self.robot.get_qpos()  # (num_envs, num_joints)
+
+        action_list = [init_pose.clone() for _ in range(num_steps)]
+
+        logger.log_info(
+            f"Generated {len(action_list)} hold-still demo actions "
+            f"(robot stationary)."
+        )
+        return action_list

--- a/scripts/benchmark/data_pipeline/benchmark_lerobot_save.py
+++ b/scripts/benchmark/data_pipeline/benchmark_lerobot_save.py
@@ -1,0 +1,521 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+"""Benchmark LeRobot data saving under parallel environments.
+
+Compares four saving strategies on the same real ``StayStillSave-v1`` rollout
+(N parallel envs x K episodes x 100 steps, each frame carrying an RGB image
+from ``cam_high``):
+
+- ``baseline_sync``      : ``LeRobotRecorder`` (current default; synchronous).
+- ``opt_a_async_image``  : ``LeRobotRecorder`` + lerobot ``AsyncImageWriter``
+                           (per-frame PNG writes offloaded to a thread pool).
+- ``opt_b_async_episode``: ``AsyncLeRobotRecorder`` (whole-episode convert+save
+                           offloaded to a background worker; sim never blocks).
+- ``opt_ab_async_both``  : ``AsyncLeRobotRecorder`` + ``AsyncImageWriter``
+                           (two levels of async).
+
+Metrics (per variant):
+- ``t_run``      : step loop. Sync baseline includes the save stall on every
+                   reset; async variants do not.
+- ``t_finalize`` : ``dataset_manager.finalize()`` time - drains the async worker
+                   and flushes the dataset. This is the saving close cost.
+- ``t_total``    : ``t_run + t_finalize`` (total time to generate AND persist).
+
+.. note::
+   ``env.close()`` calls ``sim.destroy()`` (a dexsim C++ teardown that exits the
+   process without returning to Python), so each variant runs in its own
+   subprocess. Results are written to a JSON file before the subprocess exits.
+
+Run: python -m scripts.benchmark.data_pipeline.benchmark_lerobot_save
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import psutil
+
+# Variant -> (recorder func, image_writer_threads).
+VARIANTS: dict[str, dict[str, Any]] = {
+    "baseline_sync": {"func": "LeRobotRecorder", "image_writer_threads": 0},
+    "opt_a_async_image": {"func": "LeRobotRecorder", "image_writer_threads": 4},
+    "opt_b_async_episode": {"func": "AsyncLeRobotRecorder", "image_writer_threads": 0},
+    "opt_ab_async_both": {"func": "AsyncLeRobotRecorder", "image_writer_threads": 4},
+}
+
+DEFAULT_GYM_CONFIG = "embodichain_tasks/configs/gym/special/stay_still_save_ur10.json"
+
+
+# --------------------------------------------------------------------------- #
+# Child process: run one variant (or sim baseline) and write a JSON result.    #
+# --------------------------------------------------------------------------- #
+def _make_modifier(
+    variant: str,
+    num_envs: int,
+    save_root: Path,
+    camera_hw: tuple[int, int],
+    skip_save: bool = False,
+):
+    """Build a gym_config_modifier that selects a variant and output path."""
+
+    def modifier(cfg_dict: dict) -> None:
+        cfg_dict["num_envs"] = num_envs
+        for sensor in cfg_dict.get("sensor", []):
+            sensor["width"], sensor["height"] = camera_hw
+        ds = cfg_dict["env"]["dataset"]["lerobot"]
+        if skip_save:
+            # Keep the dataset block but mark saving filtered -> no DatasetManager,
+            # no rollout buffer, pure sim.
+            return
+        v = VARIANTS[variant]
+        ds["func"] = v["func"]
+        # Save every completed episode on reset (not only successes) so that
+        # saves happen *during* the step loop. This is what makes the sync
+        # baseline block the sim on every reset and lets the async recorder
+        # pipeline saves into sim time.
+        ds["save_failed_episodes"] = True
+        ds["params"]["image_writer_threads"] = v["image_writer_threads"]
+        ds["params"]["save_path"] = str(save_root / variant)
+
+    return modifier
+
+
+def _read_dataset_meta(save_root: Path, variant: str) -> tuple[int, int]:
+    """Return (total_episodes, total_frames) saved for a variant."""
+    ds_dirs = sorted(glob.glob(str(save_root / variant / "*")))
+    if not ds_dirs:
+        return 0, 0
+    info_path = Path(ds_dirs[0]) / "meta" / "info.json"
+    if not info_path.exists():
+        return 0, 0
+    info = json.loads(info_path.read_text())
+    return int(info.get("total_episodes", 0)), int(info.get("total_frames", 0))
+
+
+def _run_child(args: argparse.Namespace) -> int:
+    """Run a single variant or the sim baseline; write JSON; exit."""
+    import gymnasium  # imported lazily so the parent doesn't need dexsim
+    import torch
+
+    from embodichain.lab.gym.utils.gym_utils import (
+        add_env_launcher_args_to_parser,
+        build_env_cfg_from_args,
+    )
+    from embodichain.lab.gym.utils.registration import (
+        discover_task_packages,
+        execute_init_hooks,
+    )
+
+    discover_task_packages()
+    execute_init_hooks()
+
+    save_root = Path(args.save_root)
+    camera_hw = (args.width, args.height)
+    skip_save = args.variant == "sim_only"
+
+    if not skip_save:
+        shutil.rmtree(save_root / args.variant, ignore_errors=True)
+
+    parser = argparse.ArgumentParser()
+    add_env_launcher_args_to_parser(parser)
+    launcher_args = parser.parse_args(["--gym_config", args.gym_config, "--headless"])
+    env_cfg, gcfg, action_config = build_env_cfg_from_args(
+        launcher_args,
+        gym_config_modifier=_make_modifier(
+            args.variant, args.num_envs, save_root, camera_hw, skip_save
+        ),
+    )
+    if skip_save:
+        env_cfg.filter_dataset_saving = True
+
+    proc = psutil.Process()
+    mem_before = proc.memory_info().rss / 1024**2
+    if torch.cuda.is_available():
+        torch.cuda.reset_peak_memory_stats()
+
+    env = gymnasium.make(id=gcfg["id"], cfg=env_cfg, **action_config)
+    # Initial reset: nothing to save yet, so skip the save path.
+    env.reset(options={"save_data": False})
+    qpos = env.get_wrapper_attr("robot").get_qpos().clone()
+
+    # --- Timed: K episodes x `steps` steps, with an explicit save-reset ---
+    # --- at each episode boundary.                                  ---
+    # EmbodiChain's BaseEnv does not auto-reset on truncation, so we drive
+    # episode boundaries ourselves. The reset(save_data=True) call is where
+    # the sync baseline blocks on saving and where the async recorder only
+    # enqueues.
+    t0 = time.perf_counter()
+    for _ in range(args.episodes):
+        for _ in range(args.steps):
+            env.step(qpos)
+        env.reset(options={"save_data": True})
+    t_run = time.perf_counter() - t0
+
+    # --- Timed: finalize = drain async worker + flush dataset. ---
+    # NOTE: we call dataset_manager.finalize() directly instead of env.close(),
+    # because env.close() -> sim.destroy() exits the process without returning.
+    dataset_manager = getattr(env.unwrapped, "dataset_manager", None)
+    t_f0 = time.perf_counter()
+    if dataset_manager is not None:
+        dataset_manager.finalize()
+    t_finalize = time.perf_counter() - t_f0
+
+    mem_after = proc.memory_info().rss / 1024**2
+    peak_gpu = (
+        torch.cuda.max_memory_allocated() / 1024**2
+        if torch.cuda.is_available()
+        else 0.0
+    )
+    saved_episodes, saved_frames = (
+        _read_dataset_meta(save_root, args.variant) if not skip_save else (0, 0)
+    )
+
+    result = {
+        "variant": args.variant,
+        "func": VARIANTS[args.variant]["func"] if args.variant in VARIANTS else "-",
+        "image_writer_threads": (
+            VARIANTS[args.variant]["image_writer_threads"]
+            if args.variant in VARIANTS
+            else 0
+        ),
+        "num_envs": args.num_envs,
+        "episodes": args.episodes,
+        "steps": args.steps,
+        "camera": list(camera_hw),
+        "t_run_s": round(t_run, 4),
+        "t_finalize_s": round(t_finalize, 4),
+        "t_total_s": round(t_run + t_finalize, 4),
+        "cpu_delta_mb": round(mem_after - mem_before, 1),
+        "peak_gpu_mb": round(peak_gpu, 1),
+        "saved_episodes": saved_episodes,
+        "saved_frames": saved_frames,
+    }
+
+    Path(args.result_file).write_text(json.dumps(result))
+    # Results are persisted. Force-exit to skip lerobot/dexsim interpreter
+    # teardown, which can hang (image-writer threads / dataset stats) at higher
+    # resolutions and would otherwise block the parent on subprocess.run.
+    os._exit(0)
+
+
+# --------------------------------------------------------------------------- #
+# Parent process: spawn children, aggregate into a markdown report.            #
+# --------------------------------------------------------------------------- #
+def _spawn_child(
+    args: argparse.Namespace, variant: str, result_file: Path
+) -> dict | None:
+    """Run one variant in a subprocess and return its result dict."""
+    cmd = [
+        sys.executable,
+        "-u",
+        "-m",
+        "scripts.benchmark.data_pipeline.benchmark_lerobot_save",
+        "--child",
+        "--variant",
+        variant,
+        "--result_file",
+        str(result_file),
+        "--gym_config",
+        args.gym_config,
+        "--num_envs",
+        str(args.num_envs),
+        "--episodes",
+        str(args.episodes),
+        "--steps",
+        str(args.steps),
+        "--width",
+        str(args.width),
+        "--height",
+        str(args.height),
+        "--save_root",
+        args.save_root,
+    ]
+    print(f"  spawning subprocess for '{variant}'...", flush=True)
+    try:
+        completed = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=args.child_timeout
+        )
+    except subprocess.TimeoutExpired:
+        print(
+            f"  [WARN] '{variant}' subprocess timed out after "
+            f"{args.child_timeout}s (result JSON may still be present)",
+            flush=True,
+        )
+        completed = None
+    if completed is not None and completed.returncode != 0:
+        print(
+            f"  [WARN] '{variant}' subprocess exited with code "
+            f"{completed.returncode}",
+            flush=True,
+        )
+        tail = "\n".join(completed.stderr.strip().splitlines()[-15:])
+        if tail:
+            print(f"  stderr tail:\n{tail}", flush=True)
+    if not result_file.exists():
+        print(f"  [ERROR] no result file for '{variant}'", flush=True)
+        return None
+    return json.loads(result_file.read_text())
+
+
+def write_markdown_report(
+    num_envs: int,
+    episodes: int,
+    steps: int,
+    camera_hw: tuple[int, int],
+    t_sim: float,
+    results: list[dict[str, Any]],
+    report_path: Path,
+) -> Path:
+    """Write the 3-table benchmark report."""
+    baseline_total = next(
+        (r["t_total_s"] for r in results if r["variant"] == "baseline_sync"),
+        None,
+    )
+    expected_episodes = num_envs * episodes
+    expected_frames = expected_episodes * steps
+
+    perf_rows: list[dict[str, object]] = []
+    metric_rows: list[dict[str, object]] = []
+    leaderboard: list[dict[str, object]] = []
+
+    for r in results:
+        save_overhead = max(0.0, r["t_run_s"] - t_sim)
+        speedup = (
+            round(baseline_total / r["t_total_s"], 2)
+            if baseline_total and r["t_total_s"] > 0
+            else "-"
+        )
+        frames_per_s = (
+            round(r["saved_frames"] / r["t_total_s"], 1) if r["t_total_s"] > 0 else 0.0
+        )
+        integrity = (
+            "ok"
+            if (
+                r["saved_episodes"] == expected_episodes
+                and r["saved_frames"] == expected_frames
+            )
+            else "MISMATCH"
+        )
+        perf_rows.append(
+            {
+                "variant": r["variant"],
+                "func": r["func"],
+                "img_threads": r["image_writer_threads"],
+                "t_run_s": r["t_run_s"],
+                "t_finalize_s": r["t_finalize_s"],
+                "t_total_s": r["t_total_s"],
+                "save_overhead_s": round(save_overhead, 4),
+                "cpu_delta_mb": r["cpu_delta_mb"],
+                "peak_gpu_mb": r["peak_gpu_mb"],
+            }
+        )
+        metric_rows.append(
+            {
+                "variant": r["variant"],
+                "saved_episodes": r["saved_episodes"],
+                "expected_episodes": expected_episodes,
+                "saved_frames": r["saved_frames"],
+                "expected_frames": expected_frames,
+                "integrity": integrity,
+                "frames_per_s": frames_per_s,
+                "speedup_vs_baseline": speedup,
+            }
+        )
+
+    ranked = sorted(results, key=lambda r: r["t_total_s"])
+    for rank, r in enumerate(ranked, start=1):
+        speedup = (
+            round(baseline_total / r["t_total_s"], 2)
+            if baseline_total and r["t_total_s"] > 0
+            else "-"
+        )
+        leaderboard.append(
+            {
+                "rank": rank,
+                "variant": r["variant"],
+                "t_total_s": r["t_total_s"],
+                "speedup_vs_baseline": speedup,
+                "frames_per_s": (
+                    round(r["saved_frames"] / r["t_total_s"], 1)
+                    if r["t_total_s"] > 0
+                    else 0.0
+                ),
+            }
+        )
+
+    def _table(rows: list[dict[str, object]]) -> list[str]:
+        if not rows:
+            return ["No rows."]
+        headers = list(rows[0].keys())
+        out = [
+            "| " + " | ".join(headers) + " |",
+            "| " + " | ".join(["---"] * len(headers)) + " |",
+        ]
+        for row in rows:
+            out.append("| " + " | ".join(str(row[h]) for h in headers) + " |")
+        return out
+
+    lines: list[str] = [
+        "# LeRobot Save Benchmark Report",
+        "",
+        f"Generated at: {datetime.now().isoformat(timespec='seconds')}",
+        "",
+        "- Env: StayStillSave-v1 (robot holds still; `cam_high` camera).",
+        f"- Parallel envs (num_envs): {num_envs}",
+        f"- Episodes per env: {episodes}  x  {steps} steps/episode",
+        f"- Camera: {camera_hw[0]}x{camera_hw[1]} RGB (PNG, use_videos=False)",
+        f"- Expected saved per variant: {expected_episodes} episodes / {expected_frames} frames",
+        f"- Pure-sim baseline (no save), {episodes}x{steps} steps: {t_sim:.4f} s",
+        "",
+        "`t_run` = step loop (sync baseline includes the save stall on every reset).",
+        "`t_finalize` = dataset_manager.finalize() (async recorder drains worker here).",
+        "`save_overhead` = t_run - t_sim (time the sim was blocked by saving).",
+        "`t_total` = t_run + t_finalize (total time to generate AND persist).",
+        "",
+        "## Time & Memory",
+        "",
+    ]
+    lines += _table(perf_rows)
+    lines += ["", "## Success & Other Metrics", ""]
+    lines += _table(metric_rows)
+    lines += ["", "## Leaderboard (ranked by t_total, fastest first)", ""]
+    lines += _table(leaderboard)
+    lines += [
+        "",
+        "## Notes",
+        "- `baseline_sync`: current EmbodiChain default; saving blocks env.reset().",
+        "- `opt_a_async_image`: lerobot official `AsyncImageWriter` (per-frame PNG",
+        "  writes offloaded to 4 threads). EmbodiChain now wires this through.",
+        "- `opt_b_async_episode`: `AsyncLeRobotRecorder` clones each completed",
+        "  episode and persists it on a background worker; env.reset() returns at once.",
+        "- `opt_ab_async_both`: both optimizations stacked.",
+        "- All variants write the same on-disk LeRobot format; integrity is verified",
+        "  by checking episode/frame counts against the expected totals.",
+        "- Each variant runs in its own subprocess because env.close()",
+        "  (sim.destroy()) exits the process without returning to Python.",
+    ]
+
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return report_path
+
+
+def run_all_benchmarks(args: argparse.Namespace) -> None:
+    """Spawn a subprocess per variant (+ sim baseline) and aggregate."""
+    save_root = Path(args.save_root)
+    save_root.mkdir(parents=True, exist_ok=True)
+    work_dir = Path(args.work_dir)
+    work_dir.mkdir(parents=True, exist_ok=True)
+    camera_hw = (args.width, args.height)
+
+    print("=" * 70, flush=True)
+    print("LeRobot Save Benchmark (parallel environments)", flush=True)
+    print("=" * 70, flush=True)
+    print(
+        f"num_envs={args.num_envs} episodes={args.episodes} steps={args.steps} "
+        f"camera={camera_hw[0]}x{camera_hw[1]}",
+        flush=True,
+    )
+
+    print("\n--- Pure-sim baseline (no saving) ---", flush=True)
+    sim_result_file = work_dir / "sim_only.json"
+    sim = _spawn_child(args, "sim_only", sim_result_file)
+    t_sim = sim["t_run_s"] if sim else float("nan")
+    print(f"  t_sim = {t_sim:.4f} s", flush=True)
+
+    results: list[dict[str, Any]] = []
+    for variant in VARIANTS:
+        print(f"\n--- Variant: {variant} ---", flush=True)
+        r = _spawn_child(args, variant, work_dir / f"{variant}.json")
+        if r is not None:
+            results.append(r)
+            print(
+                f"  t_run={r['t_run_s']:.4f}s  t_finalize={r['t_finalize_s']:.4f}s  "
+                f"t_total={r['t_total_s']:.4f}s  cpu_delta={r['cpu_delta_mb']:+.1f}MB",
+                flush=True,
+            )
+            print(
+                f"  saved: {r['saved_episodes']} episodes / {r['saved_frames']} frames",
+                flush=True,
+            )
+
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    report_path = Path(args.report_dir) / f"lerobot_save_{ts}.md"
+    write_markdown_report(
+        args.num_envs,
+        args.episodes,
+        args.steps,
+        camera_hw,
+        t_sim,
+        results,
+        report_path,
+    )
+    print("\n" + "=" * 70, flush=True)
+    print(f"Markdown report saved: {report_path}", flush=True)
+    print("=" * 70, flush=True)
+
+
+def cli() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--gym_config",
+        default=DEFAULT_GYM_CONFIG,
+        help="Path to the stay-still gym config JSON.",
+    )
+    parser.add_argument("--num_envs", type=int, default=4)
+    parser.add_argument("--episodes", type=int, default=2)
+    parser.add_argument("--steps", type=int, default=100)
+    parser.add_argument("--width", type=int, default=480)
+    parser.add_argument("--height", type=int, default=640)
+    parser.add_argument(
+        "--save_root", default="/tmp/lerobot_save_bench", help="Dataset output root."
+    )
+    parser.add_argument(
+        "--report_dir", default="outputs/benchmarks", help="Markdown report dir."
+    )
+    parser.add_argument(
+        "--work_dir", default="/tmp/lerobot_save_bench_work", help="JSON result dir."
+    )
+    parser.add_argument(
+        "--child_timeout",
+        type=int,
+        default=900,
+        help="Per-variant subprocess timeout in seconds (safety net).",
+    )
+    # Child-mode flags (used when the parent re-invokes this script):
+    parser.add_argument("--child", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--variant", default="", help=argparse.SUPPRESS)
+    parser.add_argument("--result_file", default="", help=argparse.SUPPRESS)
+    args = parser.parse_args()
+
+    if args.child:
+        sys.exit(_run_child(args))
+    run_all_benchmarks(args)
+
+
+if __name__ == "__main__":
+    cli()

--- a/tests/gym/envs/managers/test_async_dataset_functors.py
+++ b/tests/gym/envs/managers/test_async_dataset_functors.py
@@ -1,0 +1,213 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+"""Tests for the asynchronous LeRobot recorder."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+import pytest
+import torch
+from tensordict import TensorDict
+
+# Skip all tests if LeRobot is not available.
+try:
+    from embodichain.lab.gym.envs.managers.async_datasets import (
+        AsyncLeRobotRecorder,
+        LEROBOT_AVAILABLE,
+    )
+
+    from embodichain.data.enum import LeRobotKey
+
+except ImportError:
+    LEROBOT_AVAILABLE = False
+    AsyncLeRobotRecorder = None  # type: ignore[assignment]
+    LeRobotKey = None  # type: ignore[assignment]
+
+
+class _MockRobot:
+    def __init__(self, num_joints: int = 6):
+        self.num_joints = num_joints
+        self.joint_names = [f"joint_{i}" for i in range(num_joints)]
+
+
+class _MockDataset:
+    """Minimal LeRobotDataset stand-in that records save calls."""
+
+    def __init__(self):
+        self.image_writer = None
+        self.meta = Mock()
+        self.meta.info = {"fps": 30}
+        self.add_frame_calls: list[dict] = []
+        self.save_episode_calls: int = 0
+        self.finalize_calls: int = 0
+
+    def add_frame(self, frame):
+        self.add_frame_calls.append(frame)
+
+    def save_episode(self, *args, **kwargs):
+        self.save_episode_calls += 1
+
+    def stop_image_writer(self):
+        pass
+
+    def finalize(self):
+        self.finalize_calls += 1
+
+
+class _MockEnv:
+    """Mock env with a rollout buffer for async recorder tests."""
+
+    def __init__(self, num_envs: int = 2, num_joints: int = 6, steps: int = 5):
+        self.num_envs = num_envs
+        self.device = torch.device("cpu")
+        self.active_joint_ids = list(range(num_joints))
+        self.robot = _MockRobot(num_joints)
+        self.has_sensors = False
+        # single_observation_space: only robot (+ empty sensor) so _build_features
+        # does not try to resolve camera sensors.
+        self.single_observation_space = {
+            "robot": {"qpos": Mock(), "qvel": Mock(), "qf": Mock()},
+            "sensor": {},
+        }
+        self.observation_manager = Mock()
+        self.observation_manager.active_functors = {"add": []}
+
+        # Rollout buffer shaped [num_envs, steps] of per-frame obs/actions,
+        # matching the real init_rollout_buffer_from_gym_space layout so that
+        # rollout_buffer["obs"][env_id, :step] yields a [step] TensorDict.
+        obs = TensorDict(
+            {
+                "robot": {
+                    "qpos": torch.zeros(num_envs, steps, num_joints),
+                    "qvel": torch.zeros(num_envs, steps, num_joints),
+                    "qf": torch.zeros(num_envs, steps, num_joints),
+                },
+                "sensor": {},
+            },
+            batch_size=[num_envs, steps],
+        )
+        actions = torch.zeros(num_envs, steps, num_joints)
+        self.rollout_buffer = TensorDict(
+            {"obs": obs, "actions": actions}, batch_size=[num_envs, steps]
+        )
+        self.current_rollout_step = steps
+
+
+def _make_recorder(env: _MockEnv, mock_dataset: _MockDataset) -> AsyncLeRobotRecorder:
+    """Build an AsyncLeRobotRecorder with the LeRobotDataset.create patched out."""
+    from embodichain.lab.gym.envs.managers.cfg import DatasetFunctorCfg
+
+    cfg = DatasetFunctorCfg(
+        func=AsyncLeRobotRecorder,
+        params={
+            "save_path": "/tmp/test_async_recorder",
+            "robot_meta": {"robot_type": "test", "control_freq": 30},
+            "instruction": {"lang": "test"},
+            "extra": {"scene_type": "s", "task_description": "t"},
+            "use_videos": False,
+            "image_writer_threads": 0,
+        },
+    )
+    with patch("embodichain.lab.gym.envs.managers.datasets.LeRobotDataset") as mock_cls:
+        mock_cls.create.return_value = mock_dataset
+        return AsyncLeRobotRecorder(cfg, env)
+
+
+@pytest.mark.skipif(not LEROBOT_AVAILABLE, reason="LeRobot not installed")
+class TestAsyncLeRobotRecorder:
+    """Tests for AsyncLeRobotRecorder enqueue/drain behavior."""
+
+    def test_call_accepts_construction_only_kwargs(self):
+        """``__call__`` must accept image_writer_threads/processes (regression).
+
+        DatasetManager.apply passes ``**functor_cfg.params`` to ``__call__``;
+        construction-only params must not raise TypeError.
+        """
+        env = _MockEnv(num_envs=1, steps=1)
+        mock_ds = _MockDataset()
+        recorder = _make_recorder(env, mock_ds)
+        try:
+            # Should not raise even though these params are unused at call time.
+            recorder(
+                env,
+                env_ids=torch.tensor([0]),
+                save_path="/tmp/x",
+                robot_meta={},
+                instruction=None,
+                extra={},
+                use_videos=False,
+                image_writer_threads=4,
+                image_writer_processes=0,
+            )
+        finally:
+            recorder.finalize()
+
+    def test_call_enqueues_without_blocking(self):
+        """``__call__`` returns without saving; the worker saves later."""
+        env = _MockEnv(num_envs=2, steps=4)
+        mock_ds = _MockDataset()
+        recorder = _make_recorder(env, mock_ds)
+
+        recorder(env, env_ids=torch.tensor([0, 1]))
+        # In the real flow env.reset() clears current_rollout_step after the
+        # save; mirror that so super().finalize() does not re-save the buffer.
+        env.current_rollout_step = 0
+
+        recorder.finalize()
+
+        # 2 envs x 4 steps = 8 frames, 2 episodes.
+        assert mock_ds.save_episode_calls == 2
+        assert len(mock_ds.add_frame_calls) == 8
+
+    def test_worker_operates_on_clone_not_live_buffer(self):
+        """Mutating the rollout buffer after __call__ must not corrupt the save.
+
+        This is the core correctness guarantee: the slice is cloned in the
+        caller thread so the worker is immune to buffer reuse on reset.
+        """
+        env = _MockEnv(num_envs=1, steps=3)
+        mock_ds = _MockDataset()
+        recorder = _make_recorder(env, mock_ds)
+
+        recorder(env, env_ids=torch.tensor([0]))
+        env.current_rollout_step = 0  # mirror post-save reset
+
+        # Corrupt the live buffer after enqueue (simulates reset reuse).
+        env.rollout_buffer["obs"][0, :3] = 999.0
+        env.rollout_buffer["actions"][0, :3] = 999.0
+
+        recorder.finalize()
+
+        # Saved frames should be the originals (zeros), not 999.
+        for frame in mock_ds.add_frame_calls:
+            assert (frame[LeRobotKey.OBS_STATE.value] == 0).all()
+            assert (frame[LeRobotKey.ACTION.value] == 0).all()
+
+    def test_finalize_drains_and_finalizes_dataset(self):
+        """finalize() must drain the worker then call dataset.finalize()."""
+        env = _MockEnv(num_envs=1, steps=2)
+        mock_ds = _MockDataset()
+        recorder = _make_recorder(env, mock_ds)
+
+        recorder(env, env_ids=torch.tensor([0]))
+        env.current_rollout_step = 0  # mirror post-save reset
+
+        recorder.finalize()
+
+        assert mock_ds.save_episode_calls == 1
+        assert mock_ds.finalize_calls == 1

--- a/tests/gym/envs/tasks/test_stay_still_save.py
+++ b/tests/gym/envs/tasks/test_stay_still_save.py
@@ -1,0 +1,73 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+"""Tests for the StayStillSave benchmark task environment."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from embodichain.lab.gym.utils.registration import (
+    REGISTERED_ENVS,
+    discover_task_packages,
+)
+
+# Trigger task auto-registration (idempotent).
+discover_task_packages()
+
+from embodichain_tasks.embodichain_tasks.special.stay_still_save import (  # noqa: E402
+    StayStillSaveEnv,
+)
+
+
+class TestStayStillSaveEnv:
+    """Registration and structure tests for StayStillSaveEnv."""
+
+    def test_module_all(self):
+        """``__all__`` exports the env class."""
+        from embodichain_tasks.embodichain_tasks.special import stay_still_save
+
+        assert "StayStillSaveEnv" in stay_still_save.__all__
+
+    def test_registered_with_gym_id(self):
+        """The env is registered under the StayStillSave-v1 gym id."""
+        assert "StayStillSave-v1" in REGISTERED_ENVS
+        spec = REGISTERED_ENVS["StayStillSave-v1"]
+        assert spec.cls.__name__ == "StayStillSaveEnv"
+        assert spec.max_episode_steps == 100
+
+    def test_uses_future_annotations(self):
+        """Module source starts with ``from __future__ import annotations``."""
+        from embodichain_tasks.embodichain_tasks.special import stay_still_save
+
+        src = Path(stay_still_save.__file__).read_text()
+        assert "from __future__ import annotations" in src
+
+    def test_is_embodied_env_subclass(self):
+        """StayStillSaveEnv subclasses EmbodiedEnv."""
+        from embodichain.lab.gym.envs import EmbodiedEnv
+
+        assert issubclass(StayStillSaveEnv, EmbodiedEnv)
+
+    @pytest.mark.parametrize("gym_id", ["StayStillSave-v1"])
+    def test_gym_spec_exists(self, gym_id):
+        """The gym spec is registered with gymnasium."""
+        import gymnasium
+
+        # gymnasium.registry raises if not found.
+        gymnasium.spec(gym_id)


### PR DESCRIPTION
# Description

This PR adds two independent, opt-in levers to accelerate LeRobot data saving under parallel environments. Saving was fully synchronous and ran inside `env.reset()`; with `num_envs=N` the sync stall grew linearly (each reset serially persisted N episodes).

- **Opt A — `LeRobotRecorder` + async image writing**: `image_writer_threads` / `image_writer_processes` are now read from `cfg.params` and passed to `LeRobotDataset.create()` to enable lerobot's official `AsyncImageWriter` (previously documented but never wired). `finalize()` calls `stop_image_writer()`. `_save_episodes` is refactored into a reusable `_save_single_episode(env_id, obs_list, action_list)`.
- **Opt B — `AsyncLeRobotRecorder` (new)**: `__call__` clones the completed episode's rollout-buffer slice to CPU, enqueues it, and returns immediately — `env.reset()` no longer blocks. A single daemon worker thread drains the queue and runs the same `_save_single_episode` path. `finalize()` drains the worker then finalizes the dataset. Clone-in-caller + single worker keep `LeRobotDataset` access thread-safe and preserve FIFO episode order. Selectable via `"func": "AsyncLeRobotRecorder"`.

Supporting: `manager_base._resolve_common_functor_cfg` now tolerates `**kwargs` in functor `__call__` (since `DatasetManager.apply` passes construction-only params through `**functor_cfg.params`).

All changes are backward-compatible; existing `LeRobotRecorder` configs are unchanged.

### Benchmark
`scripts/benchmark/data_pipeline/benchmark_lerobot_save.py` on the new `StayStillSave-v1` env (4 envs × 2 eps × 100 steps, 480×640, 800 frames/variant):

| Variant | t_total | speedup | sim blocked? |
|---------|---------|---------|--------------|
| `LeRobotRecorder` (sync) | 57.4 s | 1.0× | yes (~55 s) |
| + `image_writer_threads=4` | 22.0 s | 2.6× | yes (faster) |
| `AsyncLeRobotRecorder` | 56.6 s | ~1.0× | **no** (drain-bound) |
| `AsyncLeRobotRecorder` + threads | 20.8 s | **2.8×** | **no** |

The sync sim-stall grows **linearly** with `num_envs`; the async recorder's sim-stall stays near zero regardless of `num_envs` — the main reason to prefer it for parallel collection.

Dependencies: none new (uses lerobot's existing `AsyncImageWriter`, available in the pinned lerobot 0.4.4).

Fixes # (no issue — self-contained feature)

## Type of change

- New feature (non-breaking change which adds functionality)
- Enhancement (non-breaking change which improves an existing functionality)

## Checklist

- [x] I have run the `black .` command to format the code base.
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Dependencies have been updated, if applicable.
