### PR TITLE
Fix push cube training issues

### DIFF
--- a/embodichain/lab/gym/envs/embodied_env.py
+++ b/embodichain/lab/gym/envs/embodied_env.py
@@ -291,7 +291,8 @@ class EmbodiedEnv(BaseEnv):
 
         super().__init__(cfg, **kwargs)
 
-        if self.cfg.dataset and not self.cfg.filter_dataset_saving:
+        dataset_terms = getattr(self.cfg.dataset, "__dict__", self.cfg.dataset)
+        if dataset_terms and not self.cfg.filter_dataset_saving:
             self.dataset_manager = DatasetManager(self.cfg.dataset, self)
             self.cfg.init_rollout_buffer = True
 

--- a/embodichain/lab/gym/envs/managers/rewards.py
+++ b/embodichain/lab/gym/envs/managers/rewards.py
@@ -153,15 +153,12 @@ def action_smoothness_penalty(
     """Penalize large action changes between consecutive timesteps.
 
     Encourages smooth control commands by penalizing sudden changes in actions.
-    Gets previous action from env.episode_action_buffer.
+    Reads the previous action from the RL ``rollout_buffer`` (``action`` / ``done``).
+    Returns zeros when that buffer is unavailable (e.g. evaluation).
 
     Returns:
         Penalty tensor of shape (num_envs,). Zero on first step (no previous action),
         negative on subsequent steps (larger change = more negative).
-
-    Note:
-        This function reads from env.episode_action_buffer, which is automatically
-        cleared when the environment resets.
 
     Example:
         ```json
@@ -172,23 +169,25 @@ def action_smoothness_penalty(
         }
         ```
     """
-    # Extract current action tensor
     if isinstance(action, torch.Tensor):
         current_action = action
     else:
         current_action = action["qpos"]
 
-    # Get previous action from buffer for each environment
-    if env.current_rollout_step == 0:
-        penalty = torch.zeros(env.num_envs, device=env.device)
-    else:
-        dones = env.rollout_buffer["done"][: env.num_envs, env.current_rollout_step - 1]
-        pre_action = env.rollout_buffer["action"][
-            : env.num_envs, env.current_rollout_step - 1
-        ]
-        penalty = -torch.norm(current_action - pre_action, dim=-1)
-        penalty[dones] = 0.0
+    buffer = getattr(env, "rollout_buffer", None)
+    has_rl_prev_step = (
+        env.current_rollout_step > 0
+        and buffer is not None
+        and "done" in buffer.keys()
+        and "action" in buffer.keys()
+    )
+    if not has_rl_prev_step:
+        return torch.zeros(env.num_envs, device=env.device)
 
+    dones = buffer["done"][: env.num_envs, env.current_rollout_step - 1]
+    pre_action = buffer["action"][: env.num_envs, env.current_rollout_step - 1]
+    penalty = -torch.norm(current_action - pre_action, dim=-1)
+    penalty[dones] = 0.0
     return penalty
 
 

--- a/embodichain/lab/gym/utils/gym_utils.py
+++ b/embodichain/lab/gym/utils/gym_utils.py
@@ -666,6 +666,7 @@ def config_to_cfg(config: dict, manager_modules: list = None) -> "EmbodiedEnvCfg
             reward = RewardCfg(
                 func=reward_func,
                 mode=reward_params_modified["mode"],
+                weight=float(reward_params_modified.get("weight", 1.0)),
                 params=reward_params_modified["params"],
             )
 

--- a/tests/gym/envs/managers/test_reward_functors.py
+++ b/tests/gym/envs/managers/test_reward_functors.py
@@ -293,6 +293,28 @@ class TestActionSmoothnessPenalty:
         # All have negative penalty from action difference
         assert torch.all(result < 0)
 
+    def test_zero_when_expert_buffer_lacks_rl_keys(self):
+        """Expert buffers without done/action keys yield zero penalty."""
+        env = MockEnv(num_envs=4)
+        env.current_rollout_step = 1
+        env.rollout_buffer = {
+            "obs": torch.zeros(4, 100, 8),
+            "actions": torch.zeros(4, 100, 6),
+            "rewards": torch.zeros(4, 100),
+        }
+        result = action_smoothness_penalty(env, {}, torch.ones(4, 6), {})
+        assert result.shape == (4,)
+        assert torch.all(result == 0)
+
+    def test_zero_when_rollout_buffer_missing(self):
+        """Missing rollout buffer yields zero penalty."""
+        env = MockEnv(num_envs=4)
+        env.current_rollout_step = 1
+        env.rollout_buffer = None
+        result = action_smoothness_penalty(env, {}, torch.ones(4, 6), {})
+        assert result.shape == (4,)
+        assert torch.all(result == 0)
+
 
 class TestJointLimitPenalty:
     """Tests for joint_limit_penalty reward functor."""


### PR DESCRIPTION
## Description

This PR fixes two bugs that broke PushCube RL training/evaluation:

- Pass reward `weight` from JSON into `RewardCfg` 
- Avoid creating an expert rollout buffer for empty `dataset` configs

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

<img width="1523" height="325" alt="截屏2026-07-29 22 30 00" src="https://github.com/user-attachments/assets/73acb687-fc94-42da-adc6-f9146c0bac34" />

https://github.com/user-attachments/assets/05efae0e-ccc4-48a6-8cf6-6c01a679d71d



## Checklist

- [x] I have run the `black .` command to format the code base.
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Dependencies have been updated, if applicable.
