### PR TITLE
Fix cuRobo planner example startup

### DIFF
--- a/examples/sim/planners/curobo_planner.py
+++ b/examples/sim/planners/curobo_planner.py
@@ -98,7 +98,10 @@ def parse_args() -> argparse.Namespace:
         description="Run cuRobo V2 through EmbodiChain AtomicActionEngine."
     )
     add_env_launcher_args_to_parser(parser)
-    parser.set_defaults(arena_space=2.0)
+    # This standalone example does not merge a gym config after parsing, so
+    # override the launcher's ``None`` sentinel with a concrete single-world
+    # default.
+    parser.set_defaults(arena_space=2.0, num_envs=1)
     # Backward-compatible aliases used by older versions of this example.
     parser.add_argument(
         "--step-repeat",
@@ -238,7 +241,7 @@ def _build_scene(
     """Create the batched robot scene with an identical cuboid in each arena."""
     sim = SimulationManager(
         SimulationManagerCfg(
-            headless=headless,
+            headless=True,
             sim_device=device,
             num_envs=num_envs,
             arena_space=arena_space,
@@ -689,11 +692,6 @@ def main() -> None:
         )
         if sim.is_use_gpu_physics:
             sim.init_gpu_physics()
-        if not args.headless:
-            sim.open_window()
-        _start_headless_recording(sim, args)
-        if args.hold_steps:
-            sim.update(step=args.hold_steps)
 
         obstacles = [demo_block]
         obstacle_poses = _perturb_obstacles(
@@ -712,6 +710,14 @@ def main() -> None:
                     f"XY={poses[:, :2, 3].tolist()}, "
                     f"yaw_deg={yaw_deg.tolist()}"
                 )
+
+        # Delay viewer/recorder startup until the robot and every obstacle have
+        # been loaded and placed at their final initial poses.
+        if not args.headless:
+            sim.open_window()
+        _start_headless_recording(sim, args)
+        if args.hold_steps:
+            sim.update(step=args.hold_steps)
 
         motion_generator = MotionGenerator(
             MotionGenCfg(


### PR DESCRIPTION
## Description

This PR fixes the standalone cuRobo planner example startup by defaulting `num_envs` to one when no Gym configuration merge occurs. It also builds the simulation in headless mode first and opens the interactive viewer only after the robot and obstacles are loaded and placed at their final initial poses.

This prevents the example from raising a `TypeError` when `--num_envs` is omitted and avoids opening the viewer before scene setup is complete.

Dependencies: None.

Issue: N/A (reported directly; no linked GitHub issue).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

Not applicable.

## Testing

- `black .`
- `black --check --diff --color ./`
- `pytest tests/sim/planners/test_curobo_planner.py` (31 passed, 3 skipped)
- `pytest tests` (772 passed, 103 skipped)
- Interactive cuRobo example run with delayed viewer startup, forward planning, trajectory replay, and return planning

## Checklist

- [x] I have run the `black .` command to format the code base.
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Dependencies have been updated, if applicable.