### PR TITLE
Add configurable cuRobo log level

### DIFF
--- a/docs/source/overview/sim/planners/curobo_planner.md
+++ b/docs/source/overview/sim/planners/curobo_planner.md
@@ -74,6 +74,10 @@ planner_cfg = CuroboPlannerCfg(
 motion_generator = MotionGenerator(MotionGenCfg(planner_cfg=planner_cfg))
 ~~~
 
+cuRobo's Python logger defaults to error-only output. Set
+`CuroboPlannerCfg.log_level` to `"debug"`, `"info"`, `"warning"`, or `"error"`
+to change its verbosity. This setting does not affect EmbodiChain's own logs.
+
 The physics and planner devices are independent.
 `SimulationManagerCfg(sim_device="cpu")` keeps robot state, targets, and
 returned trajectories on CPU,

--- a/embodichain/lab/sim/planners/curobo/curobo_planner.py
+++ b/embodichain/lab/sim/planners/curobo/curobo_planner.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import hashlib
 import importlib
+import logging
 import os
 import threading
 import time
@@ -285,6 +286,15 @@ class CuroboPlannerCfg(BasePlannerCfg):
     """
 
     planner_type: str = "curobo"
+
+    log_level: str = "error"
+    """Log level for cuRobo's Python logger.
+
+    Supported values are ``"debug"``, ``"info"``, ``"warning"`` (or
+    ``"warn"``), and ``"error"``. The setting is applied before cuRobo is
+    imported, so it also controls messages emitted during backend
+    initialization. It does not change EmbodiChain's own log level.
+    """
 
     world: CuroboWorldCfg = CuroboWorldCfg()
     """Collision-world configuration (auto-generated from ``RigidObject`` meshes)."""
@@ -592,8 +602,37 @@ def _get_capture_coordinator() -> "Any":
     return coordinator_mod.CaptureCoordinator.get()
 
 
-def _require_curobo() -> "Any":
+def _configure_curobo_logging(log_level: str) -> None:
+    """Set cuRobo's logger level without reconfiguring the root logger.
+
+    Args:
+        log_level: One of ``"debug"``, ``"info"``, ``"warning"``/``"warn"``,
+            or ``"error"``. Matching is case-insensitive.
+
+    Raises:
+        ValueError: If ``log_level`` is unsupported.
+    """
+    levels = {
+        "debug": logging.DEBUG,
+        "info": logging.INFO,
+        "warn": logging.WARNING,
+        "warning": logging.WARNING,
+        "error": logging.ERROR,
+    }
+    normalized = str(log_level).lower()
+    if normalized not in levels:
+        raise ValueError(
+            "CuroboPlannerCfg.log_level must be one of "
+            f"{tuple(levels)}, got {log_level!r}."
+        )
+    logging.getLogger("curobo").setLevel(levels[normalized])
+
+
+def _require_curobo(log_level: str = "error") -> "Any":
     """Lazily import and bundle the cuRobo V2 public facade types.
+
+    Args:
+        log_level: cuRobo logger level applied before importing the backend.
 
     Returns:
         A namespace exposing ``MotionPlanner``, ``MotionPlannerCfg``,
@@ -603,6 +642,7 @@ def _require_curobo() -> "Any":
         ImportError: If cuRobo V2 is not installed, with an actionable message
             naming NVIDIA's CUDA-matched extras.
     """
+    _configure_curobo_logging(log_level)
     # cuRobo 0.8 references ``wp.torch.*``, which Warp >= 1.13 relocated.
     _ensure_warp_torch_compat()
     try:
@@ -731,7 +771,7 @@ class CuroboPlanner(BasePlanner):
         # cuRobo and Warp contain a few current-device-sensitive initialization
         # paths, so select the dedicated planning GPU before importing them.
         torch.cuda.set_device(self._curobo_device)
-        self._bindings = _require_curobo()
+        self._bindings = _require_curobo(cfg.log_level)
         self._backend_cache: dict[tuple[str, int, bool, MoveType], "_CuroboBackend"] = (
             {}
         )

--- a/tests/sim/planners/test_curobo_planner.py
+++ b/tests/sim/planners/test_curobo_planner.py
@@ -25,6 +25,7 @@ collision-planning coverage remains in ``test_curobo_integration.py``.
 from __future__ import annotations
 
 import importlib
+import logging
 import math
 
 import pytest
@@ -37,6 +38,7 @@ from embodichain.lab.sim.planners.curobo.curobo_planner import (
     CuroboPlanner,
     CuroboPlannerCfg as CuroboPlannerCfgDirect,
     CuroboWorldCfg,
+    _configure_curobo_logging,
     _matrix_to_position_quaternion,
     _require_curobo,
     _resolve_curobo_device,
@@ -153,6 +155,7 @@ def test_curobo_plan_options_carries_context_fields():
 def test_curobo_planner_cfg_defaults():
     cfg = CuroboPlannerCfg(robot_uid="franka")
     assert cfg.planner_type == "curobo"
+    assert cfg.log_level == "error"
     assert cfg.warmup_iterations == 1
     assert cfg.max_attempts == 5
     assert cfg.cuda_device is None
@@ -165,6 +168,33 @@ def test_curobo_planner_cfg_defaults():
     assert cfg.sim_base_to_curobo_base is None
     assert not hasattr(cfg, "robot_profiles")
     assert not hasattr(cfg.world, "world_config_path")
+
+
+@pytest.mark.parametrize(
+    ("configured", "expected"),
+    [
+        ("debug", logging.DEBUG),
+        ("INFO", logging.INFO),
+        ("warn", logging.WARNING),
+        ("warning", logging.WARNING),
+        ("error", logging.ERROR),
+    ],
+)
+def test_configure_curobo_logging_sets_package_logger(
+    monkeypatch, configured, expected
+):
+    configured_levels = []
+    curobo_logger = logging.getLogger("curobo")
+    monkeypatch.setattr(curobo_logger, "setLevel", configured_levels.append)
+
+    _configure_curobo_logging(configured)
+
+    assert configured_levels == [expected]
+
+
+def test_configure_curobo_logging_rejects_unknown_level():
+    with pytest.raises(ValueError, match="CuroboPlannerCfg.log_level"):
+        _configure_curobo_logging("silent")
 
 
 def test_curobo_world_cfg_uses_v2_safe_default_collision_cache():


### PR DESCRIPTION
## Description

This PR adds `CuroboPlannerCfg.log_level` so callers can control cuRobo Python logging. It defaults to `error`, supports `debug`, `info`, `warning`/`warn`, and `error`, and applies the level before the lazy cuRobo import without reconfiguring the root logger.

The cuRobo planner documentation and focused unit tests are updated accordingly.

Dependencies: None.

No linked issue.

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)

## Screenshots

Not applicable.

## Validation

- `black --check --diff --color ./` — 559 files unchanged
- `pytest -q tests/sim/planners/test_curobo_planner.py -m "not gpu"` — 37 passed, 3 deselected
- `make -C docs html` — succeeded with 685 existing repository-wide warnings

An additional warnings-as-errors documentation build reaches completion but fails on those same existing warnings.

## Checklist

- [x] I have run the `black .` command to format the code base.
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my change works
- [x] Dependencies have been updated, if applicable.