### PR TITLE
Reduce redundant CI runs and gate release publishing

### DIFF
--- a/.agents/skills/pr/SKILL.md
+++ b/.agents/skills/pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr
-description: Create a pull request for EmbodiChain following the project's PR template and conventions, including selecting proper GitHub repository labels
+description: Create a pull request for EmbodiChain following the project's PR template and conventions, including proportional validation and proper GitHub repository labels
 ---
 
 # EmbodiChain Pull Request Creator
@@ -44,7 +44,29 @@ Write a description that includes:
 - **Motivation and context**: Why this change is needed
 - **Dependencies**: List any dependencies required for this change
 
-### 4. Run Code Formatting
+### 4. Select Proportional Validation
+
+Inspect the changed files and validate only the affected behavior. Do not run the
+full test suite automatically.
+
+- Workflow-only changes: run `actionlint` on the changed workflows and any
+  directly related workflow-script tests.
+- Documentation-only changes: run the relevant docs checks or build; do not run
+  Python tests unless executable examples or docs tooling changed.
+- Isolated Python changes: run the nearest matching test module or package.
+- Shared infrastructure or cross-package changes: run affected package tests and
+  focused integration tests.
+- Run the full suite only for broad cross-cutting changes, global dependency or
+  test-configuration changes, release-critical changes that cannot be validated
+  narrowly, or when the user explicitly requests it.
+
+If a validation command is likely to take more than two minutes, state why it is
+needed before starting it. Honor an explicit user request to skip or narrow tests,
+and record skipped checks honestly in the PR description.
+
+Use the `pre-commit-check` skill for the detailed selection and reporting rules.
+
+### 5. Run Code Formatting
 
 Before creating the PR, ensure code is formatted:
 
@@ -59,7 +81,7 @@ git add -A
 git commit -m "Format code with black"
 ```
 
-### 5. Create or Update Branch
+### 6. Create or Update Branch
 
 If not already on a feature branch:
 
@@ -73,7 +95,7 @@ Recommended branch naming:
 - `enhance/<description>` - for enhancements
 - `docs/<description>` - for documentation changes
 
-### 6. Commit Changes
+### 7. Commit Changes
 
 Commit with a clear message following conventional commits format:
 
@@ -83,13 +105,13 @@ git commit -m "type(scope): brief description
 Detailed description of the change."
 ```
 
-### 7. Push to Remote
+### 8. Push to Remote
 
 ```bash
 git push -u origin <branch-name>
 ```
 
-### 8. Create the PR
+### 9. Create the PR
 
 Use the gh CLI with the proper PR template:
 
@@ -97,7 +119,7 @@ Use the gh CLI with the proper PR template:
 gh pr create --title "<PR Title>" --body "<PR Body>"
 ```
 
-### 9. Select and Apply Labels
+### 10. Select and Apply Labels
 
 After creating the PR, select proper labels from the repository label list and apply them.
 

--- a/.agents/skills/pre-commit-check/SKILL.md
+++ b/.agents/skills/pre-commit-check/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: pre-commit-check
-description: Use before committing or creating a PR for EmbodiChain to verify code style, headers, annotations, exports, and docstrings pass CI checks
+description: Use before committing or creating a PR for EmbodiChain to select proportional validation and verify affected code style, tests, headers, annotations, exports, and docstrings
 ---
 
 # Pre-Commit Check
 
-Run all local checks that the CI pipeline enforces, catching issues before pushing.
+Run proportional local checks for the files being changed, catching relevant
+issues before pushing without defaulting to the full test suite.
 
 ## When to Use
 
@@ -24,6 +25,9 @@ git status --short
 ```
 
 Collect all changed/added `.py` files.
+
+Classify the change by affected area: workflow, docs, packaging, isolated Python
+module, package-wide behavior, or cross-cutting infrastructure.
 
 ### 2. Run Black Formatting Check
 
@@ -100,14 +104,42 @@ For any new configuration class:
 - Must use `from dataclasses import MISSING` for required fields
 - Import from `embodichain.utils import configclass`
 
-### 9. Check Test Coverage
+### 9. Select and Run Relevant Tests
+
+Do not treat the CI test job as a requirement to run `pytest tests` locally for
+every change. Choose the smallest command set that exercises the affected
+behavior:
+
+| Change scope | Default validation |
+|---|---|
+| `.github/workflows/**` only | `actionlint` on changed workflows; run related script tests only when workflow scripts changed |
+| Docs content only | Relevant Sphinx build or docs-specific tests |
+| One Python module | Matching `tests/**/test_<module>.py` |
+| One package/subsystem | Tests for that package plus focused integration tests |
+| Packaging/release code | Package build and artifact validation |
+| Shared core, global test config, or multiple subsystems | Broader affected tests; full suite only when narrow coverage is not credible |
+
+Skip runtime tests when no executable behavior is affected, but still run the
+appropriate syntax or configuration validator. Run the full suite only when:
+
+- the change affects shared core behavior used throughout the repository;
+- global dependencies, test configuration, or environment initialization changed;
+- several subsystems are modified together;
+- a release-critical behavior cannot be validated narrowly; or
+- the user explicitly requests it.
+
+Before starting a command likely to take more than two minutes, report the
+selected scope and why narrower validation is insufficient. Honor explicit user
+instructions to skip or narrow tests.
+
+### 10. Check Test Coverage
 
 For any new public module or function:
 - A corresponding test must exist at `tests/<subpackage>/test_<module>.py`
 - Test file must also have the Apache 2.0 header
 - Report if tests are missing
 
