### PR TITLE
Support physics and render configs in gym configuration

### DIFF
--- a/docs/source/guides/configuration.md
+++ b/docs/source/guides/configuration.md
@@ -141,27 +141,44 @@ When a training config references a gym config (via `trainer.gym_config`), the n
 
 ```json
 {
+    "id": "EmbodiedEnv-v1",
+    "num_envs": 4,
     "max_episodes": 100,
     "max_episode_steps": 600,
+    "physics_config": {
+        "gravity": [0.0, 0.0, -9.81],
+        "bounce_threshold": 2.0,
+        "enable_ccd": false,
+        "length_tolerance": 0.05,
+        "speed_tolerance": 0.25
+    },
+    "render_cfg": {
+        "renderer": "auto",
+        "spp": 1,
+        "tone_mapping_enabled": false,
+        "tone_mapping_exposure": 1.0
+    },
+    "robot": {
+        "uid": "robot",
+        "urdf_cfg": {
+            "components": [
+                {
+                    "component_type": "arm",
+                    "urdf_path": "robots/my_robot/my_robot.urdf"
+                }
+            ]
+        }
+    },
+    "sensor": [
+        {
+            "uid": "cam_high",
+            "type": "StereoCamera",
+            "height": 540,
+            "width": 960
+        }
+    ],
     "env": {
-        "num_envs": 4,
-        "sim_cfg": {
-            "sim_device": "cuda:0",
-            "headless": true
-        },
-        "robot": {
-            "uid": "robot",
-            "urdf_cfg": {"fpath": "robots/my_robot/my_robot.urdf"}
-        },
         "control_parts": ["arm"],
-        "sensor": [
-            {
-                "uid": "cam_high",
-                "type": "StereoCamera",
-                "height": 540,
-                "width": 960
-            }
-        ],
         "actions": {
             "delta_qpos": {
                 "func": "DeltaQposTerm",

--- a/docs/source/overview/sim/sim_manager.md
+++ b/docs/source/overview/sim/sim_manager.md
@@ -56,7 +56,9 @@ The {class}`~cfg.PhysicsCfg` class controls the global physics simulation parame
 | `length_tolerance` | `float` | `0.05` | The length tolerance for the simulation. Larger values increase speed. |
 | `speed_tolerance` | `float` | `0.25` | The speed tolerance for the simulation. Larger values increase speed. |
 
-For more parameters and details, refer to the [PhysicsCfg](https://dexforce.github.io/EmbodiChain/api_reference/embodichain/embodichain.lab.sim.html#embodichain.lab.sim.cfg.PhysicsCfg) documentation.
+PCM and TGS remain enabled, enhanced determinism remains disabled, and friction
+is evaluated on every solver iteration. These solver implementation details use
+fixed defaults and are not exposed by `PhysicsCfg`.
 
 ### Render Configuration
 

--- a/embodichain/lab/gym/utils/gym_utils.py
+++ b/embodichain/lab/gym/utils/gym_utils.py
@@ -411,7 +411,10 @@ def config_to_cfg(config: dict, manager_modules: list = None) -> "EmbodiedEnvCfg
         RigidObjectGroupCfg,
         ArticulationCfg,
         LightCfg,
+        PhysicsCfg,
+        RenderCfg,
     )
+    from embodichain.lab.sim import SimulationManagerCfg
     from embodichain.lab.sim.sensors import SensorCfg
     from embodichain.lab.gym.envs import EmbodiedEnvCfg
     from embodichain.lab.gym.envs.managers import (
@@ -444,6 +447,24 @@ def config_to_cfg(config: dict, manager_modules: list = None) -> "EmbodiedEnvCfg
 
     env_cfg.max_episode_steps = config.get("max_episode_steps", 300)
     env_cfg.num_envs = config.get("num_envs", 1)
+
+    physics_config = deepcopy(config.get("physics_config", {}))
+    if "gravity" in physics_config:
+        physics_config["gravity"] = np.asarray(physics_config["gravity"])
+
+    render_config = deepcopy(config.get("render_cfg", {}))
+    if "renderer" in config:
+        # Keep the existing flat renderer option as the command-line override.
+        render_config["renderer"] = config["renderer"]
+
+    env_cfg.sim_cfg = SimulationManagerCfg(
+        headless=config.get("headless", False),
+        sim_device=config.get("device", "cpu"),
+        render_cfg=RenderCfg(**render_config),
+        gpu_id=config.get("gpu_id", 0),
+        arena_space=config.get("arena_space", 5.0),
+        physics_config=PhysicsCfg(**physics_config),
+    )
 
     # parser robot config
     # TODO: support multiple robots cfg initialization from config, eg, cobotmagic, dexforce_w1, etc.
@@ -816,8 +837,10 @@ def add_env_launcher_args_to_parser(
         "--renderer",
         type=str,
         choices=["auto", "hybrid", "fast-rt", "rt"],
-        default="auto",
-        help="Renderer backend to use for the simulation.",
+        default=None if require_gym_config else "auto",
+        help="Renderer backend to use for the simulation. When loading a gym "
+        "config, the configured render_cfg.renderer is used unless this option "
+        "is provided.",
     )
     parser.add_argument(
         "--arena_space",
@@ -902,7 +925,8 @@ def merge_args_with_gym_config(args: argparse.Namespace, gym_config: dict) -> di
         merged_config["num_envs"] = args.num_envs
     merged_config["device"] = args.device
     merged_config["headless"] = args.headless
-    merged_config["renderer"] = args.renderer
+    if args.renderer is not None:
+        merged_config["renderer"] = args.renderer
     merged_config["gpu_id"] = args.gpu_id
     merged_config["arena_space"] = args.arena_space
     if args.max_episodes is not None:
@@ -927,8 +951,6 @@ def build_env_cfg_from_args(
     """
     from embodichain.utils.utility import load_config
     from embodichain.lab.gym.envs import EmbodiedEnvCfg
-    from embodichain.lab.sim import SimulationManagerCfg
-    from embodichain.lab.sim.cfg import RenderCfg
 
     gym_config = load_config(args.gym_config)
     gym_config = merge_args_with_gym_config(args, gym_config)
@@ -960,14 +982,6 @@ def build_env_cfg_from_args(
     if args.action_config is not None:
         action_config = load_config(args.action_config)
         action_config["action_config"] = action_config
-
-    cfg.sim_cfg = SimulationManagerCfg(
-        headless=gym_config["headless"],
-        sim_device=gym_config["device"],
-        render_cfg=RenderCfg(renderer=gym_config["renderer"]),
-        gpu_id=gym_config["gpu_id"],
-        arena_space=gym_config["arena_space"],
-    )
 
     return cfg, gym_config, action_config
 

--- a/embodichain/lab/sim/cfg.py
+++ b/embodichain/lab/sim/cfg.py
@@ -139,20 +139,8 @@ class PhysicsCfg:
     bounce_threshold: float = 2.0
     """The speed threshold below which collisions will not produce bounce effects."""
 
-    enable_pcm: bool = True
-    """Enable persistent contact manifold (PCM) for improved collision handling."""
-
-    enable_tgs: bool = True
-    """Enable temporal gauss-seidel (TGS) solver for better stability."""
-
     enable_ccd: bool = False
     """Enable continuous collision detection (CCD) for fast-moving objects."""
-
-    enable_enhanced_determinism: bool = False
-    """Enable enhanced determinism for consistent simulation results."""
-
-    enable_friction_every_iteration: bool = True
-    """Enable friction calculations at every solver iteration."""
 
     length_tolerance: float = 0.05
     """The length tolerance for the simulation.
@@ -166,15 +154,19 @@ class PhysicsCfg:
     """
 
     def to_dexsim_args(self) -> Dict[str, Any]:
-        """Convert to dexsim physics args dictionary."""
+        """Convert to DexSim physics arguments.
+
+        Solver implementation details that are not exposed by :class:`PhysicsCfg`
+        retain their established defaults here.
+        """
         args = {
             "gravity": self.gravity.tolist(),
             "bounce_threshold": self.bounce_threshold,
-            "enable_pcm": self.enable_pcm,
-            "enable_tgs": self.enable_tgs,
+            "enable_pcm": True,
+            "enable_tgs": True,
             "enable_ccd": self.enable_ccd,
-            "enable_enhanced_determinism": self.enable_enhanced_determinism,
-            "enable_friction_every_iteration": self.enable_friction_every_iteration,
+            "enable_enhanced_determinism": False,
+            "enable_friction_every_iteration": True,
         }
         return args
 

--- a/tests/gym/utils/test_gym_utils.py
+++ b/tests/gym/utils/test_gym_utils.py
@@ -28,6 +28,7 @@ import torch
 from tensordict import TensorDict
 
 from embodichain.lab.gym.utils.gym_utils import (
+    add_env_launcher_args_to_parser,
     build_env_cfg_from_args,
     build_trajectory_buffer,
     config_to_cfg,
@@ -299,6 +300,20 @@ def test_merge_args_with_gym_config_keeps_default_max_episodes():
     assert merged_config["max_episodes"] == 3
 
 
+def test_launcher_preserves_gym_renderer_when_cli_omits_override():
+    """A required gym config supplies the renderer unless CLI overrides it."""
+    parser = argparse.ArgumentParser()
+    add_env_launcher_args_to_parser(parser, require_gym_config=True)
+
+    args = parser.parse_args(["--gym_config", "gym_config.yaml"])
+    gym_config = {"id": "Dummy-v0", "render_cfg": {"renderer": "rt"}}
+    merged_config = merge_args_with_gym_config(args, gym_config)
+
+    assert args.renderer is None
+    assert "renderer" not in merged_config
+    assert merged_config["render_cfg"]["renderer"] == "rt"
+
+
 def test_sensor_and_extra_obs_together():
     """Test that both sensors and extra observations work together."""
     config = {
@@ -394,6 +409,19 @@ class TestConfigToCfgFromFile:
         config = {
             "id": "EmbodiedEnv-v1",
             "max_episode_steps": 100,
+            "physics_config": {
+                "gravity": [0.0, 0.0, -1.62],
+                "bounce_threshold": 1.5,
+                "enable_ccd": True,
+                "length_tolerance": 0.02,
+                "speed_tolerance": 0.1,
+            },
+            "render_cfg": {
+                "renderer": "rt",
+                "spp": 4,
+                "tone_mapping_enabled": True,
+                "tone_mapping_exposure": 1.25,
+            },
             "env": {
                 "events": {},
                 "observations": {},
@@ -423,6 +451,17 @@ class TestConfigToCfgFromFile:
 
         assert cfg.max_episode_steps == 100
         assert cfg.robot.uid == "TestRobot"
+        np.testing.assert_array_equal(
+            cfg.sim_cfg.physics_config.gravity, [0.0, 0.0, -1.62]
+        )
+        assert cfg.sim_cfg.physics_config.bounce_threshold == 1.5
+        assert cfg.sim_cfg.physics_config.enable_ccd is True
+        assert cfg.sim_cfg.physics_config.length_tolerance == 0.02
+        assert cfg.sim_cfg.physics_config.speed_tolerance == 0.1
+        assert cfg.sim_cfg.render_cfg.renderer == "rt"
+        assert cfg.sim_cfg.render_cfg.spp == 4
+        assert cfg.sim_cfg.render_cfg.tone_mapping_enabled is True
+        assert cfg.sim_cfg.render_cfg.tone_mapping_exposure == 1.25
 
     def test_json_dataset_save_failed_episodes_parses_from_top_level(self, tmp_path):
         config = {
@@ -469,6 +508,15 @@ class TestConfigToCfgFromFile:
         config = {
             "id": "EmbodiedEnv-v1",
             "max_episode_steps": 100,
+            "physics_config": {
+                "gravity": [0.0, 0.0, -3.71],
+                "enable_ccd": True,
+            },
+            "render_cfg": {
+                "renderer": "rt",
+                "spp": 8,
+                "tone_mapping_enabled": True,
+            },
             "env": {"events": {}, "observations": {}, "rewards": {}},
             "robot": {
                 "uid": "TestRobot",
@@ -492,7 +540,7 @@ class TestConfigToCfgFromFile:
             num_envs=1,
             device="cpu",
             headless=True,
-            renderer="rasterization",
+            renderer="fast-rt",
             gpu_id=0,
             arena_space=2.0,
             max_episodes=None,
@@ -509,6 +557,13 @@ class TestConfigToCfgFromFile:
 
         assert merged_config["max_episode_steps"] == 321
         assert cfg.max_episode_steps == 321
+        np.testing.assert_array_equal(
+            cfg.sim_cfg.physics_config.gravity, [0.0, 0.0, -3.71]
+        )
+        assert cfg.sim_cfg.physics_config.enable_ccd is True
+        assert cfg.sim_cfg.render_cfg.renderer == "fast-rt"
+        assert cfg.sim_cfg.render_cfg.spp == 8
+        assert cfg.sim_cfg.render_cfg.tone_mapping_enabled is True
 
     @pytest.mark.parametrize(
         ("replay_mode", "expected"),

--- a/tests/sim/test_cfg.py
+++ b/tests/sim/test_cfg.py
@@ -21,7 +21,28 @@ import pytest
 
 from dexsim.types import DenoiserType, Renderer, ToneMappingType
 
-from embodichain.lab.sim.cfg import RenderCfg
+from embodichain.lab.sim.cfg import PhysicsCfg, RenderCfg
+
+
+def test_physics_cfg_does_not_expose_fixed_solver_options() -> None:
+    """Fixed solver implementation details are not part of the public config."""
+    physics_cfg = PhysicsCfg()
+
+    assert not hasattr(physics_cfg, "enable_pcm")
+    assert not hasattr(physics_cfg, "enable_tgs")
+    assert not hasattr(physics_cfg, "enable_enhanced_determinism")
+    assert not hasattr(physics_cfg, "enable_friction_every_iteration")
+
+
+def test_physics_cfg_applies_fixed_solver_defaults() -> None:
+    """Removed solver options retain their established DexSim defaults."""
+    physics_args = PhysicsCfg(enable_ccd=True).to_dexsim_args()
+
+    assert physics_args["enable_pcm"] is True
+    assert physics_args["enable_tgs"] is True
+    assert physics_args["enable_ccd"] is True
+    assert physics_args["enable_enhanced_determinism"] is False
+    assert physics_args["enable_friction_every_iteration"] is True
 
 
 def test_render_cfg_applies_default_denoiser() -> None:


### PR DESCRIPTION
## Description

This PR simplifies `PhysicsCfg` by removing four solver implementation options from the public configuration while retaining their established DexSim defaults.

It also adds top-level `physics_config` and `render_cfg` parsing to gym JSON/YAML files. Launcher-provided renderer values remain explicit overrides, while an omitted `--renderer` now preserves `render_cfg.renderer`.

The configuration guide and simulation manager documentation include the updated public surface and file-based configuration example.

Dependencies: None.

Issue: No issue linked.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which improves an existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (existing functionality will not work without user modification)
- [ ] Documentation update

## Screenshots

Not applicable.

## Testing

- `pytest tests -q`: 797 passed, 103 skipped
- `pytest tests/sim/test_cfg.py tests/gym/utils/test_gym_utils.py -q`: 30 passed
- Black passes for all files included in this PR
- `git diff --check` passes

The strict Sphinx `-W` build was attempted and reached the project-wide pre-existing documentation warnings/errors; no new warning was identified in the changed pages.

## Checklist

- [x] I have run Black to format the changed Python files.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove the change works.
- [x] Dependencies are unchanged.
