### PR TITLE
Unify EmbodiChain CLI commands

### DIFF
--- a/docs/source/features/generative_sim/simready_pipeline.md
+++ b/docs/source/features/generative_sim/simready_pipeline.md
@@ -7,7 +7,7 @@ The SimReady asset pipeline converts raw mesh archives into normalized simulatio
 Run the pipeline on a single asset directory:
 
 ```bash
-python -m embodichain.gen_sim.simready_pipeline.cli.start \
+embodichain simready \
     --input_dir /path/to/raw_mesh_folder \
     --output_root /path/to/output_folder \
     --category YourCategory
@@ -16,7 +16,7 @@ python -m embodichain.gen_sim.simready_pipeline.cli.start \
 Preview the generated SimReady mesh:
 
 ```bash
-python -m embodichain preview-asset \
+embodichain preview-asset \
     --asset_path /path/to/sim_ready_asset_or_usd_asset \
     --asset_type rigid
 ```

--- a/docs/source/features/interaction/preview_asset.md
+++ b/docs/source/features/interaction/preview_asset.md
@@ -7,7 +7,7 @@ The `preview_asset` script loads a USD or mesh asset into the simulation for vis
 Preview a rigid object from a USD file:
 
 ```bash
-python -m embodichain.lab.scripts.preview_asset \
+embodichain preview-asset \
     --asset_path /path/to/sugar_box.usda \
     --asset_type rigid
 ```
@@ -15,7 +15,7 @@ python -m embodichain.lab.scripts.preview_asset \
 Preview an articulation:
 
 ```bash
-python -m embodichain.lab.scripts.preview_asset \
+embodichain preview-asset \
     --asset_path /path/to/robot.usd \
     --asset_type articulation
 ```
@@ -26,15 +26,14 @@ The asset type is determined as follows:
 
 1. **Explicit**: use `--asset_type rigid` or `--asset_type articulation`.
 2. **URDF files**: automatically treated as articulations.
-3. **USD files**: the USD stage is inspected for `UsdPhysicsArticulationRoot` prims. If found, the file is loaded as an articulation; otherwise as a rigid object.
-4. **Other mesh formats** (`.obj`, `.stl`, `.glb`, etc.): always loaded as rigid objects.
+3. **Other files**: loaded as rigid objects when `--asset_type` is omitted.
 
 ## Interactive Preview Mode
 
 Pass `--preview` to enter an interactive REPL after the asset is loaded:
 
 ```bash
-python -m embodichain.lab.scripts.preview_asset \
+embodichain preview-asset \
     --asset_path /path/to/robot.usd \
     --asset_type articulation \
     --preview
@@ -66,13 +65,13 @@ asset.set_root_pose(pos=[0, 0, 1.0], rot=[0, 0, 0])
 | Argument             | Description                                                        | Default              |
 |----------------------|--------------------------------------------------------------------|----------------------|
 | `--asset_path`       | Path to the asset file (`.usd`/`.usda`/`.usdc`/`.obj`/`.stl`/`.glb`/`.urdf`) | **required**         |
-| `--asset_type`       | Type of asset: `rigid` or `articulation`                           | Auto-detected (fallback: `rigid`) |
+| `--asset_type`       | Type of non-URDF asset: `rigid` or `articulation`                  | `rigid` |
 | `--uid`              | Unique identifier in the scene                                     | Derived from filename |
 | `--init_pos`         | Initial position as `x y z`                                        | `0 0 0.5`            |
 | `--init_rot`         | Initial rotation in degrees as `rx ry rz`                          | `0 0 0`              |
 | `--body_type`        | Body type for rigid objects: `dynamic`, `kinematic`, `static`      | `kinematic`          |
 | `--use_usd_properties` | Use physical properties from the USD file instead of defaults    | `False`              |
-| `--fix_base`         | Fix the base of articulations                                      | `True`               |
+| `--fix_base` / `--no-fix_base` | Fix or unfix the base of articulations                  | `True`               |
 | `--sim_device`       | Simulation device                                                  | `cpu`                |
 | `--headless`         | Run without rendering window                                       | `False`              |
 | `--renderer`         | Renderer backend: `hybrid`, `fast-rt` or `rt`            | `hybrid`             |
@@ -83,7 +82,7 @@ asset.set_root_pose(pos=[0, 0, 1.0], rot=[0, 0, 0])
 **Headless smoke test** (no render window):
 
 ```bash
-python -m embodichain.lab.scripts.preview_asset \
+embodichain preview-asset \
     --asset_path /path/to/asset.usda \
     --headless
 ```
@@ -91,7 +90,7 @@ python -m embodichain.lab.scripts.preview_asset \
 **Custom position and rotation**:
 
 ```bash
-python -m embodichain.lab.scripts.preview_asset \
+embodichain preview-asset \
     --asset_path /path/to/robot.usd \
     --asset_type articulation \
     --init_pos 0.5 0 0.0 \
@@ -102,7 +101,7 @@ python -m embodichain.lab.scripts.preview_asset \
 **Dynamic rigid body** (falls under gravity):
 
 ```bash
-python -m embodichain.lab.scripts.preview_asset \
+embodichain preview-asset \
     --asset_path /path/to/box.obj \
     --body_type dynamic \
     --preview