-### 10. Summary Report
+### 11. Summary Report
 
 Output a pass/fail summary:
 
@@ -121,6 +153,8 @@ Pre-Commit Check Results
 [PASS] Docstrings on public APIs
 [PASS] Type annotations
 [PASS] @configclass usage
+[PASS] Targeted tests — tests/foo/test_bar.py
+[N/A] Full test suite — isolated change covered by targeted tests
 [WARN] Missing tests for: bar.py
 
 Fix the above issues before committing.
@@ -134,7 +168,9 @@ The project's CI pipeline (`.github/workflows/main.yml`) runs:
 2. **test** job: `pytest tests`
 3. **build** job: Sphinx docs build
 
-This skill covers items 1 and 2 locally. Docs build is heavier and typically only needed for documentation changes.
+This skill always covers the relevant lint and structural checks, then selects
+tests proportionally. It does not require reproducing the entire CI pipeline for
+every local change.
 
 ## Common Mistakes
 
@@ -155,4 +191,5 @@ This skill covers items 1 and 2 locally. Docs build is heavier and typically onl
 | Header check | Verify first line is `# ---...---` |
 | `__future__` import | Grep for `from __future__ import annotations` |
 | `__all__` export | Grep for `__all__` in module |
-| Run tests | `pytest tests/<path>` |
+| Run targeted tests | `pytest tests/<affected-path>` |
+| Run full tests | `pytest tests` only when the full-suite criteria above apply |

--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -4,6 +4,7 @@ on:
   workflow_run:
     workflows: ["CI/CD Pipeline"]
     types: [completed]
+    branches: [main]
   workflow_dispatch:
     inputs:
       ref:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,9 +4,13 @@ on:
   push:
     branches: [main]
     tags:
-      - 'v*'  # Match tags starting with v, e.g., v1.0.0
+      - 'v*'
   pull_request:
     branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/v') }}
 
 jobs:
   lint:
@@ -41,13 +45,13 @@ jobs:
           fi
 
   build:
+    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
     needs: lint
     runs-on: Linux
     env:
       NVIDIA_DRIVER_CAPABILITIES: all
       NVIDIA_VISIBLE_DEVICES: all
       NVIDIA_DISABLE_REQUIRE: 1
-      DOCS_MAX_VERSIONS: 5
     container: *container_template
     steps:
       - uses: actions/checkout@v4
@@ -80,14 +84,10 @@ jobs:
         shell: bash
         run: |
           SITE_URL="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}"
-          SKIP_VERSION="main"
-          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
-            SKIP_VERSION="${GITHUB_REF_NAME}"
-          fi
           python3 ${GITHUB_WORKSPACE}/docs/scripts/merge_published_site.py \
             --build-dir ${GITHUB_WORKSPACE}/docs/build/html \
             --site-base-url "${SITE_URL}" \
-            --skip-version "${SKIP_VERSION}"
+            --skip-version main
 
       - name: Build docs
         shell: bash
@@ -102,28 +102,11 @@ jobs:
           pip uninstall pymeshlab -y
           pip install pymeshlab==2023.12.post3
 
