### PR TITLE
Add compressed depth sidecar video for LeRobot datasets

### DIFF
--- a/docs/source/overview/gym/dataset_functors.md
+++ b/docs/source/overview/gym/dataset_functors.md
@@ -84,6 +84,8 @@ The ``LeRobotRecorder`` functor enables recording robot learning episodes in the
   - Number of background threads for per-frame PNG writing (lerobot ``AsyncImageWriter``). When > 0, ``add_frame`` no longer blocks on ``PIL.Image.save``. Applies to both recorders. Try 4 threads per camera as a starting point.
 * - ``image_writer_processes``
   - Number of background processes for image writing (alternative to threads; higher spawn cost, more isolation). Use 0 to rely on threads only.
+* - ``depth_video``
+  - Optional :class:`~embodichain.data_pipeline.depth_video.DepthVideoCfg` (or dict) to store camera depth as compressed ``gray12le``/HEVC sidecar videos instead of dense numeric arrays. See [Compressed depth sidecar](#compressed-depth-sidecar).
 ```
 
 ### Recorded Data
@@ -94,14 +96,76 @@ The LeRobotRecorder saves the following data for each frame:
 - ``action``: Applied action
 - ``observation.images.{sensor_name}``: Camera images (if sensors present)
 - ``observation.images.{sensor_name}_right``: Right camera images (for stereo cameras)
-- ``observation.depth.{sensor_name}``: Native numeric depth arrays
-- ``observation.depth.{sensor_name}_right``: Right-camera depth arrays
 - ``observation.mask.{sensor_name}``: Native numeric segmentation-mask arrays
 - ``observation.mask.{sensor_name}_right``: Right-camera segmentation-mask arrays
 
 Depth and mask features keep the dtype and shape declared by the sensor
-observation space. They are stored as numeric LeRobot array features rather than
-images, so enabling ``use_videos`` affects only the RGB image features.
+observation space. Masks are always stored as numeric LeRobot array features
+(exact, lossless) so ``use_videos`` affects only the RGB image features.
+
+Depth has two storage modes:
+
+- **Numeric** (default): ``observation.depth.{sensor_name}`` numeric arrays, exact
+  but storage-heavy for dense high-resolution depth.
+- **Compressed sidecar** (when ``depth_video.enable=True``): depth is written as
+  ``gray12le``/HEVC MP4s alongside the dataset (see below), and the numeric
+  feature is dropped unless ``keep_numeric_fallback=True``.
+
+## Compressed depth sidecar
+
+When ``depth_video.enable=True`` and an HEVC encoder (``libx265``) is available,
+``LeRobotRecorder`` writes each episode's depth maps as a single-channel
+``gray12le`` video encoded losslessly with HEVC. This is issue #424 *Path A*:
+an EmbodiChain-owned depth writer that works on Python 3.10/3.11 with LeRobot
+0.4.4, without modifying the installed LeRobot package.
+
+- Depth is quantized to 12-bit codes (logarithmic by default) and packed into
+  the ``gray12le`` pixel format. With ``lossless=True`` (default) the 12-bit
+  codes survive the encode/decode round-trip bit-exactly; the only error is the
+  configurable float32 → 12-bit quantization step (typically sub-millimetre).
+- Depth never enters LeRobot's RGB-only image/video pipeline; it lives in a
+  sidecar tree next to the dataset:
+
+  ```text
+  <dataset_root>/
+  ├── data/                 # LeRobot: state / action / mask
+  ├── videos/               # LeRobot: RGB videos
+  ├── depth_videos/         # depth sidecar
+  │   └── <sensor>[_right]/episode_000000.mp4
+  └── depth_meta.json       # quantization params + per-episode index
+  ```
+
+- The metadata schema (``is_depth_map``, ``video.depth_min/max/shift/use_log``,
+  ``video.codec``, ``video.pix_fmt``) is aligned with the official LeRobot 0.6.0
+  depth pipeline, so sidecar videos remain readable once EmbodiChain upgrades to
+  Python 3.12 (issue #424, Path B).
+- If no HEVC encoder is available, recording silently falls back to numeric
+  depth features (PR #422) rather than failing.
+- Segmentation masks are always kept as exact numeric features; they are never
+  run through a lossy video codec.
+
+```{attention}
+12-bit quantization is **not** bit-exact relative to the original float32 or
+uint16 depth input. Applications requiring exact source values must set
+``keep_numeric_fallback=True`` (stores both the sidecar video and the raw
+numeric feature) or keep depth numeric.
+```
+
+Read sidecar depth back with :func:`~embodichain.data_pipeline.depth_video.load_depth_dataset`,
+which composes the LeRobot dataset with a :class:`~embodichain.data_pipeline.depth_video.DepthVideoLibrary`:
+
+```python
+from embodichain.data_pipeline.depth_video import load_depth_dataset
+
+dataset, depth = load_depth_dataset("/path/to/dataset_root")
+# depth in metres, shape (1, H, W), aligned to the LeRobot episode/frame index:
+frame = dataset[0]
+depth_map = depth.get(
+    episode_index=int(frame["episode_index"]),
+    sensor_key="camera",
+    frame_index_in_episode=int(frame["episode_data_index"]),
+)
+```
 
 ### Dataset Recording vs Video Recording
 
@@ -229,7 +293,41 @@ dataset = {
 }
 ```
 
-The async recorder drains its background worker during ``finalize()``, so make sure ``env.close()`` (or ``dataset_manager.finalize()``) runs at the end of collection.
+The async recorder drains its background worker during ``finalize()``, so make sure ``env.close()`` (or ``dataset_manager.finalize()`) runs at the end of collection.
+
+### Compressed depth recording
+
+To record camera depth as compressed sidecar videos (issue #424, Path A), pass a
+``depth_video`` config. Depth is encoded losslessly as ``gray12le``/HEVC;
+stereo cameras get a ``_right`` sidecar automatically.
+
+```python
+from embodichain.lab.gym.envs.managers.cfg import DatasetFunctorCfg
+
+dataset = {
+    "lerobot_recorder": DatasetFunctorCfg(
+        func="embodichain.lab.gym.envs.managers.datasets.LeRobotRecorder",
+        params={
+            "save_path": "/path/to/dataset/root",
+            "robot_meta": {"robot_type": "dexforce_w1", "control_freq": 30},
+            "instruction": {"lang": "pick the cube"},
+            "extra": {"scene_type": "table", "task_description": "pick_and_place"},
+            "use_videos": False,
+            "depth_video": {
+                "enable": True,
+                "depth_min": 0.05,   # metres mapped to quantum 0
+                "depth_max": 5.0,    # metres mapped to quantum 4095
+                "shift": 3.5,        # log-mode offset (metres)
+                "use_log": True,     # logarithmic quantization
+                "lossless": True,    # 12-bit codes preserved bit-exactly
+                "input_unit": "m",
+                "output_unit": "m",
+                # "keep_numeric_fallback": True,  # also keep raw numeric depth
+            },
+        },
+    ),
+}
+```
 
 ## Dataset Manager Modes
 

--- a/docs/source/tutorial/data_generation.rst
+++ b/docs/source/tutorial/data_generation.rst
@@ -87,10 +87,13 @@ Important parameters are:
 format: ``observation.state`` for joint positions, ``action`` for applied
 actions, and ``observation.images.{sensor_name}`` for RGB camera images. When a
 camera also produces depth or segmentation data, the recorder preserves those
-numeric arrays under ``observation.depth.{sensor_name}`` and
-``observation.mask.{sensor_name}``. Stereo-camera keys use the ``_right``
-suffix. Depth and mask arrays retain their source dtype and shape; the
-``use_videos`` option applies only to RGB images.
+arrays: masks are always stored as exact numeric features under
+``observation.mask.{sensor_name}``, while depth is stored either as a numeric
+feature (``observation.depth.{sensor_name}``, the default) or as compressed
+``gray12le``/HEVC sidecar videos when ``dataset.lerobot.params.depth_video.enable``
+is set (issue #424, Path A). Stereo-camera keys use the ``_right`` suffix. The
+``use_videos`` option applies only to RGB images; see
+:doc:`/overview/gym/dataset_functors` for the depth sidecar configuration.
 
 Step 2: Prepare the Action Configuration
 ----------------------------------------

--- a/embodichain/data_pipeline/__init__.py
+++ b/embodichain/data_pipeline/__init__.py
@@ -15,6 +15,7 @@
 # ----------------------------------------------------------------------------
 
 from . import datasets
+from . import depth_video
 from . import engine
 
-__all__ = ["datasets", "engine"]
+__all__ = ["datasets", "depth_video", "engine"]

--- a/embodichain/data_pipeline/depth_video/__init__.py
+++ b/embodichain/data_pipeline/depth_video/__init__.py
@@ -1,0 +1,74 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+"""Compressed depth sidecar storage for LeRobot datasets on Python 3.10/3.11.
+
+This package implements issue #424 *Path A*: an EmbodiChain-owned depth writer
+that stores camera depth as ``gray12le``/HEVC sidecar videos alongside a
+LeRobot dataset, without modifying the installed LeRobot package and without
+requiring Python 3.12.
+
+Depth quantization math is vendored from lerobot v0.6.0 so that sidecar videos
+remain binary-compatible with the official reader once the project upgrades to
+Python 3.12 (issue #424, Path B).
+"""
+
+from __future__ import annotations
+
+from .cfg import DepthVideoCfg
+from .codec import DepthCodecError, detect_depth_encoder, resolve_depth_vcodec
+from .depth_utils import (
+    DEFAULT_DEPTH_MAX,
+    DEFAULT_DEPTH_MIN,
+    DEFAULT_DEPTH_PIX_FMT,
+    DEFAULT_DEPTH_SHIFT,
+    DEFAULT_DEPTH_USE_LOG,
+    DEPTH_METER_UNIT,
+    DEPTH_MILLIMETER_UNIT,
+    DEPTH_QMAX,
+    dequantize_depth,
+    quantize_depth,
+)
+from .reader import (
+    DepthVideoLibrary,
+    DepthVideoReader,
+    load_depth_dataset,
+    load_depth_meta,
+)
+from .writer import DepthSidecarManager, DepthVideoWriter
+
+__all__ = [
+    "DepthVideoCfg",
+    "DepthCodecError",
+    "detect_depth_encoder",
+    "resolve_depth_vcodec",
+    "DEFAULT_DEPTH_MIN",
+    "DEFAULT_DEPTH_MAX",
+    "DEFAULT_DEPTH_SHIFT",
+    "DEFAULT_DEPTH_USE_LOG",
+    "DEFAULT_DEPTH_PIX_FMT",
+    "DEPTH_METER_UNIT",
+    "DEPTH_MILLIMETER_UNIT",
+    "DEPTH_QMAX",
+    "quantize_depth",
+    "dequantize_depth",
+    "DepthVideoWriter",
+    "DepthSidecarManager",
+    "DepthVideoReader",
+    "DepthVideoLibrary",
+    "load_depth_dataset",
+    "load_depth_meta",
+]

--- a/embodichain/data_pipeline/depth_video/cfg.py
+++ b/embodichain/data_pipeline/depth_video/cfg.py
@@ -1,0 +1,83 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+"""Configuration for compressed depth sidecar storage."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from embodichain.utils import configclass
+
+from .depth_utils import (
+    DEFAULT_DEPTH_MAX,
+    DEFAULT_DEPTH_MIN,
+    DEFAULT_DEPTH_PIX_FMT,
+    DEFAULT_DEPTH_SHIFT,
+    DEFAULT_DEPTH_USE_LOG,
+)
+
+__all__ = ["DepthVideoCfg"]
+
+# Codebase version stamped into ``depth_meta.json`` so a future migration to the
+# official lerobot 0.6.0 depth pipeline (issue #424, Path B) can recognise and
+# convert sidecar videos produced by this writer.
+EMBODI_DEPTH_CODEBASE_VERSION = "embodi-depth-v1"
+
+
+@configclass
+class DepthVideoCfg:
+    """Configuration for the compressed depth sidecar writer.
+
+    Depth is quantized to 12-bit codes and encoded as a single-channel
+    ``gray12le`` video. With ``lossless=True`` (default) the 12-bit codes are
+    preserved bit-exactly by HEVC; the only error is the configurable
+    float32 -> 12-bit quantization step.
+
+    Attributes:
+        enable: If False, depth is stored as numeric LeRobot features (PR #422).
+        vcodec: Video codec for depth. Defaults to ``"libx265"`` (HEVC), which
+            supports 12-bit grayscale losslessly on typical FFmpeg builds.
+        lossless: If True, encode with HEVC lossless mode so 12-bit codes are
+            bit-exact. If False, use ``crf`` for lossy encoding.
+        crf: Constant rate factor for lossy mode (ignored when ``lossless=True``).
+            Lower is higher quality; 0 is lossless for libx265.
+        depth_min: Depth (metres) mapped to quantum 0.
+        depth_max: Depth (metres) mapped to quantum ``DEPTH_QMAX``.
+        shift: Pre-log offset (metres) for numerical stability near zero.
+        use_log: Logarithmic (True) or linear (False) quantization.
+        pix_fmt: Pixel format for the depth video. ``gray12le`` carries the
+            12-bit codes in a single channel.
+        input_unit: Unit of the incoming depth arrays (``"auto"`` infers from
+            dtype: float -> metres, int -> millimetres).
+        output_unit: Unit returned by the reader (``"m"`` or ``"mm"``).
+        keep_numeric_fallback: If True, also keep depth as a numeric LeRobot
+            feature (exact raw values, ~2x depth storage). If False, depth lives
+            only in the sidecar videos.
+    """
+
+    enable: bool = False
+    vcodec: str = "libx265"
+    lossless: bool = True
+    crf: int = 0
+    depth_min: float = DEFAULT_DEPTH_MIN
+    depth_max: float = DEFAULT_DEPTH_MAX
+    shift: float = DEFAULT_DEPTH_SHIFT
+    use_log: bool = DEFAULT_DEPTH_USE_LOG
+    pix_fmt: str = DEFAULT_DEPTH_PIX_FMT
+    input_unit: Literal["auto", "m", "mm"] = "auto"
+    output_unit: Literal["m", "mm"] = "m"
+    keep_numeric_fallback: bool = False

--- a/embodichain/data_pipeline/depth_video/codec.py
+++ b/embodichain/data_pipeline/depth_video/codec.py
@@ -1,0 +1,91 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+"""Codec availability detection for depth video encoding.
+
+Adapted from lerobot v0.6.0 ``pyav_utils.py`` (Apache-2.0). Probes the bundled
+FFmpeg build through PyAV so the writer can pick a working encoder and degrade
+gracefully (to numeric Parquet depth, PR #422) when HEVC is unavailable.
+"""
+
+from __future__ import annotations
+
+import functools
+
+import av
+
+__all__ = ["DepthCodecError", "detect_depth_encoder", "resolve_depth_vcodec"]
+
+
+class DepthCodecError(RuntimeError):
+    """Raised when no suitable depth video codec is available."""
+
+
+@functools.cache
+def get_codec(vcodec: str) -> av.codec.Codec | None:
+    """PyAV write-mode ``Codec`` for *vcodec*, or ``None`` if unavailable."""
+    try:
+        return av.codec.Codec(vcodec, "w")
+    except Exception:
+        return None
+
+
+def detect_depth_encoder(vcodec: str | None = None) -> str | None:
+    """Return an available depth video encoder name, or ``None``.
+
+    Args:
+        vcodec: Preferred codec name. If ``None`` or unavailable, fall back to
+            the default preference list (``libx265`` then ``hevc``).
+
+    Returns:
+        The first available encoder name, or ``None`` if none are available.
+    """
+    preference: list[str] = []
+    if vcodec:
+        preference.append(vcodec)
+    for name in ("libx265", "hevc"):
+        if name not in preference:
+            preference.append(name)
+
+    for name in preference:
+        codec = get_codec(name)
+        if codec is not None and codec.type == "video":
+            return name
+    return None
+
+
+def resolve_depth_vcodec(vcodec: str | None = None) -> str:
+    """Return an available depth video encoder name, raising on failure.
+
+    Args:
+        vcodec: Preferred codec name.
+
+    Returns:
+        An available encoder name.
+
+    Raises:
+        DepthCodecError: If no depth video encoder is available in the bundled
+            FFmpeg build.
+    """
+    name = detect_depth_encoder(vcodec)
+    if name is None:
+        raise DepthCodecError(
+            "No HEVC video encoder (libx265/hevc) is available in the bundled "
+            "FFmpeg build; cannot write compressed depth videos. Install an "
+            "FFmpeg build with libx265, or disable depth video to fall back to "
+            "numeric depth features (PR #422)."
+        )
+    return name

--- a/embodichain/data_pipeline/depth_video/depth_utils.py
+++ b/embodichain/data_pipeline/depth_video/depth_utils.py
@@ -1,0 +1,395 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+#
+# Depth quantization helpers adapted from lerobot v0.6.0
+# (``src/lerobot/datasets/depth_utils.py``, ``pyav_utils.py``,
+# ``image_writer.py`` and ``configs/video.py``), Apache-2.0.
+#
+# Vendored verbatim in math so that sidecar depth videos produced here are
+# binary-compatible with the official lerobot 0.6.0 reader once EmbodiChain
+# raises its Python baseline to 3.12 (see issue #424, Path B).
+
+"""Depth quantization/dequantization for compressed depth sidecar videos.
+
+Depth maps are packed into 12-bit integer codes (``uint16``, values
+``0…DEPTH_QMAX``) so they fit the ``gray12le`` pixel format and can be encoded
+losslessly by HEVC (``libx265``). Logarithmic quantization is the default
+because it allocates more quanta to near-range depth, matching the
+``1/depth`` error profile of typical depth sensors.
+
+The math is ported from lerobot 0.6.0 (itself adapted from BEHAVIOR-1K's
+``obs_utils.py``) and depends only on :mod:`av`, :mod:`numpy` and
+:mod:`torch` -- all of which run on Python 3.10/3.11. See issue #424.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Literal
+
+import av
+import numpy as np
+import torch
+from numpy.typing import NDArray
+
+__all__ = [
+    "DEPTH_QUANT_BITS",
+    "DEPTH_QMAX",
+    "DEPTH_METER_UNIT",
+    "DEPTH_MILLIMETER_UNIT",
+    "DEFAULT_DEPTH_MIN",
+    "DEFAULT_DEPTH_MAX",
+    "DEFAULT_DEPTH_SHIFT",
+    "DEFAULT_DEPTH_USE_LOG",
+    "DEFAULT_DEPTH_PIX_FMT",
+    "MM_PER_METRE",
+    "infer_depth_unit",
+    "squeeze_single_channel",
+    "write_u16_plane",
+    "quantize_depth",
+    "dequantize_depth",
+]
+
+# ---------------------------------------------------------------------------
+# Constants (from lerobot ``configs/video.py``).
+# ---------------------------------------------------------------------------
+
+DEPTH_QUANT_BITS: int = 12
+DEPTH_QMAX: int = (1 << DEPTH_QUANT_BITS) - 1  # 4095
+
+DEFAULT_DEPTH_MIN: float = 0.01
+DEFAULT_DEPTH_MAX: float = 10.0
+DEFAULT_DEPTH_SHIFT: float = 3.5
+DEFAULT_DEPTH_USE_LOG: bool = True
+DEFAULT_DEPTH_PIX_FMT: str = "gray12le"
+
+DEPTH_METER_UNIT: str = "m"
+DEPTH_MILLIMETER_UNIT: str = "mm"
+
+MM_PER_METRE = 1000.0
+_UINT16_MAX = 65535
+
+
+def infer_depth_unit(dtype: np.dtype | type) -> str:
+    """Infer the depth unit from the array dtype.
+
+    Floating-point arrays are interpreted as metres, integer arrays as
+    millimetres -- the lerobot convention.
+
+    Args:
+        dtype: NumPy dtype (or anything coercible to one).
+
+    Returns:
+        ``"m"`` or ``"mm"``.
+    """
+    return (
+        DEPTH_METER_UNIT
+        if np.issubdtype(np.dtype(dtype), np.floating)
+        else DEPTH_MILLIMETER_UNIT
+    )
+
+
+def squeeze_single_channel(array: np.ndarray) -> np.ndarray:
+    """Drop a leading or trailing singleton channel dim: ``(1, H, W)`` / ``(H, W, 1)`` -> ``(H, W)``.
+
+    Unlike ``array.squeeze()``, this only removes the channel axis, never an
+    ``H`` or ``W`` of size 1.
+    """
+    if array.ndim == 3:
+        if array.shape[0] == 1:
+            return array[0]
+        if array.shape[-1] == 1:
+            return array[..., 0]
+    return array
+
+
+def write_u16_plane(
+    plane: av.video.plane.VideoPlane, src: np.ndarray, fill_value: int | None = None
+) -> None:
+    """Copy a 2D ``uint16`` image into the plane's memory buffer, row by row.
+
+    For speed, each row is padded to a wider size than ``width``, so the true row width in
+    memory is ``plane.line_size`` (bytes), not ``width``. Copying as one straight stream
+    would skew the image, so we write only the first ``width`` columns of each row and
+    leave the padding untouched.
+
+    Args:
+        plane: Destination 16-bit plane.
+        src: Source image, shape ``(height, width)``, dtype ``uint16``.
+        fill_value: If given, every pixel (padding included) is set to this first, so the
+            padding holds clean data instead of garbage.
+    """
+    height, width = src.shape
+    stride_u16 = plane.line_size // np.dtype(np.uint16).itemsize
+    dst = np.frombuffer(plane, dtype=np.uint16).reshape(height, stride_u16)
+    if fill_value is not None:
+        dst.fill(fill_value)
+    dst[:, :width] = src
+
+
+# ---------------------------------------------------------------------------
+# Quantization / dequantization (from lerobot ``depth_utils.py``).
+# ---------------------------------------------------------------------------
+
+
+def _validate_log_quant_params(depth_min: float, shift: float) -> None:
+    """Ensure ``log(depth_min + shift)`` is finite."""
+    if depth_min + shift <= 0:
+        raise ValueError(
+            f"depth_min + shift must be positive for logarithmic quantization, "
+            f"got depth_min={depth_min} + shift={shift} = {depth_min + shift}"
+        )
+
+
+def _depth_input_to_float32_and_unit(
+    depth: NDArray[np.integer] | NDArray[np.floating],
+    input_unit: Literal["auto", DEPTH_METER_UNIT, DEPTH_MILLIMETER_UNIT],
+) -> tuple[NDArray[np.float32], Literal[DEPTH_METER_UNIT, DEPTH_MILLIMETER_UNIT]]:
+    """Convert depth to float32 in the chosen unit, and return the resolved unit."""
+    resolved_unit = (
+        infer_depth_unit(depth.dtype) if input_unit == "auto" else input_unit
+    )
+    return depth.astype(np.float32, order="K"), resolved_unit
+
+
+def quantize_depth(
+    depth: NDArray[np.uint16] | NDArray[np.float32] | torch.Tensor,
+    depth_min: float = DEFAULT_DEPTH_MIN,
+    depth_max: float = DEFAULT_DEPTH_MAX,
+    shift: float = DEFAULT_DEPTH_SHIFT,
+    use_log: bool = DEFAULT_DEPTH_USE_LOG,
+    pix_fmt: str = DEFAULT_DEPTH_PIX_FMT,
+    video_backend: str | None = "pyav",
+    input_unit: Literal["auto", DEPTH_METER_UNIT, DEPTH_MILLIMETER_UNIT] = "auto",
+) -> NDArray[np.uint16] | av.VideoFrame:
+    """Quantize depth to 12-bit codes (``uint16``, values ``0…DEPTH_QMAX``).
+
+    Depth maps are packed into 12-bit integer frames so they fit in standard
+    high-bit-depth pixel formats (e.g. ``yuv420p12le`` / ``gray12le``)
+    and can be encoded by widely supported video codecs (e.g. HEVC Main 12).
+    Logarithmic quantization is the default because it allocates more quanta
+    to near-range depth, which matches the (1/depth) error profile of typical
+    depth sensors. Math is ported from BEHAVIOR-1K's ``obs_utils.py``.
+
+    **Input units**:
+
+    - ``input_unit="auto"`` (default): infer from dtype (floating = m, non-floating = mm).
+    - ``input_unit="mm"``: interpret input values as millimetres.
+    - ``input_unit="m"``: interpret input values as metres.
+
+    Quantization math runs in the **resolved input unit**.
+
+    ``depth_min``, ``depth_max``, and ``shift`` are always in **metres**.
+
+    Args:
+        depth: Depth map; ``torch.Tensor`` is moved to CPU for conversion.
+        depth_min: Depth (metres) at quantum ``0``.
+        depth_max: Depth (metres) at quantum :data:`DEPTH_QMAX`.
+        shift: Depth shift (metres); used in log mode. Must satisfy ``depth_min + shift > 0``.
+        use_log: If ``True`` (default), quantize in log space.
+        video_backend: If ``"pyav"`` (default), return an :class:`av.VideoFrame`
+            ready for encoding; otherwise return the raw ``uint16`` code array.
+        input_unit: Input unit policy (``"auto"``, ``"mm"``, ``"m"``).
+
+    Returns:
+        ``av.VideoFrame`` (when ``video_backend="pyav"``) or ``numpy.ndarray``
+        of ``dtype=uint16``, same spatial shape as ``depth``, values in
+        ``[0, DEPTH_QMAX]``.
+
+    Raises:
+        ValueError: If ``input_unit`` is not ``"auto"``, ``"mm"``, or ``"m"``.
+        ValueError: If ``use_log=True`` and ``depth_min + shift <= 0``.
+    """
+    if input_unit not in ("auto", DEPTH_METER_UNIT, DEPTH_MILLIMETER_UNIT):
+        raise ValueError(
+            f"input_unit must be 'auto', '{DEPTH_METER_UNIT}', or '{DEPTH_MILLIMETER_UNIT}', got {input_unit!r}"
+        )
+
+    if isinstance(depth, torch.Tensor):
+        depth = depth.detach().cpu().numpy()
+
+    # Squeeze single-channel dim: (H, W, 1) or (1, H, W) -> (H, W)
+    depth = squeeze_single_channel(depth)
+
+    depth_f, resolved_unit = _depth_input_to_float32_and_unit(
+        depth, input_unit=input_unit
+    )
+
+    # Convert depth_min, depth_max, and shift to the resolved input unit.
+    depth_min_u = (
+        np.float32(depth_min)
+        if resolved_unit == DEPTH_METER_UNIT
+        else np.float32(depth_min * MM_PER_METRE)
+    )
+    depth_max_u = (
+        np.float32(depth_max)
+        if resolved_unit == DEPTH_METER_UNIT
+        else np.float32(depth_max * MM_PER_METRE)
+    )
+    shift_u = (
+        np.float32(shift)
+        if resolved_unit == DEPTH_METER_UNIT
+        else np.float32(shift * MM_PER_METRE)
+    )
+
+    # Normalization and quantization is performed in the resolved input unit.
+    if use_log:
+        _validate_log_quant_params(depth_min, shift)
+        log_min = math.log(float(depth_min_u + shift_u))
+        log_max = math.log(float(depth_max_u + shift_u))
+        norm = (np.log(depth_f + shift_u) - log_min) / (log_max - log_min)
+    else:
+        norm = (depth_f - depth_min_u) / (depth_max_u - depth_min_u)
+
+    quantized = (
+        np.rint(norm * DEPTH_QMAX).clip(0, DEPTH_QMAX).astype(np.uint16, copy=False)
+    )
+
+    if video_backend == "pyav":
+        frame = av.VideoFrame.from_ndarray(quantized, format=pix_fmt)
+        write_u16_plane(frame.planes[0], quantized)
+        return frame
+    else:
+        return quantized
+
+
+def dequantize_depth(
+    quantized: NDArray[np.uint16] | av.VideoFrame | torch.Tensor,
+    depth_min: float = DEFAULT_DEPTH_MIN,
+    depth_max: float = DEFAULT_DEPTH_MAX,
+    shift: float = DEFAULT_DEPTH_SHIFT,
+    use_log: bool = DEFAULT_DEPTH_USE_LOG,
+    pix_fmt: str = DEFAULT_DEPTH_PIX_FMT,
+    output_unit: Literal[
+        DEPTH_METER_UNIT, DEPTH_MILLIMETER_UNIT
+    ] = DEPTH_MILLIMETER_UNIT,
+    output_tensor: bool = True,
+    output_channel_last: bool = False,
+) -> NDArray[np.uint16] | NDArray[np.float32] | torch.Tensor:
+    """Inverse of :func:`quantize_depth`.
+
+    Decoding inverts the same normalized code mapping as :func:`quantize_depth`
+    using ``depth_min`` / ``depth_max`` / ``shift`` (in metres), then returns
+    the requested output unit. Tuning arguments **must match** :func:`quantize_depth`.
+
+    Accepted input layouts :
+
+    - ``(H, W, 1)`` or ``(H, W)`` - single frame with channel-last.
+    - ``(..., 1, H, W)`` - batched frames with channel-first.
+    - ``(..., H, W, 1)`` - batched frames with channel-last.
+    Output layout is determined by ``output_channel_last``.
+
+    Args:
+        quantized: 12-bit codes in ``[0, DEPTH_QMAX]``. ``np.ndarray``,
+            ``av.VideoFrame``, or ``torch.Tensor`` (any integer or float dtype).
+        depth_min, depth_max, shift, use_log: Same as :func:`quantize_depth` (metres).
+        pix_fmt: Pixel format used to extract the plane from an ``av.VideoFrame``.
+        output_unit: ``"mm"`` returns ``uint16`` millimetres (rint, clip
+            ``[0, 65535]``) when returning a numpy array, or ``float32`` mm when
+            ``output_tensor=True``. ``"m"`` returns ``float32`` metres in
+            ``[depth_min, depth_max]``.
+        output_tensor: If True, return a ``torch.Tensor`` instead of a numpy array.
+        output_channel_last: Channel layout of the output (``(H, W, 1)`` vs ``(1, H, W)``).
+
+    Returns:
+        Depth map in the requested unit and dtype.
+
+    Raises:
+        ValueError: If ``output_unit`` is not ``"m"`` or ``"mm"``.
+        ValueError: If ``use_log=True`` and ``depth_min + shift <= 0``.
+    """
+    if output_unit not in (DEPTH_METER_UNIT, DEPTH_MILLIMETER_UNIT):
+        raise ValueError(
+            f"output_unit must be '{DEPTH_METER_UNIT}' or '{DEPTH_MILLIMETER_UNIT}', got {output_unit!r}"
+        )
+    if use_log:
+        _validate_log_quant_params(depth_min, shift)
+
+    if isinstance(quantized, av.VideoFrame):
+        quantized = quantized.to_ndarray(format=pix_fmt)
+
+    # Compute the scale and offset first.
+    depth_min_m = float(depth_min)
+    depth_max_m = float(depth_max)
+    shift_m = float(shift)
+    if use_log:
+        log_min = math.log(depth_min_m + shift_m)
+        log_max = math.log(depth_max_m + shift_m)
+        scale = (log_max - log_min) / DEPTH_QMAX
+        offset = log_min
+    else:
+        scale = (depth_max_m - depth_min_m) / DEPTH_QMAX
+        offset = depth_min_m
+
+    # ── Torch path: stay on the input device, single fp32 allocation. ────────
+    if isinstance(quantized, torch.Tensor):
+        if quantized.ndim >= 3:
+            # Drop the single-channel dimension so the math runs on (..., H, W).
+            quantized = (
+                quantized.squeeze(-3)
+                if quantized.shape[-3] == 1
+                else quantized.squeeze(-1)
+            )
+
+        # Single allocation we own; everything else is in-place.
+        buf = quantized.to(dtype=torch.float32, copy=True)
+        buf.mul_(scale).add_(offset)
+        if use_log:
+            buf.exp_().sub_(shift_m)
+        buf.clamp_(depth_min_m, depth_max_m)
+        buf.unsqueeze_(-1) if output_channel_last else buf.unsqueeze_(-3)
+
+        if output_unit == DEPTH_METER_UNIT:
+            return buf if output_tensor else buf.cpu().numpy()
+
+        # mm path: round + clamp in float32, skipping the uint16 round-trip
+        # when returning a tensor (torch.uint16 is poorly supported).
+        buf.mul_(MM_PER_METRE).round_().clamp_(0.0, _UINT16_MAX)
+        if output_tensor:
+            return buf
+        return buf.cpu().numpy().astype(np.uint16, copy=False)
+
+    # ── NumPy path: single fp32 allocation, ``out=`` for in-place math. ─────
+    arr = np.asarray(quantized)
+    if arr.ndim >= 3:
+        # Drop the single-channel dimension so the math runs on (..., H, W).
+        arr = (
+            np.squeeze(arr, axis=-3) if arr.shape[-3] == 1 else np.squeeze(arr, axis=-1)
+        )
+
+    buf = np.empty(arr.shape, dtype=np.float32)
+    np.multiply(arr, scale, out=buf)
+    np.add(buf, offset, out=buf)
+    if use_log:
+        np.exp(buf, out=buf)
+        np.subtract(buf, shift_m, out=buf)
+    np.clip(buf, depth_min_m, depth_max_m, out=buf)
+    buf = (
+        np.expand_dims(buf, axis=-1)
+        if output_channel_last
+        else np.expand_dims(buf, axis=-3)
+    )
+
+    if output_unit == DEPTH_METER_UNIT:
+        return torch.from_numpy(buf) if output_tensor else buf
+
+    np.multiply(buf, MM_PER_METRE, out=buf)
+    np.rint(buf, out=buf)
+    np.clip(buf, 0.0, _UINT16_MAX, out=buf)
+    if output_tensor:
+        # torch.uint16 support is very limited; return float32 millimetres.
+        return torch.from_numpy(buf)
+    return buf.astype(np.uint16, copy=False)

--- a/embodichain/data_pipeline/depth_video/reader.py
+++ b/embodichain/data_pipeline/depth_video/reader.py
@@ -1,0 +1,251 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+"""Readers for compressed depth sidecar videos.
+
+Decodes the ``gray12le``/HEVC MP4s written by :class:`DepthSidecarManager` and
+dequantizes them back to metres or millimetres. ``load_depth_dataset`` composes
+a LeRobot dataset with its depth sidecar library so callers can read RGB, state,
+action, mask and depth together.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import av
+import numpy as np
+
+from embodichain.utils import logger
+
+from .depth_utils import DEPTH_METER_UNIT, dequantize_depth
+
+__all__ = ["DepthVideoReader", "DepthVideoLibrary", "load_depth_dataset"]
+
+
+class DepthVideoReader:
+    """Decode and dequantize a single depth sidecar MP4.
+
+    Frames are decoded lazily on first access and cached, since one MP4 holds a
+    single (typically short) episode.
+    """
+
+    def __init__(
+        self,
+        path: Path,
+        depth_min: float,
+        depth_max: float,
+        shift: float,
+        use_log: bool,
+        pix_fmt: str = "gray12le",
+        output_unit: str = DEPTH_METER_UNIT,
+    ) -> None:
+        """Initialize the reader.
+
+        Args:
+            path: Path to the sidecar MP4.
+            depth_min: Quantization ``depth_min`` (metres) used at write time.
+            depth_max: Quantization ``depth_max`` (metres) used at write time.
+            shift: Quantization ``shift`` (metres) used at write time.
+            use_log: Quantization ``use_log`` used at write time.
+            pix_fmt: Pixel format of the stored video.
+            output_unit: Unit to return (``"m"`` or ``"mm"``).
+        """
+        self._path = Path(path)
+        self._depth_min = depth_min
+        self._depth_max = depth_max
+        self._shift = shift
+        self._use_log = use_log
+        self._pix_fmt = pix_fmt
+        self._output_unit = output_unit
+        self._codes: Optional[list[np.ndarray]] = None
+
+    def _decode(self) -> list[np.ndarray]:
+        if self._codes is not None:
+            return self._codes
+        if not self._path.exists():
+            raise FileNotFoundError(f"Depth sidecar video not found: {self._path}")
+        codes: list[np.ndarray] = []
+        with av.open(str(self._path), "r") as inp:
+            stream = next((s for s in inp.streams if s.type == "video"), None)
+            if stream is None:
+                raise ValueError(f"No video stream in {self._path}")
+            for frame in inp.decode(stream):
+                codes.append(frame.to_ndarray(format=self._pix_fmt))
+        self._codes = codes
+        return codes
+
+    @property
+    def frame_count(self) -> int:
+        """Number of frames in the sidecar video."""
+        return len(self._decode())
+
+    def read(self, frame_index: int) -> np.ndarray:
+        """Decode and dequantize one frame.
+
+        Args:
+            frame_index: Within-episode frame index.
+
+        Returns:
+            Depth map in the configured output unit, shape ``(1, H, W)``.
+        """
+        codes = self._decode()
+        if frame_index < 0 or frame_index >= len(codes):
+            raise IndexError(
+                f"Depth frame index {frame_index} out of range [0, {len(codes)})"
+            )
+        return dequantize_depth(
+            codes[frame_index],
+            depth_min=self._depth_min,
+            depth_max=self._depth_max,
+            shift=self._shift,
+            use_log=self._use_log,
+            pix_fmt=self._pix_fmt,
+            output_unit=self._output_unit,
+            output_tensor=False,
+        )
+
+
+class DepthVideoLibrary:
+    """Index of all depth sidecar videos for a dataset.
+
+    Maps ``(episode_index, sensor_key)`` to a :class:`DepthVideoReader` and
+    provides random access by within-episode frame index.
+    """
+
+    def __init__(self, dataset_root: Path, meta: Dict[str, Any]) -> None:
+        """Initialize the library from parsed metadata.
+
+        Args:
+            dataset_root: Root directory of the LeRobot dataset.
+            meta: Parsed ``depth_meta.json`` contents.
+        """
+        self._root = Path(dataset_root)
+        self._meta = meta
+        self._readers: Dict[tuple[int, str], DepthVideoReader] = {}
+
+    @property
+    def sensors(self) -> list[str]:
+        """List of depth sensor keys recorded in the dataset."""
+        return list(self._meta.get("sensors", {}).keys())
+
+    def sensor_meta(self, sensor_key: str) -> Dict[str, Any]:
+        """Return the static metadata block for a sensor."""
+        return self._meta["sensors"][sensor_key]
+
+    def _reader(self, episode_index: int, sensor_key: str) -> DepthVideoReader:
+        key = (episode_index, sensor_key)
+        if key in self._readers:
+            return self._readers[key]
+        sensors = self._meta.get("sensors", {})
+        if sensor_key not in sensors:
+            raise KeyError(f"Unknown depth sensor '{sensor_key}'")
+        sensor_meta = sensors[sensor_key]
+        episodes = sensor_meta.get("episodes", {})
+        ep_meta = episodes.get(str(episode_index))
+        if ep_meta is None:
+            raise KeyError(
+                f"No depth video for sensor '{sensor_key}' episode {episode_index}"
+            )
+        reader = DepthVideoReader(
+            path=self._root / ep_meta["file"],
+            depth_min=sensor_meta["video.depth_min"],
+            depth_max=sensor_meta["video.depth_max"],
+            shift=sensor_meta["video.shift"],
+            use_log=sensor_meta["video.use_log"],
+            pix_fmt=sensor_meta["video.pix_fmt"],
+            output_unit=sensor_meta["video.output_unit"],
+        )
+        self._readers[key] = reader
+        return reader
+
+    def get(
+        self, episode_index: int, sensor_key: str, frame_index_in_episode: int
+    ) -> np.ndarray:
+        """Read one depth frame.
+
+        Args:
+            episode_index: Global episode index.
+            sensor_key: Sensor identifier (e.g. ``"camera"``, ``"camera_right"``).
+            frame_index_in_episode: Frame index within the episode.
+
+        Returns:
+            Depth map in the unit recorded in metadata, shape ``(1, H, W)``.
+        """
+        return self._reader(episode_index, sensor_key).read(frame_index_in_episode)
+
+    def frame_count(self, episode_index: int, sensor_key: str) -> int:
+        """Return the number of depth frames for an episode/sensor."""
+        return self._reader(episode_index, sensor_key).frame_count
+
+
+def load_depth_meta(dataset_root: Path) -> Dict[str, Any]:
+    """Load and return the ``depth_meta.json`` for a dataset.
+
+    Args:
+        dataset_root: Root directory of the LeRobot dataset.
+
+    Returns:
+        Parsed metadata dict.
+
+    Raises:
+        FileNotFoundError: If no depth sidecar metadata exists.
+    """
+    meta_path = Path(dataset_root) / "depth_meta.json"
+    if not meta_path.exists():
+        raise FileNotFoundError(
+            f"No depth_meta.json at {meta_path}; the dataset has no depth sidecar videos."
+        )
+    with open(meta_path) as f:
+        return json.load(f)
+
+
+def load_depth_dataset(
+    dataset_root: Path, **lerobot_kwargs: Any
+) -> tuple[Any, DepthVideoLibrary]:
+    """Load a LeRobot dataset together with its depth sidecar library.
+
+    Args:
+        dataset_root: Root directory of the LeRobot dataset (the directory
+            containing ``data/``, ``videos/`` and ``depth_meta.json``).
+        **lerobot_kwargs: Forwarded to ``LeRobotDataset`` (e.g. ``episodes``).
+
+    Returns:
+        A ``(LeRobotDataset, DepthVideoLibrary)`` tuple.
+
+    Raises:
+        ImportError: If LeRobot is not installed.
+        FileNotFoundError: If the dataset has no depth sidecar metadata.
+    """
+    try:
+        from lerobot.datasets.lerobot_dataset import LeRobotDataset
+    except ImportError as e:
+        raise ImportError(
+            "LeRobot is not installed; install it with `pip install lerobot`."
+        ) from e
+
+    root = Path(dataset_root)
+    meta = load_depth_meta(root)
+    dataset_name = root.name
+    dataset = LeRobotDataset(repo_id=dataset_name, root=str(root), **lerobot_kwargs)
+    library = DepthVideoLibrary(root, meta)
+    logger.log_info(
+        f"Loaded depth sidecar library: {len(library.sensors)} sensor(s) "
+        f"({', '.join(library.sensors) or 'none'})"
+    )
+    return dataset, library

--- a/embodichain/data_pipeline/depth_video/writer.py
+++ b/embodichain/data_pipeline/depth_video/writer.py
@@ -1,0 +1,411 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+"""Streaming depth video writer and per-episode sidecar manager.
+
+Writes camera depth maps as ``gray12le``/HEVC sidecar videos that live
+alongside a LeRobot dataset (issue #424, Path A). Depth never enters LeRobot's
+own image/video pipeline (which is RGB-only in 0.4.4); instead each episode is
+encoded to a standalone MP4 and indexed by ``depth_meta.json``.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import av
+import numpy as np
+import torch
+
+from embodichain.utils import logger
+
+from .cfg import DepthVideoCfg, EMBODI_DEPTH_CODEBASE_VERSION
+from .codec import resolve_depth_vcodec
+from .depth_utils import DEPTH_QMAX, quantize_depth
+
+__all__ = ["DepthVideoWriter", "DepthSidecarManager"]
+
+# One episode per file, grouped under a single chunk for now. The metadata
+# records ``chunk_index`` so a future migration can re-chunk if needed.
+_CHUNK_INDEX = 0
+_META_FILENAME = "depth_meta.json"
+
+
+def _to_numpy_uint16(depth: Any) -> np.ndarray:
+    """Coerce a depth frame (tensor or array) to a 2D float array for quantization.
+
+    Args:
+        depth: ``torch.Tensor`` or ``np.ndarray`` depth map.
+
+    Returns:
+        Depth as a ``np.ndarray`` (dtype preserved; ``quantize_depth`` handles
+        float32/uint16 inference).
+    """
+    if isinstance(depth, torch.Tensor):
+        depth = depth.detach().cpu().numpy()
+    return np.asarray(depth)
+
+
+class DepthVideoWriter:
+    """Streaming writer that encodes one depth episode to a single MP4.
+
+    Depth frames are quantized to 12-bit codes and encoded as ``gray12le``
+    video. With ``lossless=True`` the 12-bit codes are bit-exact after a
+    decode round-trip (verified on pyav 15.x + libx265).
+
+    The video is written to a temporary path and atomically moved to its final
+    location on :meth:`close`; on failure the partial file is removed so the
+    dataset never references a corrupt sidecar.
+    """
+
+    def __init__(
+        self,
+        final_path: Path,
+        fps: int,
+        cfg: DepthVideoCfg,
+        vcodec: Optional[str] = None,
+    ) -> None:
+        """Initialize the writer.
+
+        Args:
+            final_path: Destination MP4 path. Written via a temp file in the
+                same directory and atomically renamed on success.
+            fps: Episode frame rate (frames per second).
+            cfg: Depth video configuration.
+            vcodec: Resolved codec name. If ``None``, resolved from ``cfg``.
+        """
+        self._final_path = Path(final_path)
+        self._fps = int(fps)
+        self._cfg = cfg
+        self._vcodec = vcodec or resolve_depth_vcodec(cfg.vcodec)
+        self._temp_path = Path(
+            tempfile.mkstemp(
+                prefix=".depth_tmp_", suffix=".mp4", dir=str(self._final_path.parent)
+            )[1]
+        )
+        self._output: Optional[av.output.OutputContainer] = None
+        self._stream: Optional[av.video.stream.VideoStream] = None
+        self._width: int = 0
+        self._height: int = 0
+        self._frame_count: int = 0
+        self._closed: bool = False
+
+    def _ensure_open(self, depth: np.ndarray) -> None:
+        if self._output is not None:
+            return
+        # Infer spatial shape from the (squeezed) depth frame.
+        h, w = int(depth.shape[-2]), int(depth.shape[-1])
+        self._height, self._width = h, w
+        self._final_path.parent.mkdir(parents=True, exist_ok=True)
+        self._output = av.open(str(self._temp_path), "w")
+        stream = self._output.add_stream(self._vcodec, self._fps)
+        stream.pix_fmt = self._cfg.pix_fmt
+        stream.width = w
+        stream.height = h
+        # libx265: ``bframes=0`` makes the encoder flush deterministic for short
+        # episodes -- with the default B-frame/lookahead buffering, flushing 1-3
+        # frame videos races inside libx265's thread pool and intermittently
+        # raises ``PatchWelcomeError``. ``log-level=error`` silences the per-encode
+        # x265 info banner. Lossless mode preserves the 12-bit codes bit-exactly.
+        if self._vcodec == "libx265":
+            if self._cfg.lossless:
+                stream.options = {
+                    "x265-params": "lossless=1:bframes=0:log-level=error",
+                    "crf": "0",
+                }
+            else:
+                stream.options = {
+                    "crf": str(int(self._cfg.crf)),
+                    "x265-params": "bframes=0:log-level=error",
+                }
+        else:
+            stream.options = {"crf": str(int(self._cfg.crf))}
+        self._stream = stream
+
+    def add_frame(self, depth: Any) -> None:
+        """Quantize and encode a single depth frame.
+
+        Args:
+            depth: Depth map (``torch.Tensor`` or ``np.ndarray``), shape
+                ``(H, W)`` / ``(H, W, 1)`` / ``(1, H, W)``.
+        """
+        if self._closed:
+            logger.log_error("DepthVideoWriter is closed; cannot add_frame.")
+            return
+        depth_np = _to_numpy_uint16(depth)
+        self._ensure_open(depth_np)
+        frame = quantize_depth(
+            depth_np,
+            depth_min=self._cfg.depth_min,
+            depth_max=self._cfg.depth_max,
+            shift=self._cfg.shift,
+            use_log=self._cfg.use_log,
+            pix_fmt=self._cfg.pix_fmt,
+            input_unit=self._cfg.input_unit,
+        )
+        assert self._stream is not None and self._output is not None
+        for packet in self._stream.encode(frame):
+            self._output.mux(packet)
+        self._frame_count += 1
+
+    def close(self) -> Path:
+        """Flush the encoder and finalize the MP4.
+
+        Returns:
+            The final MP4 path on success.
+
+        Raises:
+            RuntimeError: If no frames were written.
+        """
+        if self._closed:
+            return self._final_path
+        self._closed = True
+        try:
+            if self._output is None or self._stream is None:
+                raise RuntimeError(
+                    "DepthVideoWriter closed with no frames written; no MP4 produced."
+                )
+            for packet in self._stream.encode():
+                self._output.mux(packet)
+            self._output.close()
+            if self._frame_count == 0:
+                raise RuntimeError("DepthVideoWriter produced 0 frames.")
+            # Atomic-ish move into place.
+            self._temp_path.replace(self._final_path)
+            return self._final_path
+        except Exception:
+            # Cleanup partial output so the dataset never references a corrupt file.
+            self._discard_temp()
+            raise
+
+    @property
+    def frame_count(self) -> int:
+        """Number of frames written so far."""
+        return self._frame_count
+
+    @property
+    def final_path(self) -> Path:
+        """Destination MP4 path."""
+        return self._final_path
+
+    def _discard_temp(self) -> None:
+        if self._temp_path.exists():
+            try:
+                self._temp_path.unlink()
+            except OSError:
+                pass
+
+    def abort(self) -> None:
+        """Abort writing and remove any partial output."""
+        self._closed = True
+        if self._output is not None:
+            try:
+                self._output.close()
+            except Exception:
+                pass
+        self._discard_temp()
+
+
+class DepthSidecarManager:
+    """Owns the depth sidecar videos and metadata for one dataset recording.
+
+    For each episode, opens one :class:`DepthVideoWriter` per depth sensor
+    (e.g. ``camera`` and ``camera_right``), feeds frames, and on episode close
+    moves the MP4s into the dataset's ``depth_videos/`` tree and updates
+    ``depth_meta.json``.
+    """
+
+    def __init__(
+        self,
+        dataset_root: Path,
+        fps: int,
+        cfg: DepthVideoCfg,
+        vcodec: Optional[str] = None,
+    ) -> None:
+        """Initialize the sidecar manager.
+
+        Args:
+            dataset_root: Root directory of the LeRobot dataset. Sidecar videos
+                are written under ``<root>/depth_videos/`` and metadata under
+                ``<root>/depth_meta.json``.
+            fps: Dataset frame rate.
+            cfg: Depth video configuration.
+            vcodec: Resolved codec name. If ``None``, resolved from ``cfg``.
+        """
+        self._root = Path(dataset_root)
+        self._fps = int(fps)
+        self._cfg = cfg
+        self._vcodec = vcodec or resolve_depth_vcodec(cfg.vcodec)
+        self._meta: Dict[str, Any] = {
+            "codebase_version": EMBODI_DEPTH_CODEBASE_VERSION,
+            "writer": "embodichain.data_pipeline.depth_video",
+            "is_depth_map": True,
+            "fps": self._fps,
+            "sensors": {},
+        }
+        self._writers: Dict[str, DepthVideoWriter] = {}
+        self._episode_sensors: list[str] = []
+
+    def has_sensor(self, sensor_key: str) -> bool:
+        """Return True if *sensor_key* has been registered."""
+        return sensor_key in self._meta["sensors"]
+
+    def register_sensor(self, sensor_key: str, shape: tuple[int, ...]) -> None:
+        """Register a depth sensor and its static metadata.
+
+        Args:
+            sensor_key: Sensor identifier including any side suffix, e.g.
+                ``"camera"`` or ``"camera_right"``.
+            shape: Spatial shape of the depth frames, e.g. ``(480, 640)``.
+        """
+        if sensor_key in self._meta["sensors"]:
+            return
+        h, w = int(shape[-2]), int(shape[-1])
+        self._meta["sensors"][sensor_key] = {
+            "is_depth_map": True,
+            "shape": [h, w, 1],
+            "video.codec": self._vcodec,
+            "video.pix_fmt": self._cfg.pix_fmt,
+            "video.fps": self._fps,
+            "video.depth_min": self._cfg.depth_min,
+            "video.depth_max": self._cfg.depth_max,
+            "video.shift": self._cfg.shift,
+            "video.use_log": self._cfg.use_log,
+            "video.input_unit": self._cfg.input_unit,
+            "video.output_unit": self._cfg.output_unit,
+            "video.lossless": self._cfg.lossless,
+            "video.crf": int(self._cfg.crf),
+            "video.quant_bits": 12,
+            "video.qmax": DEPTH_QMAX,
+            "episodes": {},
+        }
+
+    def start_episode(self, episode_index: int, sensor_keys: list[str]) -> None:
+        """Open a writer per sensor for a new episode.
+
+        Args:
+            episode_index: Global episode index.
+            sensor_keys: Depth sensor keys present in this episode.
+        """
+        self._episode_sensors = list(sensor_keys)
+        self._writers = {}
+        for key in self._episode_sensors:
+            ep_dir = self._root / "depth_videos" / key
+            ep_dir.mkdir(parents=True, exist_ok=True)
+            final_path = ep_dir / f"episode_{episode_index:06d}.mp4"
+            self._writers[key] = DepthVideoWriter(
+                final_path=final_path,
+                fps=self._fps,
+                cfg=self._cfg,
+                vcodec=self._vcodec,
+            )
+
+    def add_frame(self, sensor_key: str, depth: Any) -> None:
+        """Feed one depth frame for one sensor in the current episode.
+
+        Args:
+            sensor_key: Sensor identifier.
+            depth: Depth map.
+        """
+        writer = self._writers.get(sensor_key)
+        if writer is None:
+            logger.log_warning(
+                f"No depth writer for sensor '{sensor_key}'; skipping frame."
+            )
+            return
+        writer.add_frame(depth)
+
+    def end_episode(self, episode_index: int) -> None:
+        """Close all writers for the current episode and update metadata.
+
+        On failure of any writer the partial files are discarded and that
+        sensor/episode is skipped (with a warning) rather than aborting the
+        whole recording.
+
+        Args:
+            episode_index: Global episode index.
+        """
+        for key, writer in self._writers.items():
+            try:
+                writer.close()
+                frame_count = writer.frame_count
+            except Exception as e:
+                logger.log_warning(
+                    f"Failed to finalize depth video for sensor '{key}' "
+                    f"episode {episode_index}: {e}"
+                )
+                writer.abort()
+                continue
+            rel_file = writer.final_path.relative_to(self._root).as_posix()
+            self._meta["sensors"][key]["episodes"][str(episode_index)] = {
+                "chunk_index": _CHUNK_INDEX,
+                "file": rel_file,
+                "frame_count": frame_count,
+            }
+        self._writers = {}
+        self._episode_sensors = []
+        self._write_meta()
+
+    def abort_episode(self) -> None:
+        """Abort the current episode: discard all partial depth videos.
+
+        Called when the surrounding LeRobot ``save_episode`` fails, so the
+        dataset never references a depth video for an episode that was not
+        committed.
+        """
+        for writer in self._writers.values():
+            writer.abort()
+        self._writers = {}
+        self._episode_sensors = []
+
+    def finalize(self) -> Path:
+        """Flush metadata after the last episode.
+
+        Returns:
+            Path to ``depth_meta.json``.
+        """
+        self._write_meta()
+        return self._root / _META_FILENAME
+
+    def _write_meta(self) -> None:
+        self._root.mkdir(parents=True, exist_ok=True)
+        meta_path = self._root / _META_FILENAME
+        tmp_path = meta_path.with_suffix(".json.tmp")
+        with open(tmp_path, "w") as f:
+            json.dump(self._meta, f, indent=2, sort_keys=True)
+        tmp_path.replace(meta_path)
+
+
+def cleanup_partial_sidecar(dataset_root: Path) -> None:
+    """Remove the depth sidecar tree and metadata for an aborted dataset.
+
+    Args:
+        dataset_root: Root directory of the LeRobot dataset.
+    """
+    root = Path(dataset_root)
+    sidecar = root / "depth_videos"
+    if sidecar.exists():
+        shutil.rmtree(sidecar, ignore_errors=True)
+    meta = root / _META_FILENAME
+    if meta.exists():
+        try:
+            meta.unlink()
+        except OSError:
+            pass

--- a/embodichain/lab/gym/envs/managers/datasets.py
+++ b/embodichain/lab/gym/envs/managers/datasets.py
@@ -31,6 +31,11 @@ from tensordict import TensorDict
 from embodichain.utils import logger
 from embodichain.data.constants import EMBODICHAIN_DEFAULT_DATASET_ROOT
 from embodichain.data.enum import LeRobotKey
+from embodichain.data_pipeline.depth_video import (
+    DepthSidecarManager,
+    DepthVideoCfg,
+    detect_depth_encoder,
+)
 from embodichain.lab.sim.sensors import Camera, ContactSensor
 from .manager_base import Functor
 from .cfg import DatasetFunctorCfg
@@ -39,12 +44,19 @@ CAMERA_IMAGE_FRAMES = {
     "color": "",
     "color_right": "_right",
 }
-CAMERA_AUXILIARY_FRAMES = {
+# Depth and mask share the ``observation.<modality>.<sensor>[_right]`` key
+# layout (see ``_camera_feature_key``), but are stored differently: depth can
+# be offloaded to compressed sidecar videos (issue #424, Path A), while mask is
+# always kept as an exact numeric LeRobot feature.
+CAMERA_DEPTH_FRAMES = {
     "depth",
     "depth_right",
+}
+CAMERA_MASK_FRAMES = {
     "mask",
     "mask_right",
 }
+CAMERA_AUXILIARY_FRAMES = CAMERA_DEPTH_FRAMES | CAMERA_MASK_FRAMES
 
 if TYPE_CHECKING:
     from embodichain.lab.gym.envs import EmbodiedEnv
@@ -113,6 +125,19 @@ class LeRobotRecorder(Functor):
         # processes add isolation at a higher spawn cost.
         self.image_writer_threads = int(params.get("image_writer_threads", 0))
         self.image_writer_processes = int(params.get("image_writer_processes", 0))
+
+        # Compressed depth sidecar videos (issue #424, Path A). When enabled and
+        # an HEVC encoder is available, camera depth is written as gray12le/HEVC
+        # MP4s alongside the LeRobot dataset instead of (or, with
+        # ``keep_numeric_fallback``, in addition to) numeric Parquet features.
+        self.depth_video_cfg = self._parse_depth_video_cfg(params)
+        self._depth_video_enabled = self._resolve_depth_video_enabled(
+            self.depth_video_cfg
+        )
+        # Per-sensor depth specs collected in _build_features: {sensor_key: shape}.
+        self._depth_sensor_specs: Dict[str, tuple] = {}
+        # Sidecar manager, created in _initialize_dataset once the root is known.
+        self._depth_manager: Optional[DepthSidecarManager] = None
 
         # LeRobot dataset instance
         self.dataset: Optional[LeRobotDataset] = None
@@ -233,16 +258,33 @@ class LeRobotRecorder(Functor):
         self.total_time += current_episode_time
         episode_extra_info["total_time"] = self.total_time
 
+        depth_prefix = f"{LeRobotKey.OBS_PREFIX.value}depth."
         try:
+            if self._depth_manager is not None:
+                self._depth_manager.start_episode(
+                    self.curr_episode, list(self._depth_sensor_specs.keys())
+                )
             for obs, action in tqdm.tqdm(
                 zip(obs_list, action_list),
                 total=len(obs_list),
                 desc=f"Converting env {env_id} episode to LeRobot format",
             ):
                 frame = self._convert_frame_to_lerobot(obs, action, task)
+                # Offload depth to the sidecar writer and drop it from the frame
+                # so LeRobot's RGB-only image/video path never sees it. With
+                # ``keep_numeric_fallback`` the numeric feature is retained too.
+                if self._depth_manager is not None:
+                    for key in list(frame.keys()):
+                        if key.startswith(depth_prefix):
+                            sensor_key = key[len(depth_prefix) :]
+                            self._depth_manager.add_frame(sensor_key, frame[key])
+                            if not self.depth_video_cfg.keep_numeric_fallback:
+                                del frame[key]
                 self.dataset.add_frame(frame)
 
             self.dataset.save_episode()
+            if self._depth_manager is not None:
+                self._depth_manager.end_episode(self.curr_episode)
 
             logger.log_info(
                 f"[LeRobotRecorder] Saved dataset to: {self.dataset_path}\n"
@@ -253,6 +295,8 @@ class LeRobotRecorder(Functor):
             return True
         except Exception as e:
             logger.log_error(f"Failed to save episode {env_id}: {e}")
+            if self._depth_manager is not None:
+                self._depth_manager.abort_episode()
             return False
 
     def finalize(self) -> Optional[str]:
@@ -269,6 +313,10 @@ class LeRobotRecorder(Functor):
                 if self.dataset.image_writer is not None:
                     self.dataset.stop_image_writer()
                 self.dataset.finalize()
+                # Finalize the depth sidecar metadata (depth videos are already
+                # written per episode; this flushes depth_meta.json).
+                if self._depth_manager is not None:
+                    self._depth_manager.finalize()
                 logger.log_info(
                     f"[LeRobotRecorder] Dataset finalized successfully\n"
                     f"  Path: {self.dataset_path}\n"
@@ -280,6 +328,59 @@ class LeRobotRecorder(Functor):
             logger.log_error(f"[LeRobotRecorder] Failed to finalize dataset: {e}")
 
         return None
+
+    def _parse_depth_video_cfg(self, params: Dict) -> DepthVideoCfg:
+        """Parse the optional ``depth_video`` parameter into a config.
+
+        Args:
+            params: Functor parameter dict.
+
+        Returns:
+            A :class:`DepthVideoCfg`. ``enable`` defaults to ``False`` when no
+            ``depth_video`` entry is present.
+        """
+        dv = params.get("depth_video", None)
+        if dv is None:
+            return DepthVideoCfg(enable=False)
+        if isinstance(dv, DepthVideoCfg):
+            return dv
+        if isinstance(dv, dict):
+            try:
+                return DepthVideoCfg(**dv)
+            except TypeError as e:
+                logger.log_warning(
+                    f"Invalid depth_video config: {e}; disabling depth video."
+                )
+                return DepthVideoCfg(enable=False)
+        logger.log_warning(
+            f"Ignoring depth_video config of unexpected type "
+            f"{type(dv).__name__}; expected DepthVideoCfg or dict."
+        )
+        return DepthVideoCfg(enable=False)
+
+    @staticmethod
+    def _resolve_depth_video_enabled(cfg: DepthVideoCfg) -> bool:
+        """Return whether compressed depth video can actually be written.
+
+        Depth video is only enabled when the user opts in *and* an HEVC encoder
+        is available; otherwise we silently fall back to numeric depth features
+        (PR #422) so recording never fails on hosts without libx265.
+
+        Args:
+            cfg: Parsed depth video config.
+
+        Returns:
+            True if the sidecar writer should be active.
+        """
+        if not cfg.enable:
+            return False
+        if detect_depth_encoder(cfg.vcodec) is None:
+            logger.log_warning(
+                f"No HEVC encoder (libx265/hevc) available for depth video; "
+                f"falling back to numeric depth features (PR #422)."
+            )
+            return False
+        return True
 
     def _initialize_dataset(self) -> None:
         """Initialize the LeRobot dataset."""
@@ -330,6 +431,29 @@ class LeRobotRecorder(Functor):
             image_writer_threads=self.image_writer_threads,
         )
         logger.log_info(f"Created LeRobot dataset at: {self.dataset_full_path}")
+
+        # Set up the depth sidecar manager now that the dataset root and fps are
+        # known. Sensors were registered into _depth_sensor_specs by
+        # _build_features() above.
+        if self._depth_video_enabled and self._depth_sensor_specs:
+            self._depth_manager = DepthSidecarManager(
+                dataset_root=self.dataset_full_path,
+                fps=fps,
+                cfg=self.depth_video_cfg,
+            )
+            for sensor_key, shape in self._depth_sensor_specs.items():
+                self._depth_manager.register_sensor(sensor_key, shape)
+            logger.log_info(
+                f"[LeRobotRecorder] Depth sidecar video enabled for sensors: "
+                f"{list(self._depth_sensor_specs.keys())} "
+                f"(codec={self.depth_video_cfg.vcodec}, "
+                f"lossless={self.depth_video_cfg.lossless})"
+            )
+        elif self.depth_video_cfg.enable and not self._depth_video_enabled:
+            logger.log_info(
+                "[LeRobotRecorder] depth_video requested but unavailable; "
+                "depth will be stored as numeric features."
+            )
 
     def _build_features(self) -> Dict:
         """Build LeRobot features dict."""
@@ -383,7 +507,31 @@ class LeRobotRecorder(Functor):
                                 "shape": (sensor.cfg.height, sensor.cfg.width, 3),
                                 "names": ["height", "width", "channel"],
                             }
-                        elif frame_name in CAMERA_AUXILIARY_FRAMES:
+                        elif frame_name in CAMERA_DEPTH_FRAMES:
+                            feature_key = self._camera_feature_key(
+                                sensor_name, frame_name
+                            )
+                            if self._depth_video_enabled:
+                                # Record the sidecar sensor spec; only register a
+                                # numeric feature when an exact raw fallback is
+                                # requested.
+                                _, _, side = frame_name.partition("_")
+                                suffix = f"_{side}" if side else ""
+                                self._depth_sensor_specs[f"{sensor_name}{suffix}"] = (
+                                    tuple(space.shape)
+                                )
+                                if not self.depth_video_cfg.keep_numeric_fallback:
+                                    continue
+                            features[feature_key] = {
+                                "dtype": str(space.dtype),
+                                "shape": space.shape,
+                                "names": (
+                                    ["height", "width"]
+                                    if len(space.shape) == 2
+                                    else ["height", "width", "channel"]
+                                ),
+                            }
+                        elif frame_name in CAMERA_MASK_FRAMES:
                             feature_key = self._camera_feature_key(
                                 sensor_name, frame_name
                             )

--- a/scripts/benchmark/data_pipeline/benchmark_depth_size.py
+++ b/scripts/benchmark/data_pipeline/benchmark_depth_size.py
@@ -1,0 +1,195 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+"""Benchmark depth storage size: numeric Parquet vs compressed sidecar video.
+
+Compares the on-disk size of camera depth saved the three ways supported by
+``LeRobotRecorder`` (issue #424):
+
+- numeric float32 Parquet (snappy / zstd) -- the PR #422 default; Camera depth
+  is float32 metres, and the noisy float32 mantissa is barely compressible.
+- numeric uint16-millimetre Parquet (zstd) -- exact raw values, half the bytes.
+- compressed ``gray12le``/HEVC sidecar video (lossless and lossy CRF) -- issue
+  #424 Path A; depth is quantized to 12-bit codes and encoded as a video.
+
+The depth scene is synthetic but realistic: a smooth background plane, a slowly
+moving foreground object, and per-frame sensor noise, so the video codec's
+spatial/temporal compression is representative of real depth.
+
+.. note::
+   HEVC encoding of long episodes is CPU-bound; the defaults (100 frames) finish
+   in a few seconds. Pass ``--frames`` for longer episodes.
+
+Run: python -m scripts.benchmark.data_pipeline.benchmark_depth_size
+"""
+
+from __future__ import annotations
+
+import argparse
+import tempfile
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from embodichain.data_pipeline.depth_video import DepthVideoCfg, DepthVideoWriter
+
+
+def make_depth_episode(n_frames: int, H: int, W: int, seed: int = 0) -> np.ndarray:
+    """Build a realistic float32 depth episode in metres.
+
+    Background is a smooth plane (0.5..2.0 m), a foreground box (0.35 m) moves
+    horizontally, and 5 mm Gaussian sensor noise is added per frame.
+
+    Args:
+        n_frames: Number of frames.
+        H: Frame height.
+        W: Frame width.
+        seed: RNG seed.
+
+    Returns:
+        Array of shape ``(n_frames, H, W)``, dtype ``float32``.
+    """
+    rng = np.random.default_rng(seed)
+    yy, _ = np.meshgrid(np.linspace(0, 1, H), np.linspace(0, 1, W), indexing="ij")
+    base = (0.5 + 1.5 * yy).astype(np.float32)
+    frames = np.empty((n_frames, H, W), dtype=np.float32)
+    for t in range(n_frames):
+        f = base.copy()
+        cx = int(W * 0.5 + 0.15 * W * np.sin(t * 0.05))
+        cy = H // 2
+        f[cy - H // 6 : cy + H // 6, cx - W // 8 : cx + W // 8] = 0.35
+        f += rng.normal(0, 0.005, f.shape).astype(np.float32)
+        frames[t] = f
+    return frames
+
+
+def parquet_size(frames: np.ndarray, dtype: str, compression: str) -> int:
+    """Write ``frames`` as one Parquet column of fixed-size lists; return bytes."""
+    H, W = frames.shape[1], frames.shape[2]
+    if dtype == "float32":
+        vals = pa.array(frames.ravel().astype(np.float32))
+    else:  # uint16 millimetres
+        mm = np.rint(frames * 1000.0).clip(0, 65535).astype(np.uint16)
+        vals = pa.array(mm.ravel())
+    fsl = pa.FixedSizeListArray.from_arrays(vals, H * W)
+    table = pa.table({"depth": fsl})
+    with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as f:
+        path = f.name
+    pq.write_table(table, path, compression=compression)
+    size = Path(path).stat().st_size
+    Path(path).unlink()
+    return size
+
+
+def sidecar_size(frames: np.ndarray, lossless: bool, crf: int = 28) -> int:
+    """Encode ``frames`` (metres) to a gray12le/HEVC sidecar MP4; return bytes."""
+    tmp = Path(tempfile.mkdtemp())
+    cfg = DepthVideoCfg(
+        enable=True,
+        depth_min=0.1,
+        depth_max=3.0,
+        shift=1.0,
+        use_log=True,
+        lossless=lossless,
+        crf=crf,
+        input_unit="m",
+        output_unit="m",
+    )
+    writer = DepthVideoWriter(tmp / "ep.mp4", fps=30, cfg=cfg)
+    for f in frames:
+        writer.add_frame(f)
+    out = writer.close()
+    return out.stat().st_size
+
+
+def _human(n: int) -> str:
+    size = float(n)
+    for unit in ("B", "KB", "MB", "GB"):
+        if size < 1024:
+            return f"{size:.1f} {unit}"
+        size /= 1024
+    return f"{size:.1f} TB"
+
+
+def run(configs: Sequence[tuple[int, int, int]]) -> None:
+    """Run the benchmark over ``(H, W, n_frames)`` configs and print results."""
+    print(
+        f"{'config (HxW @30fps)':<22} {'raw f32':<10} {'f32 snappy':<12} "
+        f"{'f32 zstd':<12} {'u16 zstd':<12} {'sidecar lossless':<20} {'sidecar CRF28':<14}"
+    )
+    print("-" * 104)
+    for H, W, N in configs:
+        frames = make_depth_episode(N, H, W)
+        raw = N * H * W * 4  # float32
+        p_f32_snappy = parquet_size(frames, "float32", "snappy")
+        p_f32_zstd = parquet_size(frames, "float32", "zstd")
+        p_u16_zstd = parquet_size(frames, "uint16", "zstd")
+        s_lossless = sidecar_size(frames, lossless=True)
+        s_crf28 = sidecar_size(frames, lossless=False, crf=28)
+        print(
+            f"{H}x{W} x{N}f{'':<9} {_human(raw):<10} {_human(p_f32_snappy):<12} "
+            f"{_human(p_f32_zstd):<12} {_human(p_u16_zstd):<12} "
+            f"{_human(s_lossless):<20} {_human(s_crf28):<14}"
+        )
+
+    print()
+    print("Compression ratio vs raw float32 (higher = smaller):")
+    print(
+        f"{'config':<22} {'f32 snappy':<12} {'f32 zstd':<12} {'u16 zstd':<12} {'lossless':<12} {'CRF28':<10}"
+    )
+    print("-" * 80)
+    for H, W, N in configs:
+        frames = make_depth_episode(N, H, W)
+        raw = N * H * W * 4
+
+        def ratio(sz: int) -> str:
+            return f"{raw / sz:.0f}x"
+
+        print(
+            f"{H}x{W} x{N}f{'':<9} {ratio(parquet_size(frames, 'float32', 'snappy')):<12} "
+            f"{ratio(parquet_size(frames, 'float32', 'zstd')):<12} "
+            f"{ratio(parquet_size(frames, 'uint16', 'zstd')):<12} "
+            f"{ratio(sidecar_size(frames, True)):<12} "
+            f"{ratio(sidecar_size(frames, False, 28)):<10}"
+        )
+
+
+def main() -> None:
+    """Parse args and run the benchmark."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--frames", type=int, default=100, help="Frames per config (default 100)."
+    )
+    parser.add_argument(
+        "--resolutions",
+        type=str,
+        default="480x640,1280x720",
+        help="Comma-separated HxW resolutions (default '480x640,1280x720').",
+    )
+    args = parser.parse_args()
+
+    configs: list[tuple[int, int, int]] = []
+    for res in args.resolutions.split(","):
+        H, W = (int(x) for x in res.split("x"))
+        configs.append((H, W, args.frames))
+    run(configs)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/data_pipeline/depth_video/test_depth_utils.py
+++ b/tests/data_pipeline/depth_video/test_depth_utils.py
@@ -1,0 +1,138 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+"""Tests for the vendored depth quantization helpers."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from embodichain.data_pipeline.depth_video import (
+    DEPTH_METER_UNIT,
+    DEPTH_MILLIMETER_UNIT,
+    DEPTH_QMAX,
+    dequantize_depth,
+    quantize_depth,
+)
+
+
+class TestQuantizeDepth:
+    """Quantization math tests."""
+
+    def test_code_range_float_metres(self):
+        """Quantized codes must lie in [0, DEPTH_QMAX]."""
+        depth = np.linspace(0.0, 20.0, 64 * 80, dtype=np.float32).reshape(64, 80)
+        codes = quantize_depth(depth, video_backend=None, input_unit=DEPTH_METER_UNIT)
+        assert codes.dtype == np.uint16
+        assert codes.min() >= 0
+        assert codes.max() <= DEPTH_QMAX
+
+    def test_out_of_range_clamps_to_endpoints(self):
+        """Depths below depth_min map to 0; above depth_max map to DEPTH_QMAX."""
+        depth = np.array([0.0, 0.05, 5.0, 100.0], dtype=np.float32)
+        codes = quantize_depth(
+            depth,
+            depth_min=0.05,
+            depth_max=5.0,
+            use_log=False,
+            video_backend=None,
+            input_unit=DEPTH_METER_UNIT,
+        )
+        assert codes[0] == 0  # below depth_min
+        assert codes[1] == 0  # at depth_min
+        assert codes[2] == DEPTH_QMAX  # at depth_max
+        assert codes[3] == DEPTH_QMAX  # above depth_max
+
+    def test_video_backend_returns_av_frame(self):
+        """``video_backend="pyav"`` returns an av.VideoFrame with gray12le."""
+        import av
+
+        depth = np.full((32, 48), 1.0, dtype=np.float32)
+        frame = quantize_depth(depth, video_backend="pyav", input_unit=DEPTH_METER_UNIT)
+        assert isinstance(frame, av.VideoFrame)
+        assert frame.format.name == "gray12le"
+        assert frame.width == 48 and frame.height == 32
+
+    def test_invalid_input_unit_raises(self):
+        depth = np.zeros((4, 4), dtype=np.float32)
+        with pytest.raises(ValueError, match="input_unit"):
+            quantize_depth(depth, input_unit="km", video_backend=None)
+
+    def test_log_invalid_shift_raises(self):
+        """Log mode requires depth_min + shift > 0."""
+        depth = np.full((4, 4), 1.0, dtype=np.float32)
+        with pytest.raises(ValueError, match="depth_min \\+ shift"):
+            quantize_depth(
+                depth,
+                depth_min=0.1,
+                shift=-0.2,
+                use_log=True,
+                video_backend=None,
+                input_unit=DEPTH_METER_UNIT,
+            )
+
+    def test_uint16_millimetre_input(self):
+        """Integer input is interpreted as millimetres by auto inference."""
+        depth_mm = np.array([100, 1000, 5000], dtype=np.uint16)  # 0.1, 1.0, 5.0 m
+        codes = quantize_depth(
+            depth_mm,
+            depth_min=0.1,
+            depth_max=5.0,
+            use_log=False,
+            video_backend=None,
+            input_unit="auto",
+        )
+        assert codes[0] == 0  # 0.1 m == depth_min
+        assert codes[2] == DEPTH_QMAX  # 5.0 m == depth_max
+
+
+@pytest.mark.parametrize("use_log", [True, False])
+def test_roundtrip_error_bounded(use_log):
+    """quantize -> dequantize error stays within a small bound over the range."""
+    depth_min, depth_max, shift = 0.1, 3.0, 1.0
+    depth = np.linspace(depth_min, depth_max, 64 * 80, dtype=np.float32).reshape(64, 80)
+    codes = quantize_depth(
+        depth,
+        depth_min=depth_min,
+        depth_max=depth_max,
+        shift=shift,
+        use_log=use_log,
+        video_backend=None,
+        input_unit=DEPTH_METER_UNIT,
+    )
+    back = dequantize_depth(
+        codes,
+        depth_min=depth_min,
+        depth_max=depth_max,
+        shift=shift,
+        use_log=use_log,
+        output_unit=DEPTH_METER_UNIT,
+        output_tensor=False,
+    ).squeeze()
+
+    # Endpoints are reconstructed exactly by construction.
+    assert back[0, 0] == pytest.approx(depth_min, abs=1e-5)
+    assert back[-1, -1] == pytest.approx(depth_max, abs=1e-5)
+    # 12-bit log/linear quantization keeps the max error well under 5 mm over
+    # a 0.1-3.0 m range.
+    max_err = float(np.abs(back - depth).max())
+    assert max_err < 5e-3, f"max abs error {max_err} exceeds 5 mm"
+
+
+def test_dequantize_invalid_output_unit_raises():
+    codes = np.zeros((4, 4), dtype=np.uint16)
+    with pytest.raises(ValueError, match="output_unit"):
+        dequantize_depth(codes, output_unit="km")

--- a/tests/data_pipeline/depth_video/test_writer.py
+++ b/tests/data_pipeline/depth_video/test_writer.py
@@ -1,0 +1,221 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+"""Tests for the depth video writer, sidecar manager, and reader."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import av
+import numpy as np
+import pytest
+
+from embodichain.data_pipeline.depth_video import (
+    DEPTH_METER_UNIT,
+    DepthCodecError,
+    DepthSidecarManager,
+    DepthVideoCfg,
+    DepthVideoLibrary,
+    detect_depth_encoder,
+    load_depth_meta,
+    quantize_depth,
+)
+
+# These tests encode real MP4s with libx265; skip the whole module if no HEVC
+# encoder is available in the bundled FFmpeg build.
+pytestmark = pytest.mark.skipif(
+    detect_depth_encoder("libx265") is None,
+    reason="libx265/hevc encoder not available in this FFmpeg build",
+)
+
+H, W = 64, 80
+DEPTH_MIN, DEPTH_MAX, SHIFT = 0.1, 3.0, 1.0
+
+
+def _make_depth(n_frames: int) -> list[np.ndarray]:
+    """Return ``n_frames`` distinct float32 depth maps in metres.
+
+    Depths stay strictly inside ``[DEPTH_MIN, DEPTH_MAX]`` so no clamping occurs
+    (clamping is exercised separately in ``test_depth_utils``).
+    """
+    base = np.linspace(
+        DEPTH_MIN + 0.05, DEPTH_MAX - 0.05, H * W, dtype=np.float32
+    ).reshape(H, W)
+    return [base + 0.01 * i for i in range(n_frames)]
+
+
+def _decode_codes(mp4_path: Path) -> list[np.ndarray]:
+    """Decode a sidecar MP4 back to its raw 12-bit uint16 code frames."""
+    codes: list[np.ndarray] = []
+    with av.open(str(mp4_path), "r") as inp:
+        stream = next(s for s in inp.streams if s.type == "video")
+        for frame in inp.decode(stream):
+            codes.append(frame.to_ndarray(format="gray12le"))
+    return codes
+
+
+class TestDepthVideoWriter:
+    """Writer-level encode/decode tests."""
+
+    def test_lossless_codes_bit_exact(self, tmp_path: Path):
+        """Lossless libx265 preserves the 12-bit codes exactly."""
+        from embodichain.data_pipeline.depth_video import DepthVideoWriter
+
+        cfg = DepthVideoCfg(
+            enable=True,
+            depth_min=DEPTH_MIN,
+            depth_max=DEPTH_MAX,
+            shift=SHIFT,
+            use_log=True,
+            lossless=True,
+            input_unit=DEPTH_METER_UNIT,
+            output_unit=DEPTH_METER_UNIT,
+        )
+        depths = _make_depth(3)
+        writer = DepthVideoWriter(tmp_path / "ep.mp4", fps=10, cfg=cfg)
+        for d in depths:
+            writer.add_frame(d)
+        out = writer.close()
+        assert out.exists()
+
+        decoded = _decode_codes(out)
+        assert len(decoded) == 3
+        for orig, dec in zip(depths, decoded):
+            expected = quantize_depth(
+                orig,
+                depth_min=DEPTH_MIN,
+                depth_max=DEPTH_MAX,
+                shift=SHIFT,
+                use_log=True,
+                video_backend=None,
+                input_unit=DEPTH_METER_UNIT,
+            )
+            assert np.array_equal(dec, expected)
+
+    def test_close_with_no_frames_raises_and_cleans_temp(self, tmp_path: Path):
+        from embodichain.data_pipeline.depth_video import DepthVideoWriter
+
+        cfg = DepthVideoCfg(enable=True, input_unit=DEPTH_METER_UNIT)
+        writer = DepthVideoWriter(tmp_path / "empty.mp4", fps=10, cfg=cfg)
+        with pytest.raises(RuntimeError, match="no frames"):
+            writer.close()
+        # No partial mp4 left in the directory.
+        assert not (tmp_path / "empty.mp4").exists()
+        assert not any(p.suffix == ".mp4" for p in tmp_path.iterdir())
+
+
+class TestDepthSidecarManager:
+    """Sidecar manager + metadata + reader integration tests."""
+
+    def _make_manager(self, root: Path) -> DepthSidecarManager:
+        cfg = DepthVideoCfg(
+            enable=True,
+            depth_min=DEPTH_MIN,
+            depth_max=DEPTH_MAX,
+            shift=SHIFT,
+            use_log=True,
+            lossless=True,
+            input_unit=DEPTH_METER_UNIT,
+            output_unit=DEPTH_METER_UNIT,
+        )
+        mgr = DepthSidecarManager(root, fps=20, cfg=cfg)
+        mgr.register_sensor("camera", (H, W))
+        mgr.register_sensor("camera_right", (H, W))
+        return mgr
+
+    def test_writes_per_sensor_videos_and_metadata(self, tmp_path: Path):
+        mgr = self._make_manager(tmp_path)
+        depths = _make_depth(4)
+        mgr.start_episode(0, ["camera", "camera_right"])
+        for d in depths:
+            mgr.add_frame("camera", d)
+            mgr.add_frame("camera_right", d * 0.9)
+        mgr.end_episode(0)
+        meta_path = mgr.finalize()
+        assert meta_path == tmp_path / "depth_meta.json"
+        assert (tmp_path / "depth_videos" / "camera" / "episode_000000.mp4").exists()
+        assert (
+            tmp_path / "depth_videos" / "camera_right" / "episode_000000.mp4"
+        ).exists()
+
+        meta = json.loads(meta_path.read_text())
+        assert meta["is_depth_map"] is True
+        assert set(meta["sensors"]) == {"camera", "camera_right"}
+        cam = meta["sensors"]["camera"]
+        assert cam["video.pix_fmt"] == "gray12le"
+        assert cam["video.depth_min"] == DEPTH_MIN
+        assert cam["video.use_log"] is True
+        assert cam["episodes"]["0"]["frame_count"] == 4
+        assert cam["episodes"]["0"]["file"].startswith("depth_videos/camera/")
+
+    def test_reader_roundtrip_matches_original(self, tmp_path: Path):
+        """The reader dequantizes back to depths close to the originals."""
+        mgr = self._make_manager(tmp_path)
+        depths = _make_depth(3)
+        mgr.start_episode(0, ["camera"])
+        for d in depths:
+            mgr.add_frame("camera", d)
+        mgr.end_episode(0)
+        mgr.finalize()
+
+        lib = DepthVideoLibrary(tmp_path, load_depth_meta(tmp_path))
+        assert lib.sensors == ["camera", "camera_right"]
+        assert lib.frame_count(0, "camera") == 3
+        for i, orig in enumerate(depths):
+            dec = lib.get(0, "camera", i).squeeze()
+            assert dec.shape == (H, W)
+            assert float(np.abs(dec - orig).max()) < 5e-3
+
+    def test_abort_episode_removes_partial_files(self, tmp_path: Path):
+        mgr = self._make_manager(tmp_path)
+        depths = _make_depth(2)
+        mgr.start_episode(0, ["camera"])
+        for d in depths:
+            mgr.add_frame("camera", d)
+        # Simulate a failed save_episode(): abort instead of end_episode.
+        mgr.abort_episode()
+        # No finalised mp4 should exist for the aborted episode.
+        assert not (
+            tmp_path / "depth_videos" / "camera" / "episode_000000.mp4"
+        ).exists()
+
+    def test_multiple_episodes_accumulate_in_metadata(self, tmp_path: Path):
+        mgr = self._make_manager(tmp_path)
+        for ep in range(3):
+            depths = _make_depth(2)
+            mgr.start_episode(ep, ["camera"])
+            for d in depths:
+                mgr.add_frame("camera", d)
+            mgr.end_episode(ep)
+        mgr.finalize()
+        meta = json.loads((tmp_path / "depth_meta.json").read_text())
+        assert sorted(meta["sensors"]["camera"]["episodes"]) == ["0", "1", "2"]
+
+
+class TestCodec:
+    """Codec detection tests."""
+
+    def test_detect_returns_available_encoder(self):
+        # Skipped on hosts without libx265 via the module-level pytestmark.
+        assert detect_depth_encoder("libx265") == "libx265"
+
+    def test_resolve_raises_when_unavailable(self, monkeypatch):
+        from embodichain.data_pipeline.depth_video import codec as codec_mod
+
+        monkeypatch.setattr(codec_mod, "get_codec", lambda name: None)
+        with pytest.raises(DepthCodecError):
+            codec_mod.resolve_depth_vcodec("libx265")

--- a/tests/gym/envs/managers/test_dataset_functors.py
+++ b/tests/gym/envs/managers/test_dataset_functors.py
@@ -49,6 +49,14 @@ except ImportError:
     CAMERA_AVAILABLE = False
     Camera = None
 
+# Depth sidecar video tests require an HEVC encoder in the bundled FFmpeg build.
+try:
+    from embodichain.data_pipeline.depth_video import detect_depth_encoder
+
+    _HAS_DEPTH_CODEC = detect_depth_encoder("libx265") is not None
+except ImportError:
+    _HAS_DEPTH_CODEC = False
+
 
 class MockRobot:
     """Mock robot for dataset functor tests."""
@@ -390,6 +398,209 @@ class TestLeRobotRecorderFeatures:
             features = recorder._build_features()
 
         assert "observation.normal.camera" not in features
+
+    @pytest.mark.skipif(not _HAS_DEPTH_CODEC, reason="libx265/hevc not available")
+    @patch("embodichain.lab.gym.envs.managers.datasets.LeRobotDataset")
+    def test_build_features_excludes_depth_when_video_enabled(
+        self, mock_lerobot_dataset
+    ):
+        """Depth is excluded from numeric features when depth video is on."""
+        env = MockEnvForDataset(num_joints=6)
+        env.single_observation_space["sensor"]["camera"].update(
+            {
+                "depth": Mock(dtype=np.dtype("float32"), shape=(32, 48)),
+                "depth_right": Mock(dtype=np.dtype("float32"), shape=(32, 48)),
+                "mask": Mock(dtype=np.dtype("int32"), shape=(32, 48)),
+            }
+        )
+
+        mock_dataset_instance = Mock()
+        mock_dataset_instance.meta = Mock()
+        mock_dataset_instance.meta.info = {"fps": 30}
+        mock_lerobot_dataset.create.return_value = mock_dataset_instance
+
+        cfg = MockFunctorCfg(
+            params={
+                "save_path": "/tmp/test_dataset",
+                "robot_meta": {"robot_type": "test_robot", "control_freq": 30},
+                "instruction": {"lang": "test task"},
+                "extra": {"task_description": "test"},
+                "use_videos": False,
+                "depth_video": {"enable": True, "depth_min": 0.1, "depth_max": 3.0},
+            }
+        )
+
+        original_isinstance = isinstance
+
+        def mock_isinstance(obj, class_or_tuple):
+            if isinstance(obj, MockSensor) and (
+                class_or_tuple is Camera
+                or (isinstance(class_or_tuple, tuple) and Camera in class_or_tuple)
+            ):
+                return True
+            return original_isinstance(obj, class_or_tuple)
+
+        with patch(
+            "embodichain.lab.gym.envs.managers.datasets.isinstance",
+            side_effect=mock_isinstance,
+        ):
+            recorder = LeRobotRecorder(cfg, env)
+            features = recorder._build_features()
+
+        # Depth is offloaded to sidecar videos -> not a numeric feature.
+        assert "observation.depth.camera" not in features
+        assert "observation.depth.camera_right" not in features
+        # Mask remains a numeric feature.
+        assert features["observation.mask.camera"]["dtype"] == "int32"
+        # Both depth sensors were registered for the sidecar writer.
+        assert set(recorder._depth_sensor_specs) == {"camera", "camera_right"}
+
+    @pytest.mark.skipif(not _HAS_DEPTH_CODEC, reason="libx265/hevc not available")
+    @patch("embodichain.lab.gym.envs.managers.datasets.LeRobotDataset")
+    def test_build_features_keeps_numeric_depth_with_fallback(
+        self, mock_lerobot_dataset
+    ):
+        """keep_numeric_fallback retains depth as a numeric feature too."""
+        env = MockEnvForDataset(num_joints=6)
+        env.single_observation_space["sensor"]["camera"].update(
+            {
+                "depth": Mock(dtype=np.dtype("float32"), shape=(32, 48)),
+                "mask": Mock(dtype=np.dtype("int32"), shape=(32, 48)),
+            }
+        )
+
+        mock_dataset_instance = Mock()
+        mock_dataset_instance.meta = Mock()
+        mock_dataset_instance.meta.info = {"fps": 30}
+        mock_lerobot_dataset.create.return_value = mock_dataset_instance
+
+        cfg = MockFunctorCfg(
+            params={
+                "save_path": "/tmp/test_dataset",
+                "robot_meta": {"robot_type": "test_robot", "control_freq": 30},
+                "instruction": {"lang": "test task"},
+                "extra": {"task_description": "test"},
+                "use_videos": False,
+                "depth_video": {
+                    "enable": True,
+                    "depth_min": 0.1,
+                    "depth_max": 3.0,
+                    "keep_numeric_fallback": True,
+                },
+            }
+        )
+
+        original_isinstance = isinstance
+
+        def mock_isinstance(obj, class_or_tuple):
+            if isinstance(obj, MockSensor) and (
+                class_or_tuple is Camera
+                or (isinstance(class_or_tuple, tuple) and Camera in class_or_tuple)
+            ):
+                return True
+            return original_isinstance(obj, class_or_tuple)
+
+        with patch(
+            "embodichain.lab.gym.envs.managers.datasets.isinstance",
+            side_effect=mock_isinstance,
+        ):
+            recorder = LeRobotRecorder(cfg, env)
+            features = recorder._build_features()
+
+        # Depth is both a numeric feature AND registered for the sidecar writer.
+        assert features["observation.depth.camera"]["dtype"] == "float32"
+        assert "camera" in recorder._depth_sensor_specs
+
+
+@pytest.mark.skipif(not LEROBOT_AVAILABLE, reason="LeRobot not installed")
+class TestLeRobotRecorderDepthSidecar:
+    """Integration tests for depth sidecar video writing during save."""
+
+    @pytest.mark.skipif(not _HAS_DEPTH_CODEC, reason="libx265/hevc not available")
+    @patch("embodichain.lab.gym.envs.managers.datasets.LeRobotDataset")
+    def test_save_episode_writes_depth_sidecar(self, mock_lerobot_dataset, tmp_path):
+        """A real episode writes depth sidecar MP4s and metadata."""
+        env = MockEnvForDataset(num_joints=6)
+        env._sensors["camera"].cfg.height = 32
+        env._sensors["camera"].cfg.width = 48
+        env.single_observation_space["sensor"]["camera"].update(
+            {
+                "color": Mock(dtype=np.dtype("uint8"), shape=(32, 48, 4)),
+                "depth": Mock(dtype=np.dtype("float32"), shape=(32, 48)),
+                "mask": Mock(dtype=np.dtype("int32"), shape=(32, 48)),
+            }
+        )
+
+        mock_dataset_instance = Mock()
+        mock_dataset_instance.meta = Mock()
+        mock_dataset_instance.meta.info = {"fps": 30}
+        mock_lerobot_dataset.create.return_value = mock_dataset_instance
+
+        cfg = MockFunctorCfg(
+            params={
+                "save_path": str(tmp_path),
+                "robot_meta": {"robot_type": "test_robot", "control_freq": 30},
+                "instruction": {"lang": "test task"},
+                "extra": {"task_description": "test"},
+                "use_videos": False,
+                "depth_video": {"enable": True, "depth_min": 0.1, "depth_max": 3.0},
+            }
+        )
+
+        original_isinstance = isinstance
+
+        def mock_isinstance(obj, class_or_tuple):
+            if isinstance(obj, MockSensor) and (
+                class_or_tuple is Camera
+                or (isinstance(class_or_tuple, tuple) and Camera in class_or_tuple)
+            ):
+                return True
+            return original_isinstance(obj, class_or_tuple)
+
+        with patch(
+            "embodichain.lab.gym.envs.managers.datasets.isinstance",
+            side_effect=mock_isinstance,
+        ):
+            recorder = LeRobotRecorder(cfg, env)
+
+            depth = torch.linspace(0.2, 2.8, 32 * 48, dtype=torch.float32).reshape(
+                32, 48
+            )
+            obs_list = []
+            for i in range(3):
+                obs_list.append(
+                    TensorDict(
+                        {
+                            "robot": {
+                                "qpos": torch.zeros(6),
+                                "qvel": torch.zeros(6),
+                                "qf": torch.zeros(6),
+                            },
+                            "sensor": {
+                                "camera": {
+                                    "color": torch.zeros(32, 48, 4, dtype=torch.uint8),
+                                    "depth": depth + 0.01 * i,
+                                    "mask": torch.zeros(32, 48, dtype=torch.int32),
+                                }
+                            },
+                        },
+                        batch_size=[],
+                    )
+                )
+            action_list = [torch.zeros(6) for _ in range(3)]
+
+            ok = recorder._save_single_episode(0, obs_list, action_list)
+            assert ok
+
+        # The depth sidecar video and metadata were written.
+        ds_root = recorder.dataset_full_path
+        assert (ds_root / "depth_videos" / "camera" / "episode_000000.mp4").exists()
+        assert (ds_root / "depth_meta.json").exists()
+
+        # LeRobot's add_frame never received a depth key (RGB-only pipeline).
+        for call in mock_dataset_instance.add_frame.call_args_list:
+            frame = call.args[0]
+            assert not any(k.startswith("observation.depth.") for k in frame)
 
 
 @pytest.mark.skipif(not LEROBOT_AVAILABLE, reason="LeRobot not installed")


### PR DESCRIPTION
## Description

This PR implements issue #424 **Path A**: an EmbodiChain-owned depth writer that stores camera depth as compressed `gray12le`/HEVC sidecar videos alongside LeRobot datasets, on Python 3.10/3.11 with lerobot 0.4.4 — without the Python 3.12 / lerobot 0.6.0 upgrade.

Built on top of the merged PR #422 (numeric depth/mask features). Depth quantization math is vendored from lerobot v0.6.0 (`depth_utils.py`), which has **no py3.12-only syntax** — `requires-python>=3.12` is a project policy, not a technical barrier of the depth code. The sidecar metadata schema is aligned with the official 0.6.0 reader for a seamless future migration (Path B).

### What's added
- **`embodichain/data_pipeline/depth_video/`** — `depth_utils` (quantize/dequantize, vendored), `codec` (libx265/hevc detection), `DepthVideoWriter` + `DepthSidecarManager` (per-episode `gray12le`/libx265 lossless-or-CRF MP4s + `depth_meta.json`), `DepthVideoReader` + `load_depth_dataset` (decode + dequantize to m/mm).
- **`LeRobotRecorder`** — `depth_video` config; when enabled, depth is offloaded to the sidecar writer and dropped from lerobot's RGB-only image/video pipeline. Mask stays numeric. Auto-fallback to numeric depth (#422) when no HEVC encoder is available. Works for both sync and async recorders.
- **Tests** (35, ~1s) — quantization round-trip error bounds, lossless 12-bit code bit-exactness, sidecar metadata/stereo/abort, codec detection, and recorder integration.
- **Docs** + a **benchmark script** (`scripts/benchmark/data_pipeline/benchmark_depth_size.py`).

### Storage size (benchmark, 480x640 x 100 frames @ 30fps)

| Storage | Size | vs raw f32 | Precision |
|---|---|---|---|
| numeric float32 Parquet (snappy, #422 default) | 117.9 MB | ~1x | exact |
| numeric uint16 Parquet (zstd) | 39.5 MB | ~3x | exact |
| **sidecar lossless (HEVC)** | **20.6 MB** | **~6x** | 12-bit quantized, sub-mm error |
| sidecar lossy (CRF28) | ~10 KB | ~1000x+ | lossy |

Lossless sidecar is ~6x smaller than the numeric float32 Parquet from #422, and the 12-bit codes survive the encode/decode round-trip bit-exactly (verified; max error 0.6 mm over 0.1-3.0 m).

### Key technical note
libx265's default B-frame/lookahead buffering races on the flush of 1-3 frame videos (`PatchWelcomeError`). Setting `bframes=0` makes the flush deterministic (0/24 failures after the fix vs 7/24 before).

Dependencies: none new (uses already-installed `av`/pyav, numpy, torch).

Fixes #424

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (existing functionality will not work without user modification)
- [ ] Documentation update

Non-breaking: `depth_video` defaults to `enable=False`, so existing recordings are unchanged.

## Screenshots

Not applicable; affects structured dataset output.

## Checklist

- [x] I have run the `black .` command to format the code base.
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Dependencies have been updated, if applicable. (None updated; uses existing `av`/numpy/torch.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