--- a/docs/source/features/toolkits/convex_decomposition.md
+++ b/docs/source/features/toolkits/convex_decomposition.md
@@ -57,10 +57,10 @@ generate_urdf_collision_convexes(
 
 ## Command-Line Interface
 
-Run the module directly for one-off or batch asset preparation:
+Use the unified CLI for one-off or batch asset preparation:
 
 ```bash
-python -m embodichain.toolkits.acd.urdf_modifider [OPTIONS]
+embodichain decompose-urdf [OPTIONS]
 ```
 
 ### Options
@@ -80,13 +80,13 @@ for the function and `8` for the CLI.
 
 ```bash
 # Generate convex collision meshes.
-python -m embodichain.toolkits.acd.urdf_modifider \
+embodichain decompose-urdf \
     --urdf_path ./assets/my_robot.urdf \
     --output_urdf_name my_robot_convex.urdf \
     --max_convex_hull_num 16
 
 # Scale the model and recompute inertia.
-python -m embodichain.toolkits.acd.urdf_modifider \
+embodichain decompose-urdf \
     --urdf_path ./assets/my_robot.urdf \
     --output_urdf_name my_robot_scaled.urdf \
     --recompute_inertia \

--- a/docs/source/features/toolkits/grasp_generator.rst
+++ b/docs/source/features/toolkits/grasp_generator.rst
@@ -236,7 +236,7 @@ EmbodiChain provides a dedicated CLI for interactively annotating grasp regions 
 
 Basic usage::
 
-   python -m embodichain annotate-grasp --mesh_path /path/to/object.ply
+   embodichain annotate-grasp --mesh_path /path/to/object.ply
 
 This will:
 
@@ -247,7 +247,7 @@ This will:
 
 Common options::
 
-   python -m embodichain annotate-grasp \
+   embodichain annotate-grasp \
        --mesh_path /path/to/object.ply \
        --viser_port 15531 \
        --n_sample 20000 \

--- a/docs/source/guides/cli.md
+++ b/docs/source/guides/cli.md
@@ -1,8 +1,9 @@
 # CLI Reference
 
-EmbodiChain provides a unified CLI, available both as the ``embodichain``
-console command and via ``python -m embodichain <subcommand>``. The two are
-equivalent; this guide uses the ``python -m embodichain`` form.
+EmbodiChain provides a unified CLI through the ``embodichain`` console
+command. ``python -m embodichain <command>`` is an equivalent fallback.
+Run ``embodichain --help`` to list commands or
+``embodichain <command> --help`` for complete command arguments.
 
 ---
 
@@ -12,19 +13,19 @@ List and download simulation assets (robots, objects, scenes, etc.).
 
 ```bash
 # List all available assets
-python -m embodichain.data list
+embodichain data list
 
 # List assets in a category
-python -m embodichain.data list --category robot
+embodichain data list --category robot
 
 # Download a specific asset
-python -m embodichain.data download --name CobotMagicArm
+embodichain data download --name CobotMagicArm
 
 # Download all assets in a category
-python -m embodichain.data download --category robot
+embodichain data download --category robot
 
 # Download everything
-python -m embodichain.data download --all
+embodichain data download --all
 ```
 
 ---
@@ -35,7 +36,7 @@ Convert a raw mesh asset directory into sim_ready assets for simulation.
 
 ```bash
 # Run the full SimReady pipeline on a single asset directory
-python -m embodichain.gen_sim.simready_pipeline.cli.start \
+embodichain simready \
     --input_dir /path/to/raw_mesh_folder \
     --output_root /path/to/output_folder \
     --category YourCategory
@@ -64,19 +65,19 @@ Preview a USD or mesh asset in the simulation without writing code.
 
 ```bash
 # Preview a rigid object
-python -m embodichain preview-asset \
+embodichain preview-asset \
     --asset_path /path/to/sugar_box.usda \
     --asset_type rigid \
     --preview
 
 # Preview an articulation
-python -m embodichain preview-asset \
+embodichain preview-asset \
     --asset_path /path/to/robot.usd \
     --asset_type articulation \
     --preview
 
 # Headless check (no render window)
-python -m embodichain preview-asset \
+embodichain preview-asset \
     --asset_path /path/to/asset.usda \
     --headless
 ```
@@ -85,7 +86,7 @@ python -m embodichain preview-asset \
 
 | Argument | Default | Description |
 |---|---|---|
-| ``--asset_path`` | *(required)* | Path to the asset file (``.usd``/``.usda``/``.usdc``/``.obj``/``.stl``/``.glb``) |
+| ``--asset_path`` | *(required)* | One or more asset paths (``.usd``/``.usda``/``.usdc``/``.obj``/``.stl``/``.glb``/``.urdf``) |
 | ``--asset_type`` | ``rigid`` | Asset type: ``rigid`` or ``articulation``. URDF files are auto-detected as articulation. |
 | ``--uid`` | *(from filename)* | Unique identifier for the asset in the scene |
 | ``--init_pos X Y Z`` | ``0 0 0.5`` | Initial position |
@@ -95,7 +96,7 @@ python -m embodichain preview-asset \
 | ``--fix_base`` | ``True`` | Fix the base of articulations |
 | ``--sim_device`` | ``cpu`` | Simulation device |
 | ``--headless`` | ``False`` | Run without rendering window |
-| ``--renderer`` | ``hybrid`` | Renderer backend: ``legacy``, ``hybrid``, ``fast-rt``, or ``rt`` |
+| ``--renderer`` | ``hybrid`` | Renderer backend: ``hybrid``, ``fast-rt``, or ``rt`` |
 | ``--preview`` | ``False`` | Enter interactive embed mode after loading |
 
 ### Preview Mode
@@ -121,20 +122,20 @@ is selected by the ``"id"`` field of the gym config.
 
 ```bash
 # Run an environment with a gym config file
-python -m embodichain run-env --gym_config path/to/config.yaml
+embodichain run-env --gym_config path/to/config.yaml
 
 # Run with multiple environments on GPU
-python -m embodichain run-env \
+embodichain run-env \
     --gym_config config.yaml \
     --num_envs 4 \
     --device cuda \
     --gpu_id 0
 
 # Preview mode for interactive development
-python -m embodichain run-env --gym_config config.yaml --preview
+embodichain run-env --gym_config config.yaml --preview
 
 # Headless execution
-python -m embodichain run-env --gym_config config.yaml --headless
+embodichain run-env --gym_config config.yaml --headless
 ```
 
 ### Arguments
@@ -146,7 +147,7 @@ python -m embodichain run-env --gym_config config.yaml --headless
 | ``--num_envs`` | ``1`` | Number of parallel environments |
 | ``--device`` | ``cpu`` | Device (``cpu`` or ``cuda``) |
 | ``--headless`` | ``False`` | Run in headless mode |
-| ``--renderer`` | ``hybrid`` | Renderer backend: ``legacy``, ``hybrid``, ``fast-rt`` or ``rt`` |
+| ``--renderer`` | ``auto`` | Renderer backend: ``auto``, ``hybrid``, ``fast-rt`` or ``rt`` |
 | ``--arena_space`` | ``5.0`` | Arena space size |
 | ``--gpu_id`` | ``0`` | GPU ID to use |
 | ``--preview`` | ``False`` | Enter interactive preview mode |
@@ -169,10 +170,10 @@ Launch reinforcement learning training from a JSON or YAML config file.
 
 ```bash
 # Train with a config file (JSON or YAML)
-python -m embodichain train-rl --config embodichain_tasks/configs/agents/rl/basic/cart_pole/train_config.yaml
+embodichain train-rl --config embodichain_tasks/configs/agents/rl/basic/cart_pole/train_config.yaml
 
 # JSON configs remain supported
-python -m embodichain train-rl --config embodichain_tasks/configs/agents/rl/push_cube/train_config.json
+embodichain train-rl --config embodichain_tasks/configs/agents/rl/push_cube/train_config.json
 
 # Multi-GPU distributed training
 torchrun --nproc_per_node=2 -m embodichain train-rl \
@@ -180,7 +181,7 @@ torchrun --nproc_per_node=2 -m embodichain train-rl \
     --distributed
 ```
 
-The direct module entry point remains available:
+The module entry point remains available for compatibility:
 
 ```bash
 python -m embodichain.learning.rl.train --config embodichain_tasks/configs/agents/rl/basic/cart_pole/train_config.yaml
@@ -194,3 +195,70 @@ python -m embodichain.learning.rl.train --config embodichain_tasks/configs/agent
 | ``--distributed`` | ``None`` | Enable multi-GPU distributed training. If omitted, uses ``trainer.distributed`` from the config. Use ``--no-distributed`` to force single-process training. |
 
 Outputs are written to ``./outputs/<exp_name>_<timestamp>/`` (TensorBoard logs and checkpoints). See the :doc:`../tutorial/rl` tutorial for config structure and training workflow.
+
+---
+
+## Annotate Grasp
+
+Launch the browser-based grasp-region annotation tool.
+
+```bash
+embodichain annotate-grasp --mesh_path /path/to/object.ply
+```
+
+Run ``embodichain annotate-grasp --help`` for sampling, gripper-length, port,
+and device options.
+
+---
+
+## URDF Convex Decomposition
+
+Generate convex collision meshes and an updated URDF.
+
+```bash
+embodichain decompose-urdf \
+    --urdf_path ./assets/robot.urdf \
+    --output_urdf_name robot_convex.urdf
+```
+
+Run ``embodichain decompose-urdf --help`` for hull-count, inertia, and scaling
+options.
+
+---
+
+## Benchmarks
+
+Run the packaged benchmark suites through the same CLI:
+
+```bash
+# RL train/evaluate/report workflow
+embodichain benchmark rl --tasks push_cube --algorithms ppo
+
+# Kinematic solver and neural planner benchmarks
+embodichain benchmark robotics-kinematic-solver --solvers all
+embodichain benchmark planners-neural-planner --num-waypoints 1 3 5
+
+# Atomic actions, grasp generation, and workspace analysis
+embodichain benchmark atomic-action --smoke
+embodichain benchmark grasp-pose-generator --device auto
+embodichain benchmark workspace-analyzer
+```
+
+Use ``embodichain benchmark --help`` to list benchmark suites and
+``embodichain benchmark <suite> --help`` for suite-specific arguments.
+
+---
+
+## Workspace Cache
+
+Inspect disk usage and manage workspace analyzer cache sessions:
+
+```bash
+embodichain workspace-cache list
+embodichain workspace-cache info <session>
+embodichain workspace-cache size
+embodichain workspace-cache clean <session>
+```
+
+Use ``embodichain workspace-cache clean --all`` to remove every workspace
+analyzer cache session; the command asks for confirmation before deletion.

--- a/docs/source/overview/rl/index.rst
+++ b/docs/source/overview/rl/index.rst
@@ -62,7 +62,7 @@ Example
 
 .. code-block:: bash
 
-    python -m embodichain train-rl --config embodichain_tasks/configs/agents/rl/basic/cart_pole/train_config.yaml
+    embodichain train-rl --config embodichain_tasks/configs/agents/rl/basic/cart_pole/train_config.yaml
 
 For more details, please refer to the source code and API documentation of each submodule.
 

--- a/docs/source/overview/rl/train_script.md
+++ b/docs/source/overview/rl/train_script.md
@@ -34,7 +34,7 @@ This module provides the RL training entry script, responsible for parsing confi
 
 ## Usage Example
 ```bash
-python -m embodichain train-rl --config embodichain_tasks/configs/agents/rl/basic/cart_pole/train_config.yaml
+embodichain train-rl --config embodichain_tasks/configs/agents/rl/basic/cart_pole/train_config.yaml
 ```
 
 ## Extension and Customization

--- a/docs/source/resources/assets.md
+++ b/docs/source/resources/assets.md
@@ -19,16 +19,16 @@ export EMBODICHAIN_DATASET_ROOT=/mnt/shared/embodichain_datasets
 
 ## Download CLI
 
-The `embodichain.data` module provides a command-line interface for managing assets.
+The unified `embodichain data` command manages downloadable assets.
 
 ### List Available Assets
 
 ```bash
 # List all assets across every category
-python -m embodichain.data list
+embodichain data list
 
 # List assets in a specific category
-python -m embodichain.data list --category robot
+embodichain data list --category robot
 ```
 
 The output shows each asset name and whether it has already been downloaded (`✓`):
@@ -48,13 +48,13 @@ Data root: /home/user/.cache/embodichain_data
 
 ```bash
 # Download a single asset by name
-python -m embodichain.data download --name CobotMagicArm
+embodichain data download --name CobotMagicArm
 
 # Download all assets in a category
-python -m embodichain.data download --category robot
+embodichain data download --category robot
 
 # Download everything
-python -m embodichain.data download --all
+embodichain data download --all
 ```
 
 Downloaded files are saved to `<data_root>/download/` and automatically extracted to `<data_root>/extract/`. Non-zip assets (e.g. `.glb` files) are copied into the extract directory.

--- a/docs/source/tutorial/data_generation.rst
+++ b/docs/source/tutorial/data_generation.rst
@@ -142,7 +142,7 @@ The recommended CLI entrypoint is:
 
 .. code-block:: bash
 
-   python -m embodichain run-env \
+   embodichain run-env \
        --gym_config embodichain_tasks/configs/gym/pour_water/gym_config.json \
        --action_config embodichain_tasks/configs/gym/pour_water/action_config.json \
        --headless

--- a/docs/source/tutorial/rl.rst
+++ b/docs/source/tutorial/rl.rst
@@ -226,13 +226,13 @@ To start training, run:
 
 .. code-block:: bash
 
-   python -m embodichain train-rl --config embodichain_tasks/configs/agents/rl/basic/cart_pole/train_config.yaml
+   embodichain train-rl --config embodichain_tasks/configs/agents/rl/basic/cart_pole/train_config.yaml
 
 JSON configs are also supported:
 
 .. code-block:: bash
 
-   python -m embodichain train-rl --config embodichain_tasks/configs/agents/rl/push_cube/train_config.json
+   embodichain train-rl --config embodichain_tasks/configs/agents/rl/push_cube/train_config.json
 
 Outputs
 -------

--- a/embodichain/__main__.py
+++ b/embodichain/__main__.py
@@ -14,100 +14,156 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
-"""Unified CLI entry point for ``python -m embodichain``.
+"""Unified command-line interface for EmbodiChain.
 
-Usage examples::
-
-    python -m embodichain preview-asset --asset_path /path/to/asset.usda --preview
-    python -m embodichain run-env --env_name my_env
-    python -m embodichain train-rl --config embodichain_tasks/configs/agents/rl/push_cube/train_config.json
-    python -m embodichain annotate-grasp --mesh_path /path/to/object.ply
+The ``embodichain`` console script and ``python -m embodichain`` both dispatch
+through this module.
 """
 
 from __future__ import annotations
 
 import argparse
+import importlib
 import sys
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+
+from embodichain import __version__
 
 
-def main() -> None:
-    """Dispatch to the appropriate sub-command CLI."""
+@dataclass(frozen=True)
+class Command:
+    """Description of one lazily imported CLI command."""
+
+    name: str
+    target: str
+    help: str
+
+
+COMMANDS = (
+    Command(
+        name="data",
+        target="embodichain.data.download:main",
+        help="List and download EmbodiChain data assets.",
+    ),
+    Command(
+        name="simready",
+        target="embodichain.gen_sim.simready_pipeline.cli.start:main",
+        help="Convert a raw asset directory into a SimReady asset.",
+    ),
+    Command(
+        name="preview-asset",
+        target="embodichain.lab.scripts.preview_asset:cli",
+        help="Preview a USD, URDF, or mesh asset in simulation.",
+    ),
+    Command(
+        name="run-env",
+        target="embodichain.lab.scripts.run_env:cli",
+        help="Run an environment for data generation or preview.",
+    ),
+    Command(
+        name="train-rl",
+        target="embodichain.learning.rl.train:cli",
+        help="Train an RL agent from a JSON or YAML config.",
+    ),
+    Command(
+        name="annotate-grasp",
+        target="embodichain.toolkits.graspkit.scripts.annotate_grasp:cli",
+        help="Interactively annotate a grasp region on a mesh.",
+    ),
+    Command(
+        name="decompose-urdf",
+        target="embodichain.toolkits.acd.cli:main",
+        help="Generate convex collision meshes for a URDF.",
+    ),
+    Command(
+        name="benchmark",
+        target="scripts.benchmark.__main__:main",
+        help="Run EmbodiChain performance benchmarks.",
+    ),
+    Command(
+        name="workspace-cache",
+        target="embodichain.workspace_cache_cli:main",
+        help="Inspect and clean workspace analyzer caches.",
+    ),
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the top-level argument parser.
+
+    Returns:
+        The parser used for top-level help and command validation.
+    """
     parser = argparse.ArgumentParser(
         prog="embodichain",
         description="EmbodiChain command-line interface.",
     )
-    subparsers = parser.add_subparsers(dest="command")
-
-    # -- preview-asset -------------------------------------------------------
-    preview_asset_parser = subparsers.add_parser(
-        "preview-asset",
-        help="Preview a USD or mesh asset in the simulation.",
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}",
     )
-    # Import and wire up the existing CLI so argparse is handled by the
-    # sub-command module itself.  We pass ``parse_known_args`` style by
-    # letting the sub-command parser own its own arguments.
-    from embodichain.lab.scripts.preview_asset import cli as preview_asset_cli
-
-    preview_asset_parser.set_defaults(func=preview_asset_cli)
-
-    # Re-add the preview-asset arguments here so ``--help`` works on the
-    # sub-command.  We delegate to the existing ``cli()`` which calls
-    # ``parse_args()`` internally, so we pass through the raw argv.
-    # Instead of duplicating argument definitions, we let the sub-command
-    # module handle its own argument parsing by slicing sys.argv.
-
-    # -- run-env -------------------------------------------------------------
-    run_env_parser = subparsers.add_parser(
-        "run-env",
-        help="Run an environment for data generation or preview.",
+    subparsers = parser.add_subparsers(
+        dest="command",
+        metavar="COMMAND",
+        title="commands",
     )
-    from embodichain.lab.scripts.run_env import cli as run_env_cli
+    for command in COMMANDS:
+        # The command module owns its parser. Disabling help here lets
+        # ``embodichain <command> --help`` reach that complete parser.
+        subparsers.add_parser(
+            command.name,
+            add_help=False,
+            help=command.help,
+            description=command.help,
+        )
+    return parser
 
-    run_env_parser.set_defaults(func=run_env_cli)
 
-    # -- annotate-grasp ------------------------------------------------------
-    annotate_grasp_parser = subparsers.add_parser(
-        "annotate-grasp",
-        help="Interactively annotate grasp region on a mesh.",
-    )
-    from embodichain.toolkits.graspkit.scripts.annotate_grasp import (
-        cli as annotate_grasp_cli,
-    )
+def _load_handler(target: str) -> Callable[[Sequence[str] | None], None]:
+    """Load a command handler from a ``module:attribute`` target."""
+    module_name, attribute = target.split(":", maxsplit=1)
+    module = importlib.import_module(module_name)
+    return getattr(module, attribute)
 
-    annotate_grasp_parser.set_defaults(func=annotate_grasp_cli)
 
-    # -- train-rl ------------------------------------------------------------
-    train_rl_parser = subparsers.add_parser(
-        "train-rl",
-        help="Train an RL agent from a config file (.json, .yaml, or .yml).",
-    )
-    from embodichain.learning.rl.train import cli as train_rl_cli
+def main(argv: Sequence[str] | None = None) -> None:
+    """Dispatch a command through the unified CLI.
 
-    train_rl_parser.set_defaults(func=train_rl_cli)
+    Args:
+        argv: Arguments excluding the executable name. Uses ``sys.argv`` when
+            omitted.
+    """
+    parser = build_parser()
+    arguments = list(sys.argv[1:] if argv is None else argv)
 
-    # -- Parse ---------------------------------------------------------------
-    # If no sub-command is given, print help and exit.
-    if len(sys.argv) < 2 or sys.argv[1] in ("-h", "--help"):
+    if not arguments:
         parser.print_help()
-        sys.exit(0)
+        return
 
-    # Determine which sub-command was selected, then reconstruct argv so
-    # that each sub-command's ``cli()`` can call ``parse_args()`` normally.
-    known, _ = parser.parse_known_args()
+    if arguments[0] in {"-h", "--help"}:
+        parser.parse_args(arguments)
+        return
 
-    if hasattr(known, "func"):
-        # Rewrite sys.argv so the sub-command's argparse sees only its own args.
-        subcommand_argv = [f"embodichain {sys.argv[1]}"] + sys.argv[2:]
-        original_argv = sys.argv
-        sys.argv = subcommand_argv
-        try:
-            known.func()
-        finally:
-            sys.argv = original_argv
-    else:
-        parser.print_help()
-        sys.exit(1)
+    if arguments[0] == "--version":
+        parser.parse_args(arguments)
+        return
+
+    command_by_name = {command.name: command for command in COMMANDS}
+    command = command_by_name.get(arguments[0])
+    if command is None:
+        parser.error(
+            f"argument COMMAND: invalid choice: {arguments[0]!r} "
+            f"(choose from {', '.join(command_by_name)})"
+        )
+
+    handler = _load_handler(command.target)
+    handler(arguments[1:])
 
 
 if __name__ == "__main__":
     main()
+
+
+__all__ = ["COMMANDS", "Command", "build_parser", "main"]

--- a/embodichain/data/__main__.py
+++ b/embodichain/data/__main__.py
@@ -14,8 +14,17 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
-"""Allow ``python -m embodichain.data`` to invoke the download CLI."""
+"""Backward-compatible module entry point for the data CLI.
+
+Prefer ``embodichain data`` or ``python -m embodichain data``.
+"""
+
+from __future__ import annotations
 
 from embodichain.data.download import main
 
-main()
+if __name__ == "__main__":
+    main()
+
+
+__all__ = ["main"]

--- a/embodichain/data/download.py
+++ b/embodichain/data/download.py
@@ -19,19 +19,19 @@
 Usage::
 
     # List all available assets
-    python -m embodichain.data.download list
+    embodichain data list
 
     # List assets in a specific category
-    python -m embodichain.data.download list --category robot
+    embodichain data list --category robot
 
     # Download a specific asset by name
-    python -m embodichain.data.download download --name CobotMagicArm
+    embodichain data download --name CobotMagicArm
 
     # Download all assets in a category
-    python -m embodichain.data.download download --category robot
+    embodichain data download --category robot
 
     # Download everything
-    python -m embodichain.data.download download --all
+    embodichain data download --all
 """
 
 from __future__ import annotations
@@ -42,10 +42,13 @@ import inspect
 import os
 import shutil
 import sys
-
-import open3d as o3d
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 from embodichain.data.constants import EMBODICHAIN_DEFAULT_DATA_ROOT
+
+if TYPE_CHECKING:
+    import open3d
 
 # Mapping from category name to the module path that defines the asset classes.
 CATEGORY_MODULES: dict[str, str] = {
@@ -61,12 +64,14 @@ CATEGORY_MODULES: dict[str, str] = {
 
 def _get_asset_classes(module_path: str) -> list[tuple[str, type]]:
     """Return (name, cls) pairs for all DownloadDataset subclasses in *module_path*."""
+    import open3d
+
     module = importlib.import_module(module_path)
     results: list[tuple[str, type]] = []
     for name, obj in inspect.getmembers(module, inspect.isclass):
         if (
-            issubclass(obj, o3d.data.DownloadDataset)
-            and obj is not o3d.data.DownloadDataset
+            issubclass(obj, open3d.data.DownloadDataset)
+            and obj is not open3d.data.DownloadDataset
             and obj.__module__ == module.__name__
         ):
             results.append((name, obj))
@@ -99,7 +104,7 @@ def find_asset_class(
 # ---------------------------------------------------------------------------
 
 
-def _ensure_extract(data_obj: o3d.data.DownloadDataset, prefix: str) -> None:
+def _ensure_extract(data_obj: open3d.data.DownloadDataset, prefix: str) -> None:
     """For non-zip assets, copy the downloaded file into the extract directory.
 
     ``o3d.data.DownloadDataset`` extracts zip archives automatically but
@@ -210,9 +215,15 @@ def cmd_download(args: argparse.Namespace) -> None:
     print(f"\nDone. {len(targets)} asset(s) processed.")
 
 
-def main() -> None:
+def main(argv: Sequence[str] | None = None) -> None:
+    """Run the data asset CLI.
+
+    Args:
+        argv: Arguments excluding the command name. Uses ``sys.argv`` when
+            omitted.
+    """
     parser = argparse.ArgumentParser(
-        prog="embodichain.data.download",
+        prog="embodichain data",
         description="Pre-download EmbodiChain data assets from HuggingFace.",
     )
     subparsers = parser.add_subparsers(dest="command")
@@ -238,7 +249,7 @@ def main() -> None:
         "--all", action="store_true", help="Download every registered asset."
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
     if args.command == "list":
         cmd_list(args)
     elif args.command == "download":
@@ -250,3 +261,14 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+
+
+__all__ = [
+    "CATEGORY_MODULES",
+    "cmd_download",
+    "cmd_list",
+    "download_asset",
+    "find_asset_class",
+    "get_registry",
+    "main",
+]

--- a/embodichain/gen_sim/simready_pipeline/cli/start.py
+++ b/embodichain/gen_sim/simready_pipeline/cli/start.py
@@ -14,18 +14,33 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
+"""Command-line interface for the SimReady asset pipeline."""
+
+from __future__ import annotations
+
 import argparse
-from pathlib import Path
 import os
-
-os.environ["PYOPENGL_PLATFORM"] = "egl"
-
-from embodichain.gen_sim.simready_pipeline.pipeline.ingest import ingest_one_asset
-from embodichain.gen_sim.simready_pipeline.io.json_store import JsonStore
-from embodichain.gen_sim.simready_pipeline.parser.base import ParserManager
+from collections.abc import Sequence
+from pathlib import Path
 
 
-def cli_ingest_single(input_dir: str, output_dir: str, category: str):
+def cli_ingest_single(input_dir: str, output_dir: str, category: str) -> None:
+    """Ingest one asset directory.
+
+    Args:
+        input_dir: Directory containing the source asset.
+        output_dir: Root directory for generated assets.
+        category: Semantic category assigned to the asset.
+
+    Raises:
+        FileNotFoundError: If the input directory does not exist.
+    """
+    os.environ["PYOPENGL_PLATFORM"] = "egl"
+
+    from embodichain.gen_sim.simready_pipeline.io.json_store import JsonStore
+    from embodichain.gen_sim.simready_pipeline.parser.base import ParserManager
+    from embodichain.gen_sim.simready_pipeline.pipeline.ingest import ingest_one_asset
+
     input_path = Path(input_dir)
     output_path = Path(output_dir)
 
@@ -47,30 +62,48 @@ def cli_ingest_single(input_dir: str, output_dir: str, category: str):
     )
 
     if asset:
-        print(f"Successfully Processed")
+        print("Successfully processed")
     else:
-        print("no asset returned (might be direct_copy mode)")
+        print("No asset returned (might be direct_copy mode)")
 
 
-def main():
+def main(argv: Sequence[str] | None = None) -> None:
+    """Run the SimReady asset pipeline CLI.
+
+    Args:
+        argv: Arguments excluding the command name. Uses ``sys.argv`` when
+            omitted.
+    """
     parser = argparse.ArgumentParser(
-        description="embodichain.gen_sim.simready_pipeline Asset Ingestion Pipeline"
+        prog="embodichain simready",
+        description="Convert a raw asset directory into a SimReady asset.",
     )
 
     parser.add_argument(
-        "--input_dir", type=str, help="Path to the single asset directory"
+        "--input_dir",
+        type=str,
+        required=True,
+        help="Path to the single asset directory.",
     )
-    parser.add_argument("--output_root", type=str, help="Path to the output directory")
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        required=True,
+        help="Root directory for generated assets.",
+    )
     parser.add_argument(
         "--category",
         type=str,
         required=True,
         help="Specify the category for this asset (e.g., 'cup', 'chair')",
     )
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     cli_ingest_single(args.input_dir, args.output_root, args.category)
 
 
 if __name__ == "__main__":
     main()
+
+
+__all__ = ["cli_ingest_single", "main"]

--- a/embodichain/lab/gym/utils/gym_utils.py
+++ b/embodichain/lab/gym/utils/gym_utils.py
@@ -762,7 +762,11 @@ def assign_data_to_dict(data_dict: TensorDict, name: str, value: Any) -> None:
     current_data[last_key] = value
 
 
-def add_env_launcher_args_to_parser(parser: argparse.ArgumentParser) -> None:
+def add_env_launcher_args_to_parser(
+    parser: argparse.ArgumentParser,
+    *,
+    require_gym_config: bool = False,
+) -> None:
     """Add common environment launcher arguments to an existing argparse parser.
 
     This function adds the following arguments to the provided parser:
@@ -781,7 +785,10 @@ def add_env_launcher_args_to_parser(parser: argparse.ArgumentParser) -> None:
         1. In preview mode, the environment will be launched and keep running in a loop for user interaction.
 
     Args:
-        parser (argparse.ArgumentParser): The parser to which arguments will be added.
+        parser: The parser to which arguments will be added.
+        require_gym_config: Whether ``--gym_config`` is required. Environment
+            runners should enable this; standalone simulation scripts can
+            leave it disabled.
     """
     parser.add_argument(
         "--num_envs",
@@ -825,7 +832,7 @@ def add_env_launcher_args_to_parser(parser: argparse.ArgumentParser) -> None:
         type=str,
         help="Path to gym config file (.json, .yaml, or .yml).",
         default="",
-        required=False,
+        required=require_gym_config,
     )
     parser.add_argument(
         "--action_config",
@@ -1004,6 +1011,31 @@ def init_rollout_buffer_from_gym_space(
         device=device,
     )
     return rollout_buffer
+
+
+__all__ = [
+    "DEFAULT_MANAGER_MODULES",
+    "add_env_launcher_args_to_parser",
+    "assign_data_to_dict",
+    "batch",
+    "build_env_cfg_from_args",
+    "cat_tensor_with_ids",
+    "clip_and_scale_action",
+    "config_to_cfg",
+    "convert_observation_to_space",
+    "dict_array_to_torch_inplace",
+    "fetch_data_from_dict",
+    "flatten_state_dict",
+    "get_dtype_bounds",
+    "get_manager_modules",
+    "init_rollout_buffer_from_config",
+    "init_rollout_buffer_from_gym_space",
+    "map_qpos_to_eef_pose",
+    "merge_args_with_gym_config",
+    "register_manager_modules",
+    "to_cpu_tensor",
+    "to_tensor",
+]
 
 
 def init_rollout_buffer_from_config(

--- a/embodichain/lab/scripts/preview_asset.py
+++ b/embodichain/lab/scripts/preview_asset.py
@@ -14,34 +14,34 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
-"""Standalone script to preview a USD or mesh asset in the simulation.
+"""Preview a USD or mesh asset in the simulation.
 
 Usage examples::
 
     # Preview a rigid object from USD
-    python -m embodichain.lab.scripts.preview_asset \\
+    embodichain preview-asset \\
         --asset_path /path/to/sugar_box.usda \\
         --asset_type rigid \\
         --preview
 
     # Preview an articulation from USD
-    python -m embodichain.lab.scripts.preview_asset \\
+    embodichain preview-asset \\
         --asset_path /path/to/robot.usd \\
         --asset_type articulation \\
         --preview
 
     # Headless check (no render window)
-    python -m embodichain.lab.scripts.preview_asset \\
+    embodichain preview-asset \\
         --asset_path /path/to/asset.usda \\
         --headless
 
     # Preview with a built-in environment map
-    python -m embodichain.lab.scripts.preview_asset \\
+    embodichain preview-asset \\
         --asset_path /path/to/sugar_box.usda \\
         --env_map "Studio"
 
     # Preview with a custom HDR environment map
-    python -m embodichain.lab.scripts.preview_asset \\
+    embodichain preview-asset \\
         --asset_path /path/to/sugar_box.usda \\
         --env_map /path/to/environment.hdr
 """
@@ -51,6 +51,7 @@ from __future__ import annotations
 import argparse
 import os
 
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 from embodichain.utils.logger import log_info, log_warning, log_error
@@ -81,9 +82,8 @@ def build_sim_cfg(args: argparse.Namespace):
 def load_assets(sim: SimulationManager, args: argparse.Namespace):
     """Load one or more assets into the simulation.
 
-    If ``--asset_type`` is not specified and the file is USD, the script will
-    inspect the USD stage for articulation roots to decide between articulation
-    and rigid object.  For non-USD files the default is always ``rigid``.
+    URDF files are always loaded as articulations. Other file types use the
+    value of ``--asset_type``, which defaults to ``rigid``.
 
     Args:
         sim: The simulation manager instance.
@@ -240,13 +240,16 @@ def main(args: argparse.Namespace) -> None:
         sim.destroy()
 
 
-def cli():
+def cli(argv: Sequence[str] | None = None) -> None:
     """Command-line interface for asset preview.
 
-    Parses CLI arguments and launches the preview workflow.
+    Args:
+        argv: Arguments excluding the command name. Uses ``sys.argv`` when
+            omitted.
     """
     parser = argparse.ArgumentParser(
-        description="Preview a USD or mesh asset in the EmbodiChain simulation."
+        prog="embodichain preview-asset",
+        description="Preview a USD or mesh asset in the EmbodiChain simulation.",
     )
 
     parser.add_argument(
@@ -261,7 +264,7 @@ def cli():
         type=str,
         choices=["rigid", "articulation"],
         default="rigid",
-        help="Asset type. Auto-detected for USD files if not specified (default: rigid).",
+        help="Asset type for non-URDF files (default: rigid).",
     )
     parser.add_argument(
         "--uid",
@@ -298,7 +301,7 @@ def cli():
         "--body_type",
         type=str,
         choices=["dynamic", "kinematic", "static"],
-        default="dynamic",
+        default="kinematic",
         help="Body type for rigid objects (default: kinematic).",
     )
     parser.add_argument(
@@ -309,9 +312,9 @@ def cli():
     )
     parser.add_argument(
         "--fix_base",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
         default=True,
-        help="Fix the base of articulations (default: True).",
+        help="Fix or unfix the base of articulations (default: fixed).",
     )
     parser.add_argument(
         "--sim_device",
@@ -348,10 +351,13 @@ def cli():
         help="Enter interactive embed mode after loading.",
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     main(args)
 
 
 if __name__ == "__main__":
     cli()
+
+
+__all__ = ["build_sim_cfg", "cli", "load_assets", "main", "preview"]

--- a/embodichain/lab/scripts/run_env.py
+++ b/embodichain/lab/scripts/run_env.py
@@ -14,10 +14,15 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
-import gymnasium
-import numpy as np
+from __future__ import annotations
+
 import argparse
 import os
+
+from collections.abc import Sequence
+
+import gymnasium
+import numpy as np
 import torch
 import tqdm
 
@@ -176,20 +181,24 @@ def preview(env: gymnasium.Env) -> None:
     exit(0)
 
 
-def cli():
+def cli(argv: Sequence[str] | None = None) -> None:
     """Command-line interface for environment runner.
 
-    Parses CLI arguments, builds the environment config, and launches
-    the data generation or preview workflow.
+    Args:
+        argv: Arguments excluding the command name. Uses ``sys.argv`` when
+            omitted.
     """
     np.set_printoptions(5, suppress=True)
     torch.set_printoptions(precision=5, sci_mode=False)
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(
+        prog="embodichain run-env",
+        description="Run an environment for data generation or interactive preview.",
+    )
 
-    add_env_launcher_args_to_parser(parser)
+    add_env_launcher_args_to_parser(parser, require_gym_config=True)
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     # Step 1: Discover all task packages via entry_points
     discover_task_packages()
@@ -206,3 +215,12 @@ def cli():
 
 if __name__ == "__main__":
     cli()
+
+
+__all__ = [
+    "cli",
+    "generate_and_execute_action_list",
+    "generate_function",
+    "main",
+    "preview",
+]

--- a/embodichain/lab/sim/utility/workspace_analyzer/caches/cache_utils.py
+++ b/embodichain/lab/sim/utility/workspace_analyzer/caches/cache_utils.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # ----------------------------------------------------------------------------
 # Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
 #
@@ -19,37 +18,29 @@
 Cache management utility for workspace analyzer.
 
 Usage:
-    python cache_utils.py list              # List all cache sessions
-    python cache_utils.py info <session>    # Show cache session info
-    python cache_utils.py clean <session>   # Clean specific session
-    python cache_utils.py clean --all       # Clean all cache sessions
-    python cache_utils.py size              # Show total cache size
+    embodichain workspace-cache list              # List all cache sessions
+    embodichain workspace-cache info <session>    # Show cache session info
+    embodichain workspace-cache clean <session>   # Clean specific session
+    embodichain workspace-cache clean --all       # Clean all cache sessions
+    embodichain workspace-cache size              # Show total cache size
 """
 
+from __future__ import annotations
+
 import os
-import sys
 import shutil
-import argparse
-from pathlib import Path
+from collections.abc import Sequence
 from datetime import datetime
+
 from embodichain.utils import logger
 
-# Add current directory to path for local imports
-sys.path.insert(0, os.path.dirname(__file__))
 
-try:
-    from disk_cache import DiskCache
-except ImportError:
-    print("Error: Unable to import DiskCache")
-    sys.exit(1)
-
-
-def get_cache_root():
+def get_cache_root() -> str:
     """Get the root cache directory."""
     return os.path.expanduser("~/.cache/embodichain/workspace_analyzer")
 
 
-def get_dir_size(path):
+def get_dir_size(path: str) -> int:
     """Calculate total size of a directory in bytes."""
     total = 0
     try:
@@ -64,7 +55,7 @@ def get_dir_size(path):
     return total
 
 
-def format_size(bytes_size):
+def format_size(bytes_size: int) -> str:
     """Format bytes to human-readable size."""
     for unit in ["B", "KB", "MB", "GB"]:
         if bytes_size < 1024.0:
@@ -73,7 +64,7 @@ def format_size(bytes_size):
     return f"{bytes_size:.2f} TB"
 
 
-def list_sessions():
+def list_sessions() -> None:
     """List all cache sessions."""
     cache_root = get_cache_root()
 
@@ -122,7 +113,7 @@ def list_sessions():
     logger.log_info(f"\nCache location: {cache_root}")
 
 
-def show_session_info(session_name):
+def show_session_info(session_name: str) -> None:
     """Show detailed information about a cache session."""
     cache_root = get_cache_root()
     session_path = os.path.join(cache_root, session_name)
@@ -161,7 +152,7 @@ def show_session_info(session_name):
             logger.log_info(f"Total poses: {total_poses:,}")
 
 
-def clean_session(session_name):
+def clean_session(session_name: str) -> None:
     """Clean a specific cache session."""
     cache_root = get_cache_root()
     session_path = os.path.join(cache_root, session_name)
@@ -180,7 +171,7 @@ def clean_session(session_name):
         logger.log_info("Cancelled.")
 
 
-def clean_all_sessions():
+def clean_all_sessions() -> None:
     """Clean all cache sessions."""
     cache_root = get_cache_root()
 
@@ -209,7 +200,7 @@ def clean_all_sessions():
         logger.log_info("Cancelled.")
 
 
-def show_total_size():
+def show_total_size() -> None:
     """Show total cache size."""
     cache_root = get_cache_root()
 
@@ -228,50 +219,30 @@ def show_total_size():
     logger.log_info(f"Total size: {format_size(total_size)}")
 
 
-def main():
-    parser = argparse.ArgumentParser(
-        description="Manage workspace analyzer cache sessions",
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog="""
-Examples:
-  %(prog)s list                    List all cache sessions
-  %(prog)s info session_20241127   Show session details
-  %(prog)s clean session_20241127  Clean specific session
-  %(prog)s clean --all             Clean all sessions
-  %(prog)s size                    Show total cache size
-        """,
-    )
+def main(argv: Sequence[str] | None = None) -> None:
+    """Run the backward-compatible workspace analyzer cache CLI.
 
-    parser.add_argument(
-        "command", choices=["list", "info", "clean", "size"], help="Command to execute"
-    )
-    parser.add_argument(
-        "session", nargs="?", help="Session name (for info/clean commands)"
-    )
-    parser.add_argument(
-        "--all", action="store_true", help="Apply to all sessions (for clean command)"
-    )
+    Args:
+        argv: Arguments excluding the command name. Uses ``sys.argv`` when
+            omitted.
+    """
+    from embodichain.workspace_cache_cli import main as cli_main
 
-    args = parser.parse_args()
-
-    if args.command == "list":
-        list_sessions()
-    elif args.command == "info":
-        if not args.session:
-            print("Error: Session name required for 'info' command")
-            sys.exit(1)
-        show_session_info(args.session)
-    elif args.command == "clean":
-        if args.all:
-            clean_all_sessions()
-        elif args.session:
-            clean_session(args.session)
-        else:
-            print("Error: Specify a session name or use --all flag")
-            sys.exit(1)
-    elif args.command == "size":
-        show_total_size()
+    cli_main(argv)
 
 
 if __name__ == "__main__":
     main()
+
+
+__all__ = [
+    "clean_all_sessions",
+    "clean_session",
+    "format_size",
+    "get_cache_root",
+    "get_dir_size",
+    "list_sessions",
+    "main",
+    "show_session_info",
+    "show_total_size",
+]

--- a/embodichain/learning/rl/train.py
+++ b/embodichain/learning/rl/train.py
@@ -14,9 +14,12 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
+from __future__ import annotations
+
 import argparse
 import os
 import time
+from collections.abc import Sequence
 from pathlib import Path
 
 import numpy as np
@@ -44,9 +47,20 @@ from embodichain.lab.sim.cfg import RenderCfg
 from embodichain.lab.gym.envs.managers.cfg import EventCfg
 
 
-def parse_args():
-    """Parse command line arguments."""
-    parser = argparse.ArgumentParser()
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments.
+
+    Args:
+        argv: Arguments excluding the command name. Uses ``sys.argv`` when
+            omitted.
+
+    Returns:
+        Parsed training arguments.
+    """
+    parser = argparse.ArgumentParser(
+        prog="embodichain train-rl",
+        description="Train an RL agent from a JSON or YAML config.",
+    )
     parser.add_argument(
         "--config",
         type=str,
@@ -59,7 +73,7 @@ def parse_args():
         default=None,
         help="Enable or disable multi-GPU distributed training",
     )
-    return parser.parse_args()
+    return parser.parse_args(argv)
 
 
 def train_from_config(config_path: str, distributed: bool | None = None):
@@ -414,7 +428,7 @@ def train_from_config(config_path: str, distributed: bool | None = None):
             logger.log_info("Training finished")
 
 
-def cli() -> None:
+def cli(argv: Sequence[str] | None = None) -> None:
     """Command-line interface for RL training.
 
     Parses CLI arguments and launches training from a config file.
@@ -424,7 +438,7 @@ def cli() -> None:
     ``embodichain_tasks``) are available to ``build_env``. This mirrors the
     ``run_env`` CLI.
     """
-    args = parse_args()
+    args = parse_args(argv)
 
     # Discover all installed task packages and run init hooks (register custom
     # manager modules / asset resolvers) before building any environment.
@@ -436,3 +450,6 @@ def cli() -> None:
 
 if __name__ == "__main__":
     cli()
+
+
+__all__ = ["cli", "parse_args", "train_from_config"]

--- a/embodichain/toolkits/acd/__init__.py
+++ b/embodichain/toolkits/acd/__init__.py
@@ -13,6 +13,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ----------------------------------------------------------------------------
-from .urdf_modifider import generate_urdf_collision_convexes
+
+"""Approximate convex decomposition toolkit."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .urdf_modifider import generate_urdf_collision_convexes
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily import APIs with optional geometry dependencies."""
+    if name == "generate_urdf_collision_convexes":
+        from .urdf_modifider import generate_urdf_collision_convexes
+
+        return generate_urdf_collision_convexes
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = ["generate_urdf_collision_convexes"]

--- a/embodichain/toolkits/acd/cli.py
+++ b/embodichain/toolkits/acd/cli.py
@@ -1,0 +1,86 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+"""Command-line interface for URDF convex decomposition."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Sequence
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """Generate convex collision meshes and an updated URDF.
+
+    Args:
+        argv: Arguments excluding the command name. Uses ``sys.argv`` when
+            omitted.
+    """
+    parser = argparse.ArgumentParser(
+        prog="embodichain decompose-urdf",
+        description="Generate convex collision meshes for a URDF.",
+    )
+    parser.add_argument(
+        "--urdf_path",
+        type=str,
+        required=True,
+        help="Path to the source URDF.",
+    )
+    parser.add_argument(
+        "--output_urdf_name",
+        type=str,
+        default="articulation_acd.urdf",
+        help="Name of the generated URDF.",
+    )
+    parser.add_argument(
+        "--max_convex_hull_num",
+        type=int,
+        default=8,
+        help="Maximum number of convex hulls for each mesh.",
+    )
+    parser.add_argument(
+        "--recompute_inertia",
+        action="store_true",
+        help="Recompute inertia after convex decomposition.",
+    )
+    parser.add_argument(
+        "--scale",
+        type=float,
+        nargs=3,
+        default=None,
+        metavar=("X", "Y", "Z"),
+        help="Scale the URDF by three per-axis factors.",
+    )
+    args = parser.parse_args(argv)
+
+    from embodichain.toolkits.acd.urdf_modifider import (
+        generate_urdf_collision_convexes,
+    )
+
+    generate_urdf_collision_convexes(
+        args.urdf_path,
+        args.output_urdf_name,
+        max_convex_hull_num=args.max_convex_hull_num,
+        recompute_inertia=args.recompute_inertia,
+        scale=args.scale,
+    )
+
+
+if __name__ == "__main__":
+    main()
+
+
+__all__ = ["main"]

--- a/embodichain/toolkits/acd/urdf_modifider.py
+++ b/embodichain/toolkits/acd/urdf_modifider.py
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ----------------------------------------------------------------------------
+
+from __future__ import annotations
+
 import os
 import xml.etree.ElementTree as ET
 import open3d as o3d
@@ -322,48 +325,9 @@ class URDFModifider:
 
 
 if __name__ == "__main__":
-    import argparse
+    from embodichain.toolkits.acd.cli import main
 
-    parser = argparse.ArgumentParser(
-        description="Create and simulate a camera with gizmo in SimulationManager"
-    )
-    parser.add_argument(
-        "--urdf_path",
-        type=str,
-        help="Input urdf file path",
-    )
-    parser.add_argument(
-        "--output_urdf_name",
-        type=str,
-        default="articulation_acd.urdf",
-        help="Output urdf file name, ",
-    )
-    parser.add_argument(
-        "--max_convex_hull_num",
-        type=int,
-        default=8,
-        help="Maximum number of convex hulls for decomposition",
-    )
-    parser.add_argument(
-        "--recompute_inertia",
-        default=False,
-        action="store_true",
-        help="Whether to recompute inertia after convex decomposition",
-    )
+    main()
 
-    parser.add_argument(
-        "--scale",
-        type=float,
-        nargs=3,
-        default=None,
-        help="Scale the urdf by [scale_x, scale_y, scale_z]",
-    )
 
-    args = parser.parse_args()
-    generate_urdf_collision_convexes(
-        args.urdf_path,
-        args.output_urdf_name,
-        max_convex_hull_num=args.max_convex_hull_num,
-        recompute_inertia=args.recompute_inertia,
-        scale=args.scale,
-    )
+__all__ = ["URDFModifider", "generate_urdf_collision_convexes"]

--- a/embodichain/toolkits/graspkit/scripts/annotate_grasp.py
+++ b/embodichain/toolkits/graspkit/scripts/annotate_grasp.py
@@ -22,32 +22,25 @@ point pairs to the grasp-annotator cache.
 
 Usage examples::
 
-    python -m embodichain annotate-grasp --mesh_path /path/to/object.ply
-    python -m embodichain annotate-grasp --mesh_path mug.obj
+    embodichain annotate-grasp --mesh_path /path/to/object.ply
+    embodichain annotate-grasp --mesh_path mug.obj
 """
 
 from __future__ import annotations
 
 import argparse
-
-import torch
-import trimesh
-
-from embodichain.toolkits.graspkit.pg_grasp import (
-    AntipodalSamplerCfg,
-    GraspGenerator,
-    GraspGeneratorCfg,
-)
-from embodichain.utils.logger import log_info
+from collections.abc import Sequence
 
 
-def cli() -> None:
+def cli(argv: Sequence[str] | None = None) -> None:
     """Command-line interface for grasp pose annotation.
 
-    Parses CLI arguments, loads the mesh, and launches interactive
-    annotation via the Viser browser UI.
+    Args:
+        argv: Arguments excluding the command name. Uses ``sys.argv`` when
+            omitted.
     """
     parser = argparse.ArgumentParser(
+        prog="embodichain annotate-grasp",
         description=(
             "Interactively annotate a grasp region on a mesh and "
             "compute antipodal point pairs."
@@ -91,7 +84,17 @@ def cli() -> None:
         help="Compute device, e.g. 'cpu' or 'cuda' (default: cpu).",
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
+
+    import torch
+    import trimesh
+
+    from embodichain.toolkits.graspkit.pg_grasp import (
+        AntipodalSamplerCfg,
+        GraspGenerator,
+        GraspGeneratorCfg,
+    )
+    from embodichain.utils.logger import log_info
 
     # Load mesh via trimesh
     log_info(f"Loading mesh from {args.mesh_path}", color="green")
@@ -114,7 +117,7 @@ def cli() -> None:
     generator = GraspGenerator(vertices=vertices, triangles=triangles, cfg=cfg)
     log_info(
         "Annotate the grasp region in the browser window:\n"
-        "  1. Open http://localhost:{port}\n"
+        f"  1. Open http://localhost:{args.viser_port}\n"
         "  2. Click 'Rect Select Region' and drag to select\n"
         "  3. Click 'Confirm Selection' to finish",
         color="green",
@@ -129,3 +132,6 @@ def cli() -> None:
 
 if __name__ == "__main__":
     cli()
+
+
+__all__ = ["cli"]

--- a/embodichain/workspace_cache_cli.py
+++ b/embodichain/workspace_cache_cli.py
@@ -1,0 +1,91 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+"""Command-line interface for workspace analyzer cache management."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Sequence
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """Run the workspace analyzer cache CLI.
+
+    Args:
+        argv: Arguments excluding the command name. Uses ``sys.argv`` when
+            omitted.
+    """
+    parser = argparse.ArgumentParser(
+        prog="embodichain workspace-cache",
+        description="Manage workspace analyzer cache sessions.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s list                    List all cache sessions
+  %(prog)s info session_20241127   Show session details
+  %(prog)s clean session_20241127  Clean a specific session
+  %(prog)s clean --all             Clean all sessions
+  %(prog)s size                    Show total cache size
+        """,
+    )
+    parser.add_argument(
+        "command",
+        choices=["list", "info", "clean", "size"],
+        help="Command to execute.",
+    )
+    parser.add_argument(
+        "session",
+        nargs="?",
+        help="Session name for the info and clean commands.",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Apply the clean command to all sessions.",
+    )
+    args = parser.parse_args(argv)
+
+    from embodichain.lab.sim.utility.workspace_analyzer.caches.cache_utils import (
+        clean_all_sessions,
+        clean_session,
+        list_sessions,
+        show_session_info,
+        show_total_size,
+    )
+
+    if args.command == "list":
+        list_sessions()
+    elif args.command == "info":
+        if not args.session:
+            parser.error("the info command requires a session name")
+        show_session_info(args.session)
+    elif args.command == "clean":
+        if args.all:
+            clean_all_sessions()
+        elif args.session:
+            clean_session(args.session)
+        else:
+            parser.error("the clean command requires a session name or --all")
+    elif args.command == "size":
+        show_total_size()
+
+
+if __name__ == "__main__":
+    main()
+
+
+__all__ = ["main"]

--- a/examples/gym/pour_water.sh
+++ b/examples/gym/pour_water.sh
@@ -1,3 +1,3 @@
-python -m embodichain.lab.scripts.run_env --gym_config embodichain_tasks/configs/gym/pour_water/gym_config.json \
+embodichain run-env --gym_config embodichain_tasks/configs/gym/pour_water/gym_config.json \
        --action_config embodichain_tasks/configs/gym/pour_water/action_config.json \
        --filter_visual_rand

--- a/examples/gym/run_blocks_ranking_rgb.sh
+++ b/examples/gym/run_blocks_ranking_rgb.sh
@@ -1,6 +1,5 @@
-python -m embodichain.lab.scripts.run_env \
+embodichain run-env \
     --gym_config embodichain_tasks/configs/gym/blocks_ranking_rgb/cobot_magic_3cam.json \
     --num_envs 1 \
     --device cpu \
     --debug_mode
-

--- a/examples/gym/run_scoop_ice.sh
+++ b/examples/gym/run_scoop_ice.sh
@@ -1,1 +1,1 @@
-python -m embodichain.lab.scripts.run_env --gym_config embodichain_tasks/configs/gym/scoop_ice/gym_config.json
+embodichain run-env --gym_config embodichain_tasks/configs/gym/scoop_ice/gym_config.json

--- a/examples/gym/run_stack_blocks_two.sh
+++ b/examples/gym/run_stack_blocks_two.sh
@@ -1,4 +1,4 @@
-python -m embodichain.lab.scripts.run_env \
+embodichain run-env \
     --gym_config embodichain_tasks/configs/gym/stack_blocks_two/cobot_magic_3cam.json \
     --num_envs 1 \
     --device cpu \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,9 @@ gensim = [
 # ``embodichain run-env`` discovers all installed task packages (via the
 # ``embodichain.tasks`` entry points) and runs their init hooks (via
 # ``embodichain.init``) before building and launching the environment.
-# Other sub-commands: preview-asset, annotate-grasp, train-rl.
+# Other commands cover data assets, SimReady generation, asset preview,
+# grasp annotation, RL training, URDF convex decomposition, benchmarks, and
+# workspace cache management.
 embodichain = "embodichain.__main__:main"
 
 [tool.uv.sources]

--- a/scripts/benchmark/__main__.py
+++ b/scripts/benchmark/__main__.py
@@ -14,21 +14,24 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
-"""Unified CLI entry point for ``python -m scripts.benchmark``.
+"""Unified benchmark CLI.
 
 Usage examples::
 
-    python -m scripts.benchmark rl --tasks push_cube --algorithms ppo --suite default
-    python -m scripts.benchmark rl --rebuild-report-only
-    python -m scripts.benchmark robotics-kinematic-solver -s pytorch
-    python -m scripts.benchmark planners-neural-planner --num-waypoints 1 3 5
-    python -m scripts.benchmark atomic-action --smoke
+    embodichain benchmark rl --tasks push_cube --algorithms ppo --suite default
+    embodichain benchmark rl --rebuild-report-only
+    embodichain benchmark robotics-kinematic-solver -s pytorch
+    embodichain benchmark planners-neural-planner --num-waypoints 1 3 5
+    embodichain benchmark atomic-action --smoke
+    embodichain benchmark grasp-pose-generator --device cuda
+    embodichain benchmark workspace-analyzer
 """
 
 from __future__ import annotations
 
 import argparse
 import sys
+from collections.abc import Sequence
 
 
 def _run_robotics_kinematic_solver_cli(args: argparse.Namespace) -> None:
@@ -74,10 +77,26 @@ def _run_atomic_action_cli(_: argparse.Namespace) -> None:
     atomic_main()
 
 
-def main() -> None:
+def _run_grasp_pose_generator_cli(_: argparse.Namespace) -> None:
+    """Run grasp pose generator benchmark CLI entrypoint."""
+    from scripts.benchmark.grasp_pose_generator.run_benchmark import main
+
+    main()
+
+
+def _run_workspace_analyzer_cli(_: argparse.Namespace) -> None:
+    """Run workspace analyzer benchmarks."""
+    from scripts.benchmark.workspace_analyzer.benchmark_workspace_analyzer import (
+        run_all_benchmarks,
+    )
+
+    run_all_benchmarks()
+
+
+def main(argv: Sequence[str] | None = None) -> None:
     """Dispatch to the appropriate benchmark sub-command CLI."""
     parser = argparse.ArgumentParser(
-        prog="scripts.benchmark",
+        prog="embodichain benchmark",
         description="EmbodiChain benchmark command-line interface.",
     )
     subparsers = parser.add_subparsers(dest="command")
@@ -85,6 +104,7 @@ def main() -> None:
     # -- rl ------------------------------------------------------------------
     rl_parser = subparsers.add_parser(
         "rl",
+        add_help=False,
         help="Run RL benchmark: train, evaluate, aggregate, and report results.",
     )
     rl_parser.set_defaults(func=_run_rl_cli)
@@ -178,26 +198,47 @@ def main() -> None:
     # -- atomic-action -------------------------------------------------------
     atomic_action_parser = subparsers.add_parser(
         "atomic-action",
+        add_help=False,
         help="Benchmark atomic actions over object presets and positions.",
     )
-    from scripts.benchmark.atomic_action.run_benchmark import add_benchmark_args
-
-    add_benchmark_args(atomic_action_parser)
     atomic_action_parser.set_defaults(func=_run_atomic_action_cli)
+
+    # -- grasp-pose-generator -----------------------------------------------
+    grasp_pose_parser = subparsers.add_parser(
+        "grasp-pose-generator",
+        add_help=False,
+        help="Benchmark grasp sampling and pose selection.",
+    )
+    grasp_pose_parser.set_defaults(func=_run_grasp_pose_generator_cli)
+
+    # -- workspace-analyzer -------------------------------------------------
+    workspace_parser = subparsers.add_parser(
+        "workspace-analyzer",
+        help="Benchmark workspace analysis operations.",
+    )
+    workspace_parser.set_defaults(func=_run_workspace_analyzer_cli)
 
     # -- Parse ---------------------------------------------------------------
     # If no sub-command is given, print help and exit.
-    if len(sys.argv) < 2 or sys.argv[1] in ("-h", "--help"):
+    arguments = list(sys.argv[1:] if argv is None else argv)
+    if not arguments or arguments[0] in ("-h", "--help"):
         parser.print_help()
-        sys.exit(0)
+        return
 
     # Determine which sub-command was selected, then reconstruct argv so
     # that each sub-command's entry point can call ``parse_args()`` normally.
-    known, _ = parser.parse_known_args()
+    delegated_commands = {"rl", "atomic-action", "grasp-pose-generator"}
+    if arguments[0] in delegated_commands:
+        known, _ = parser.parse_known_args(arguments)
+    else:
+        known = parser.parse_args(arguments)
 
     if hasattr(known, "func"):
         # Rewrite sys.argv so the sub-command's argparse sees only its own args.
-        subcommand_argv = [f"scripts.benchmark {sys.argv[1]}"] + sys.argv[2:]
+        subcommand_argv = [
+            f"embodichain benchmark {arguments[0]}",
+            *arguments[1:],
+        ]
         original_argv = sys.argv
         sys.argv = subcommand_argv
         try:

--- a/scripts/benchmark/atomic_action/move_end_effector_benchmark.py
+++ b/scripts/benchmark/atomic_action/move_end_effector_benchmark.py
@@ -18,7 +18,7 @@
 
 Measures planning latency, memory usage, trajectory success, and final TCP
 translation error for several reachable pose targets.
-Run: python -m scripts.benchmark.atomic_action.move_end_effector_benchmark
+Run: embodichain benchmark atomic-action --action move_end_effector
 """
 
 from __future__ import annotations

--- a/scripts/benchmark/atomic_action/move_held_object_benchmark.py
+++ b/scripts/benchmark/atomic_action/move_held_object_benchmark.py
@@ -18,7 +18,7 @@
 
 Measures MoveHeldObject-only planning latency and memory usage once a held
 object state has been produced by PickUp.
-Run: python -m scripts.benchmark.atomic_action.move_held_object_benchmark
+Run: embodichain benchmark atomic-action --action move_held_object
 """
 
 from __future__ import annotations

--- a/scripts/benchmark/atomic_action/move_joints_benchmark.py
+++ b/scripts/benchmark/atomic_action/move_joints_benchmark.py
@@ -18,7 +18,7 @@
 
 Measures planning latency, memory usage, trajectory success, and final arm joint
 error for named and explicit joint-position targets.
-Run: python -m scripts.benchmark.atomic_action.move_joints_benchmark
+Run: embodichain benchmark atomic-action --action move_joints
 """
 
 from __future__ import annotations

--- a/scripts/benchmark/atomic_action/pickup_benchmark.py
+++ b/scripts/benchmark/atomic_action/pickup_benchmark.py
@@ -18,7 +18,7 @@
 
 Measures planning latency, memory usage, grasp planning success, held-object
 state creation, and trajectory length for the PickUp action.
-Run: python -m scripts.benchmark.atomic_action.pickup_benchmark
+Run: embodichain benchmark atomic-action --action pick_up
 """
 
 from __future__ import annotations

--- a/scripts/benchmark/atomic_action/place_benchmark.py
+++ b/scripts/benchmark/atomic_action/place_benchmark.py
@@ -18,7 +18,7 @@
 
 Measures Place-only planning latency and memory usage once a held-object state
 has been produced by the PickUp action.
-Run: python -m scripts.benchmark.atomic_action.place_benchmark
+Run: embodichain benchmark atomic-action --action place
 """
 
 from __future__ import annotations

--- a/scripts/benchmark/atomic_action/press_benchmark.py
+++ b/scripts/benchmark/atomic_action/press_benchmark.py
@@ -20,7 +20,7 @@ The benchmark sweeps object presets such as bottle and mug against multiple
 initial XY positions that cover all four workspace quadrants. It reports
 planning latency, memory usage, planning success, and whether the generated
 trajectory reaches the object's top center.
-Run: python -m scripts.benchmark.atomic_action.press_benchmark
+Run: embodichain benchmark atomic-action --action press
 """
 
 from __future__ import annotations

--- a/scripts/benchmark/atomic_action/run_benchmark.py
+++ b/scripts/benchmark/atomic_action/run_benchmark.py
@@ -17,7 +17,7 @@
 """Dispatch benchmarks for all atomic actions.
 
 Run a single action benchmark or all action benchmarks in sequence.
-Run: python -m scripts.benchmark.atomic_action.run_benchmark --action press
+Run: embodichain benchmark atomic-action --action press
 """
 
 from __future__ import annotations

--- a/scripts/benchmark/grasp_pose_generator/run_benchmark.py
+++ b/scripts/benchmark/grasp_pose_generator/run_benchmark.py
@@ -20,7 +20,7 @@ Measures how ``grasp_cfg.antipodal_sampler_cfg.n_sample`` and
 ``grasp_cfg.n_top_grasps`` affect antipodal sampling, grasp-pose selection
 latency, and memory usage for the CoffeeCup mesh used in
 ``scripts/tutorials/grasp/grasp_generator.py``.
-Run: python -m scripts.benchmark.grasp_pose_generator.run_benchmark
+Run: embodichain benchmark grasp-pose-generator
 """
 
 from __future__ import annotations
@@ -28,6 +28,7 @@ from __future__ import annotations
 import argparse
 import os
 import time
+from collections.abc import Sequence
 from datetime import datetime
 from pathlib import Path
 
@@ -53,10 +54,11 @@ DEFAULT_N_TOP_GRASPS = [30, 50, 100]
 DEFAULT_MESH_SCALE = 4.0
 
 
-def _parse_args() -> argparse.Namespace:
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     """Parse command line arguments for grasp generator benchmarks."""
     parser = argparse.ArgumentParser(
-        description="Benchmark CoffeeCup grasp pose generation parameter sweeps."
+        prog="embodichain benchmark grasp-pose-generator",
+        description="Benchmark CoffeeCup grasp pose generation parameter sweeps.",
     )
     parser.add_argument(
         "--n-samples",
@@ -89,7 +91,7 @@ def _parse_args() -> argparse.Namespace:
         action="store_true",
         help="Only benchmark antipodal point generation.",
     )
-    return parser.parse_args()
+    return parser.parse_args(argv)
 
 
 def _resolve_device(device_name: str) -> torch.device:
@@ -552,8 +554,9 @@ def run_all_benchmarks(
     print(f"Markdown report saved: {report_path}")
 
 
-if __name__ == "__main__":
-    args = _parse_args()
+def main(argv: Sequence[str] | None = None) -> None:
+    """Run the grasp pose generator benchmark CLI."""
+    args = _parse_args(argv)
     run_all_benchmarks(
         n_samples=args.n_samples,
         n_top_grasps_list=args.n_top_grasps,
@@ -561,3 +564,10 @@ if __name__ == "__main__":
         seed=args.seed,
         skip_pose_selection=args.skip_pose_selection,
     )
+
+
+if __name__ == "__main__":
+    main()
+
+
+__all__ = ["main", "run_all_benchmarks"]

--- a/scripts/benchmark/planners/neural_planner/run_benchmark.py
+++ b/scripts/benchmark/planners/neural_planner/run_benchmark.py
@@ -35,8 +35,7 @@ Output
 
 Run::
 
-    python -m scripts.benchmark planners-neural-planner
-    python -m scripts.benchmark.planners.neural_planner.run_benchmark
+    embodichain benchmark planners-neural-planner
 """
 
 from __future__ import annotations

--- a/scripts/benchmark/rl/run_benchmark.py
+++ b/scripts/benchmark/rl/run_benchmark.py
@@ -16,7 +16,7 @@
 
 """Run RL benchmark training/evaluation and generate one markdown report.
 
-Run: python -m scripts.benchmark.rl.run_benchmark
+Run: embodichain benchmark rl
 """
 
 from __future__ import annotations

--- a/scripts/benchmark/robotics/kinematic_solver/run_benchmark.py
+++ b/scripts/benchmark/robotics/kinematic_solver/run_benchmark.py
@@ -19,7 +19,7 @@
 Measures IK wall-clock latency, pose accuracy, success rate, and memory usage
 across OPW (Warp CUDA vs CPU), UR analytic (Warp CPU vs CUDA), and the
 Pytorch solver (CPU vs optional CUDA).
-Run: python -m scripts.benchmark.robotics.kinematic_solver.run_benchmark
+Run: embodichain benchmark robotics-kinematic-solver
 """
 
 from __future__ import annotations

--- a/scripts/benchmark/workspace_analyzer/benchmark_workspace_analyzer.py
+++ b/scripts/benchmark/workspace_analyzer/benchmark_workspace_analyzer.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 """Benchmark script for workspace analyzer performance optimizations.
 
 Measures each optimization independently across multiple sample sizes.
-Run: python -m scripts.benchmark.workspace_analyzer.benchmark_workspace_analyzer
+Run: embodichain benchmark workspace-analyzer
 """
 
 import os

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,100 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import pytest
+
+from embodichain import __main__ as cli
+
+EXPECTED_COMMANDS = {
+    "annotate-grasp",
+    "benchmark",
+    "data",
+    "decompose-urdf",
+    "preview-asset",
+    "run-env",
+    "simready",
+    "train-rl",
+    "workspace-cache",
+}
+
+
+def test_all_public_commands_are_registered() -> None:
+    """Every documented public CLI should have one unified command."""
+    assert {command.name for command in cli.COMMANDS} == EXPECTED_COMMANDS
+
+
+def test_root_help_does_not_import_command_modules(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Top-level help should remain lightweight."""
+
+    def fail_if_loaded(_: str) -> None:
+        raise AssertionError("Top-level help loaded a command module")
+
+    monkeypatch.setattr(cli, "_load_handler", fail_if_loaded)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(["--help"])
+
+    assert exc_info.value.code == 0
+
+
+def test_dispatch_forwards_subcommand_arguments(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The selected command should receive all arguments after its name."""
+    received: list[str] = []
+
+    def fake_handler(argv: Sequence[str] | None = None) -> None:
+        received.extend(argv or [])
+
+    monkeypatch.setattr(cli, "_load_handler", lambda _: fake_handler)
+
+    cli.main(["preview-asset", "--asset_path", "robot.urdf", "--headless"])
+
+    assert received == ["--asset_path", "robot.urdf", "--headless"]
+
+
+def test_subcommand_help_uses_complete_command_parser(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Subcommand help should show real arguments instead of an empty shell."""
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(["simready", "--help"])
+
+    assert exc_info.value.code == 0
+    output = capsys.readouterr().out
+    assert "--input_dir" in output
+    assert "--output_root" in output
+    assert "--category" in output
+
+
+def test_nested_benchmark_help_uses_suite_parser(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Nested benchmark help should include suite-specific arguments."""
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(["benchmark", "rl", "--help"])
+
+    assert exc_info.value.code == 0
+    output = capsys.readouterr().out
+    assert "--tasks" in output
+    assert "--algorithms" in output
+    assert "--rebuild-report-only" in output


### PR DESCRIPTION
## Description

This PR unifies EmbodiChain's public command-line tools under the `embodichain <command> [args]` entry point.

It adds lazy command dispatch for data assets, SimReady processing, URDF decomposition, benchmarks, and workspace cache management; forwards each command to its complete parser so nested `--help` output is accurate; and preserves the existing module entry points for compatibility. It also aligns required/default arguments, updates command examples across the documentation, and adds CLI routing tests.

Motivation: several user-facing tools still required deep `python -m ...` paths, while existing unified subcommands exposed empty help parsers and eagerly loaded unrelated heavy modules.

Dependencies: none.

Issue: N/A (requested directly).

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)

## Screenshots

Not applicable; this change affects command-line interfaces and documentation.

## Validation

- `black . --extend-exclude '(^|/)\\.worktrees/'` — 470 files unchanged
- `pytest -q tests` — 711 passed, 99 skipped
- CLI and nested benchmark `--help` smoke checks
- Python compileall and wheel packaging checks

## Checklist

- [x] I have run the `black .` command to format the code base.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] Dependencies have been updated, if applicable (no new dependencies).
