### PR TITLE
Remove default physics arguments

### DIFF
--- a/embodichain/lab/sim/cfg.py
+++ b/embodichain/lab/sim/cfg.py
@@ -163,8 +163,6 @@ class PhysicsCfg:
         args = {
             "gravity": self.gravity.tolist(),
             "bounce_threshold": self.bounce_threshold,
-            "enable_pcm": True,
-            "enable_tgs": True,
             "enable_ccd": self.enable_ccd,
             "enable_enhanced_determinism": False,
             "enable_friction_every_iteration": True,

--- a/tests/sim/test_cfg.py
+++ b/tests/sim/test_cfg.py
@@ -28,8 +28,6 @@ def test_physics_cfg_does_not_expose_fixed_solver_options() -> None:
     """Fixed solver implementation details are not part of the public config."""
     physics_cfg = PhysicsCfg()
 
-    assert not hasattr(physics_cfg, "enable_pcm")
-    assert not hasattr(physics_cfg, "enable_tgs")
     assert not hasattr(physics_cfg, "enable_enhanced_determinism")
     assert not hasattr(physics_cfg, "enable_friction_every_iteration")
 
@@ -38,8 +36,6 @@ def test_physics_cfg_applies_fixed_solver_defaults() -> None:
     """Removed solver options retain their established DexSim defaults."""
     physics_args = PhysicsCfg(enable_ccd=True).to_dexsim_args()
 
-    assert physics_args["enable_pcm"] is True
-    assert physics_args["enable_tgs"] is True
     assert physics_args["enable_ccd"] is True
     assert physics_args["enable_enhanced_determinism"] is False
     assert physics_args["enable_friction_every_iteration"] is True


### PR DESCRIPTION
## Description

This PR removes the fixed enable_pcm and enable_tgs arguments from PhysicsCfg.to_dexsim_args() and deletes their obsolete unit-test assertions.

These solver options should no longer be forwarded to DexSim.

Dependencies: None.

Related issue: N/A.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (existing functionality will not work without user modification)
- [ ] Documentation update

## Screenshots

Not applicable.

## Validation

- black . (565 files unchanged)
- pytest -q tests/sim/test_cfg.py (8 passed)

## Checklist

- [x] I have run the black . command to format the code base.
- [x] Documentation changes are not required.
- [x] Obsolete unit-test assertions were removed with the options.
- [x] Dependency changes are not required.