-          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
-            VERSION="${GITHUB_REF_NAME}"
-            echo "Building docs for release tag ${VERSION}..."
-            sphinx-build source build/html/${VERSION}
-
-            cd build/html
-
-            # Prune old release versions beyond the window
-            mapfile -t TAG_DIRS < <(ls -d v*/ 2>/dev/null | sort -V)
-            while [[ ${#TAG_DIRS[@]} -gt ${DOCS_MAX_VERSIONS:-5} ]]; do
-              echo "Pruning old version: ${TAG_DIRS[0]}"
-              rm -rf "${TAG_DIRS[0]}"
-              TAG_DIRS=("${TAG_DIRS[@]:1}")
-            done
-
-          else
-            echo "Building dev docs for main branch..."
-            # Only rebuild main/ — other versions come from cache + live Pages merge
-            rm -rf build/html/main
-            sphinx-build source build/html/main
-            cd build/html
-          fi
+          echo "Building dev docs for main branch..."
+          # Only rebuild main/ — other versions come from cache + live Pages merge
+          rm -rf build/html/main
+          sphinx-build source build/html/main
+          cd build/html
 
           # Regenerate versions.json and root index.html from all present dirs
           python3 ${GITHUB_WORKSPACE}/docs/scripts/generate_versions_json.py \
@@ -173,7 +156,7 @@ jobs:
           echo "Default test suite (GPU-marked tests are skipped)"
           export HF_ENDPOINT=https://hf-mirror.com
           pytest tests/docs -q --confcutdir=tests/docs
-          pytest tests
+          pytest tests --ignore=tests/docs
 
       - name: Run GPU tests serially
         run: |
@@ -184,36 +167,24 @@ jobs:
   release-build:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: lint
-    runs-on: Linux
-
-    container: *container_template
-
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: ./.github/actions/activate-conda
 
-      - name: (Release) Install build tools
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Build and validate distributions
         run: |
           python -m pip install --upgrade pip
-          pip install build
-
-      - name: (Release) Build sdist and wheel
-        run: |
+          python -m pip install build twine
           python -m build
+          python -m twine check dist/*
 
-      # - name: (Release) Create GitHub Release (draft)
-      #   uses: softprops/action-gh-release@v2
-      #   with:
-      #     draft: true
-      #     generate_release_notes: true
-      #     files: |
-      #       dist/*
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: (Release) Upload distributions
+      - name: Upload validated distributions
         uses: actions/upload-artifact@v4
         with:
           name: python-distributions

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -5,6 +5,7 @@ on:
     types: [published]
 
 permissions:
+  actions: read
   contents: read
 
 jobs:
@@ -15,6 +16,7 @@ jobs:
       name: pypi
       url: https://pypi.org/p/embodichain
     permissions:
+      actions: read
       contents: read
       id-token: write  # PyPI Trusted Publishing
 
@@ -22,16 +24,81 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 1
 
-      - uses: actions/setup-python@v5
+      - name: Resolve release commit
+        id: release
+        shell: bash
+        run: echo "sha=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
+
+      - name: Find successful tag build
+        id: tag-build
+        uses: actions/github-script@v7
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_SHA: ${{ steps.release.outputs.sha }}
         with:
-          python-version: '3.11'
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const tag = process.env.RELEASE_TAG;
+            const sha = process.env.RELEASE_SHA;
+            const deadline = Date.now() + 30 * 60 * 1000;
 
-      - name: Build distributions from the published tag
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install build
-          python -m build
+            while (Date.now() < deadline) {
+              const response = await github.rest.actions.listWorkflowRuns({
+                owner,
+                repo,
+                workflow_id: "main.yml",
+                event: "push",
+                head_sha: sha,
+                per_page: 100,
+              });
+              const runs = response.data.workflow_runs.filter(
+                (run) => run.head_branch === tag && run.head_sha === sha,
+              );
+              const successfulRun = runs.find(
+                (run) =>
+                  run.status === "completed" && run.conclusion === "success",
+              );
+
+              if (successfulRun) {
+                core.info(
+                  `Using validated distributions from workflow run ${successfulRun.id}`,
+                );
+                core.setOutput("run-id", successfulRun.id);
+                return;
+              }
+
+              const activeRun = runs.find((run) => run.status !== "completed");
+              if (activeRun) {
+                core.info(
+                  `Tag build ${activeRun.id} is ${activeRun.status}; waiting...`,
+                );
+              } else if (runs.length > 0) {
+                core.setFailed(
+                  `The CI/CD Pipeline did not succeed for ${tag} at ${sha}. ` +
+                    "Rerun the tag workflow successfully before publishing.",
+                );
+                return;
+              } else {
+                core.info(`No tag build found yet for ${tag} at ${sha}; waiting...`);
+              }
+
+              await new Promise((resolve) => setTimeout(resolve, 15000));
+            }
+
+            core.setFailed(
+              `Timed out waiting for a successful tag build for ${tag} at ${sha}.`,
+            );
+
+      - name: Download validated distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: python-distributions
+          path: dist/
+          run-id: ${{ steps.tag-build.outputs.run-id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Description

This PR reduces redundant GitHub Actions work and turns the tag distribution build into a release gate.

- cancel superseded CI runs for the same PR or main ref while preserving tag builds
- limit Pages workflow chaining to successful main-branch candidates
- avoid collecting docs tests twice
- build and validate distributions once on v* tags, then reuse the exact artifact for PyPI publishing
- make PR and pre-commit skills choose proportional, change-aware validation instead of defaulting to the full test suite

The release workflow matches the tag name and exact commit SHA, waits for a successful tag CI run, and downloads its validated distribution artifact before publishing.

Dependencies: None.

Related issue: None.

## Type of change

- [x] Enhancement (non-breaking change which improves existing functionality)

## Screenshots

Not applicable.

## Validation

- `black .` — 497 files unchanged
- `actionlint` — all changed workflows passed
- skill `quick_validate.py` — both updated skills passed
- `pytest tests/docs -q --confcutdir=tests/docs` — 12 passed
- full pytest suite not run; changes are limited to workflows and skill instructions and were validated with focused checks

## Checklist

- [x] I have run the `black .` command to format the code base.
- [ ] I have made corresponding changes to the documentation — not applicable to public APIs.
- [ ] I have added tests that prove my fix is effective — no executable Python behavior changed.
- [x] Dependencies have been updated, if applicable — no dependency changes required.