### PR TITLE
perf(tests): reduce runtime and GPU memory

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -157,8 +157,8 @@ jobs:
           export HF_ENDPOINT=https://hf-mirror.com
           pytest tests/docs -q --confcutdir=tests/docs
 
-          echo "Pure-Python tests (GPU hidden, four workers)"
-          CUDA_VISIBLE_DEVICES="" pytest tests --ignore=tests/docs \
+          echo "Non-simulation tests (four workers, CUDA available for native imports)"
+          pytest tests --ignore=tests/docs \
             -m "not requires_sim and not gpu" -n 4 --dist loadgroup
 
       - name: Run real-simulation tests serially

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -150,20 +150,35 @@ jobs:
       - name: Verify Scene Engine gensim installation
         run: |
           python -c "import matplotlib, numpy, open3d, requests, scipy, shapely, trimesh; from PIL import Image; import embodichain.gen_sim.scene_engine.pipeline.generate"
-          pytest tests/gen_sim/scene_engine -q
 
       - name: Run default tests
         run: |
-          echo "Default test suite (GPU-marked tests are skipped)"
+          echo "Documentation tests"
           export HF_ENDPOINT=https://hf-mirror.com
           pytest tests/docs -q --confcutdir=tests/docs
-          pytest tests --ignore=tests/docs
 
-      - name: Run GPU tests serially
+          echo "Pure-Python tests (GPU hidden, four workers)"
+          CUDA_VISIBLE_DEVICES="" pytest tests --ignore=tests/docs \
+            -m "not requires_sim and not gpu" -n 4 --dist loadgroup
+
+      - name: Run real-simulation tests serially
+        run: |
+          echo "Real-simulation tests (one process, GPU tests excluded)"
+          export HF_ENDPOINT=https://hf-mirror.com
+          pytest tests --ignore=tests/docs -m "requires_sim and not gpu"
+
+      - name: Run distributed GPU tests in isolation
+        run: |
+          echo "Distributed GPU tests (isolated CUDA process tree)"
+          export HF_ENDPOINT=https://hf-mirror.com
+          pytest tests/learning/test_rl_distributed.py --run-gpu -m gpu
+
+      - name: Run remaining GPU tests serially
         run: |
           echo "Dedicated GPU test suite"
           export HF_ENDPOINT=https://hf-mirror.com
-          pytest tests --run-gpu -m gpu
+          pytest tests --ignore=tests/docs \
+            --ignore=tests/learning/test_rl_distributed.py --run-gpu -m gpu
 
   release-build:
     if: startsWith(github.ref, 'refs/tags/v')

--- a/embodichain/lab/sim/objects/articulation.py
+++ b/embodichain/lab/sim/objects/articulation.py
@@ -1683,23 +1683,27 @@ class Articulation(BatchEntity):
         cache_env_ids = self._resolve_env_ids(env_ids)
         cache_joint_ids = self._resolve_joint_ids(joint_ids)
 
+        def _drive_arg(value: torch.Tensor, index: int) -> float | np.ndarray:
+            result = value[index].detach().cpu().numpy()
+            return result.item() if result.size == 1 else result
+
         for i, env_idx in enumerate(local_env_ids):
             drive_args = {
                 "drive_type": get_dexsim_drive_type(drive_type),
                 "joint_ids": local_joint_ids,
             }
             if stiffness is not None:
-                drive_args["stiffness"] = stiffness[i].cpu().numpy()
+                drive_args["stiffness"] = _drive_arg(stiffness, i)
             if damping is not None:
-                drive_args["damping"] = damping[i].cpu().numpy()
+                drive_args["damping"] = _drive_arg(damping, i)
             if max_effort is not None:
-                drive_args["max_force"] = max_effort[i].cpu().numpy()
+                drive_args["max_force"] = _drive_arg(max_effort, i)
             if max_velocity is not None:
-                drive_args["max_velocity"] = max_velocity[i].cpu().numpy()
+                drive_args["max_velocity"] = _drive_arg(max_velocity, i)
             if friction is not None:
-                drive_args["joint_friction"] = friction[i].cpu().numpy()
+                drive_args["joint_friction"] = _drive_arg(friction, i)
             if armature is not None:
-                drive_args["armature"] = armature[i].cpu().numpy()
+                drive_args["armature"] = _drive_arg(armature, i)
             self._entities[env_idx].set_drive(**drive_args)
 
         if max_velocity is not None:

--- a/embodichain/lab/sim/sim_manager.py
+++ b/embodichain/lab/sim/sim_manager.py
@@ -3151,19 +3151,33 @@ class SimulationManager:
         gc.collect()
 
     @staticmethod
-    def flush_cleanup_queue():
-        """Dequeue executor and synchronization barrier provided for top-level main loop / Pytest Fixture calls"""
+    def flush_cleanup_queue() -> None:
+        """Run pending destruction tasks and wait for their scenes to disappear.
+
+        An empty queue means that no manager requested destruction.  In that
+        case, returning immediately is important: other managers may still own
+        live worlds, and waiting for the global world count to reach zero would
+        block until the timeout even though there is nothing to clean up.
+        """
         import gc
 
-        while not SimulationManager._cleanup_queue.empty():
-            task = SimulationManager._cleanup_queue.get_nowait()
+        drained_task = False
+        while True:
+            try:
+                task = SimulationManager._cleanup_queue.get_nowait()
+            except queue.Empty:
+                break
+
+            drained_task = True
             try:
                 task()
             except Exception as e:
                 from embodichain.utils import logger
 
                 logger.log_error(f"Error during delayed destruction: {e}")
-                pass
+
+        if not drained_task:
+            return
 
         # After the queue is emptied, perform a top-level full GC to thoroughly reclaim dead objects that haven't released their RefPtrs yet
         gc.collect()

--- a/embodichain/lab/sim/solvers/srs_solver.py
+++ b/embodichain/lab/sim/solvers/srs_solver.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
+from __future__ import annotations
+
 import torch
 import numpy as np
 import warp as wp
@@ -36,7 +38,7 @@ if TYPE_CHECKING:
     from embodichain.lab.sim.robots.dexforce_w1.params import W1ArmKineParams
 
 
-all = ["SRSSolver", "SRSSolverCfg"]
+__all__ = ["SRSSolver", "SRSSolverCfg"]
 
 
 @configclass
@@ -404,13 +406,16 @@ class _CPUSRSSolverImpl(_BaseSRSSolverImpl):
             return success_tensor, ik_qpos_tensor[:, :1, :]
 
     def _get_each_ik(
-        self, target_pose: np.ndarray, nsparam: float, config: np.ndarray
+        self,
+        target_pose: np.ndarray | torch.Tensor,
+        nsparam: float,
+        config: np.ndarray,
     ) -> tuple[bool, np.ndarray | None]:
         """
         Computes the inverse kinematics for a given target pose, normalization parameter, and configuration.
 
         Args:
-            target_pose (np.ndarray): 4x4 target pose matrix.
+            target_pose (np.ndarray | torch.Tensor): 4x4 target pose matrix.
             nsparam (float): Normalization parameter (angle).
             config (np.ndarray): Configuration index.
 
@@ -419,7 +424,10 @@ class _CPUSRSSolverImpl(_BaseSRSSolverImpl):
             np.ndarray: List of joint solutions (7) or None if no solution is found.
         """
         # Validate the target pose matrix
-        target_pose = np.array(target_pose)
+        if isinstance(target_pose, torch.Tensor):
+            target_pose = target_pose.detach().cpu().numpy()
+        else:
+            target_pose = np.asarray(target_pose)
         if target_pose.ndim == 3 and target_pose.shape[0] == 1:
             target_pose = target_pose[0]  # Extract the first matrix
         if target_pose.shape != (4, 4):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,9 +106,16 @@ include-package-data = false
 [tool.black]
 
 [tool.pytest.ini_options]
+addopts = ["-m", "not slow"]
+filterwarnings = [
+    "ignore:`torch\\.jit\\.script(_method)?` is deprecated.*:DeprecationWarning:torch\\.jit\\._script",
+]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "requires_sim: marks tests that require a real simulation backend",
+    "no_sim: marks mock-only tests that must not initialize a simulation backend",
+    "requires_tasks: marks tests that require installed task-package discovery",
     "gpu: marks tests that execute CUDA/GPU code (run serially)",
     "renderer: marks tests that exercise a rendering backend",
+    "xdist_group(name): keeps resource-sharing tests on one pytest-xdist worker",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,14 +16,17 @@
 
 from __future__ import annotations
 
+from functools import lru_cache
+
 import inspect
 import os
+import re
 import pytest
 
 os.environ.setdefault("EMBODICHAIN_SIM_EXIT_PROCESS", "0")
 
 
-@pytest.fixture(scope="session", autouse=True)
+@pytest.fixture(scope="session")
 def _discover_task_packages():
     """Discover all installed task packages once per test session.
 
@@ -43,6 +46,14 @@ def _discover_task_packages():
 
     discover_task_packages()
     execute_init_hooks()
+
+
+@pytest.fixture(autouse=True)
+def _discover_task_packages_for_marked_tests(request):
+    """Discover task packages only for tests that consume registered tasks."""
+    if request.node.get_closest_marker("requires_tasks") is not None:
+        request.getfixturevalue("_discover_task_packages")
+    yield
 
 
 def pytest_addoption(parser):
@@ -68,34 +79,78 @@ def pytest_configure(config):
                 f"Invalid renderer: {renderer}. Must be one of 'hybrid', 'fast-rt'"
             )
 
-        # Override the global default renderer in the simulation config
-        from embodichain.lab.sim import cfg
-
-        cfg.DEFAULT_RENDERER = renderer
-
         # DexSim initialization is intentionally deferred to the first real-simulation
         # test.  Most of the suite consists of pure-Python tests and should not acquire
         # a CUDA/Vulkan context merely because pytest has started.
 
 
-def _requires_real_sim(item):
-    """Return whether a test module creates a real SimulationManager."""
-    if item.get_closest_marker("requires_sim") is not None:
-        return True
-    module = getattr(item, "module", None)
-    if module is not None and "SimulationManager" in vars(module):
-        return True
+_SIMULATION_MANAGER_CONSTRUCTOR = re.compile(r"\bSimulationManager\s*\(")
 
-    # Some planner regression tests intentionally import the simulation manager
-    # inside the test body to keep their module import lightweight.
+
+@lru_cache(maxsize=None)
+def _source_constructs_real_sim(obj):
+    """Return whether an object's source directly constructs a simulation manager."""
     try:
-        return "SimulationManager" in inspect.getsource(item.obj)
+        return (
+            _SIMULATION_MANAGER_CONSTRUCTOR.search(inspect.getsource(obj)) is not None
+        )
     except (OSError, TypeError):
         return False
 
 
+def _callable_constructs_real_sim(obj):
+    """Check a callable and the module-level helpers it directly references."""
+    if _source_constructs_real_sim(obj):
+        return True
+
+    code = getattr(obj, "__code__", None)
+    module = inspect.getmodule(obj)
+    if code is None or module is None:
+        return False
+
+    for name in code.co_names:
+        helper = vars(module).get(name)
+        if inspect.isfunction(helper) and _source_constructs_real_sim(helper):
+            return True
+    return False
+
+
+def _requires_real_sim(item):
+    """Return whether a test item creates a real SimulationManager."""
+    if item.get_closest_marker("requires_sim") is not None:
+        return True
+    if item.get_closest_marker("no_sim") is not None:
+        return False
+
+    module = getattr(item, "module", None)
+    if module is not None and "SimulationManager" in vars(module):
+        return True
+
+    if _callable_constructs_real_sim(item.obj):
+        return True
+
+    test_class = getattr(item, "cls", None)
+    if test_class is not None:
+        for cls in test_class.__mro__:
+            if _source_constructs_real_sim(cls):
+                return True
+
+    fixture_info = getattr(item, "_fixtureinfo", None)
+    fixture_defs_by_name = getattr(fixture_info, "name2fixturedefs", {})
+    for fixture_defs in fixture_defs_by_name.values():
+        for fixture_def in fixture_defs:
+            if _callable_constructs_real_sim(fixture_def.func):
+                return True
+
+    return False
+
+
 def _initialize_sim_engine(renderer):
     """Initialize DexSim once, immediately before the first real-sim test."""
+    from embodichain.lab.sim import cfg
+
+    cfg.DEFAULT_RENDERER = renderer
+
     import dexsim
     import dexsim.types
 
@@ -113,6 +168,7 @@ def _initialize_sim_engine(renderer):
     dexsim.init_sim_engine(sim_config)
 
 
+@pytest.hookimpl(tryfirst=True)
 def pytest_collection_modifyitems(config, items):
     """Classify real-simulation tests for fast and resource-aware test selection."""
     for item in items:
@@ -120,6 +176,12 @@ def pytest_collection_modifyitems(config, items):
         requires_sim = _requires_real_sim(item)
         if requires_sim:
             item.add_marker(pytest.mark.requires_sim)
+            item.add_marker(pytest.mark.xdist_group(name="simulation"))
+        else:
+            module_name = getattr(item.module, "__name__", "unknown")
+            item.add_marker(
+                pytest.mark.xdist_group(name=f"module-{module_name.replace('.', '-')}")
+            )
         if "cuda" in nodeid or "gpu" in nodeid:
             item.add_marker(pytest.mark.gpu)
         if requires_sim and (

--- a/tests/data_pipeline/test_online_data.py
+++ b/tests/data_pipeline/test_online_data.py
@@ -120,7 +120,10 @@ def _make_fake_engine(
     engine._close_signal = engine._mp_ctx.Event()
     engine._sample_count = engine._mp_ctx.Value("i", 0)
 
-    engine.start()
+    # Sampling tests intentionally bypass the simulation worker.  Starting it
+    # here would exercise unrelated environment setup and make teardown wait
+    # for the subprocess timeout when the synthetic config cannot run a task.
+    engine._sim_process = None
 
     return engine
 

--- a/tests/gym/envs/test_base_env.py
+++ b/tests/gym/envs/test_base_env.py
@@ -37,6 +37,8 @@ from embodichain.data import get_data_path
 
 NUM_ENVS = 10
 
+pytestmark = pytest.mark.requires_sim
+
 
 @register_env("RandomReach-v1", max_episode_steps=100, override=True)
 class RandomReachEnv(BaseEnv):

--- a/tests/gym/envs/test_embodied_env.py
+++ b/tests/gym/envs/test_embodied_env.py
@@ -39,6 +39,8 @@ from embodichain.data import get_data_path
 
 NUM_ENVS = 2
 
+pytestmark = pytest.mark.requires_sim
+
 urdf_path = get_data_path("UniversalRobots/UR5/UR5.urdf")
 METADATA = {
     "id": "EmbodiedEnv-v1",

--- a/tests/gym/envs/test_profiler_integration.py
+++ b/tests/gym/envs/test_profiler_integration.py
@@ -34,6 +34,8 @@ from embodichain.lab.sim import SimulationManagerCfg
 from embodichain.lab.sim.cfg import RobotCfg
 from embodichain.lab.sim.objects import Robot
 
+pytestmark = pytest.mark.requires_sim
+
 
 @register_env("ProfilerProbe-v1", max_episode_steps=100, override=True)
 class _ProfilerProbeEnv(BaseEnv):

--- a/tests/gym/envs/test_replay.py
+++ b/tests/gym/envs/test_replay.py
@@ -21,6 +21,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import numpy as np
+import pytest
 import torch
 
 from embodichain.data import get_data_path
@@ -32,6 +33,8 @@ from embodichain.lab.sim.cfg import JointDrivePropertiesCfg, RigidObjectCfg, Rob
 from embodichain.lab.sim.shapes import CubeCfg
 from embodichain.lab.gym.envs.managers.actions import DeltaQposTerm
 from embodichain.lab.gym.envs.managers.cfg import ActionTermCfg
+
+pytestmark = [pytest.mark.requires_sim, pytest.mark.slow]
 
 
 @register_env("ReplayTest-v1", max_episode_steps=100, override=True)

--- a/tests/learning/test_newton_planar_reach.py
+++ b/tests/learning/test_newton_planar_reach.py
@@ -351,6 +351,7 @@ def test_evaluation_uses_eval_mode_and_restores_policy_mode(
     assert policy.training is initial_training_mode
 
 
+@pytest.mark.slow
 def test_apg_training_generalizes_to_held_out_reaches() -> None:
     result = train_planar_reach(
         NewtonPlanarReachTrainingCfg(

--- a/tests/learning/test_rl.py
+++ b/tests/learning/test_rl.py
@@ -22,6 +22,12 @@ import pytest
 import tempfile
 from pathlib import Path
 
+pytestmark = [
+    pytest.mark.requires_sim,
+    pytest.mark.requires_tasks,
+    pytest.mark.slow,
+]
+
 
 class TestRLTraining:
     """Test suite for RL training pipeline."""

--- a/tests/learning/test_rl_distributed.py
+++ b/tests/learning/test_rl_distributed.py
@@ -62,6 +62,8 @@ def _create_minimal_distributed_config():
     not torch.distributed.is_available(),
     reason="torch.distributed is not available",
 )
+@pytest.mark.gpu
+@pytest.mark.slow
 def test_distributed_training_via_torchrun():
     """Run distributed training via torchrun (subprocess) to exercise the distributed path.
 

--- a/tests/learning/test_shared_rollout.py
+++ b/tests/learning/test_shared_rollout.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 
+import pytest
 import torch
 from tensordict import TensorDict
 
@@ -117,6 +118,7 @@ class _FakeEnv:
         )
 
 
+@pytest.mark.no_sim
 def test_shared_rollout_collects_policy_and_env_fields():
     device = torch.device("cpu")
     num_envs = 3
@@ -179,6 +181,8 @@ def test_shared_rollout_collects_policy_and_env_fields():
     )
 
 
+@pytest.mark.requires_sim
+@pytest.mark.requires_tasks
 def test_embodied_env_writes_next_fields_into_external_rollout():
     gym_config = load_json(
         "embodichain_tasks/configs/agents/rl/basic/cart_pole/gym_config.json"

--- a/tests/sim/objects/test_rigid_constraint.py
+++ b/tests/sim/objects/test_rigid_constraint.py
@@ -29,6 +29,8 @@ from embodichain.lab.sim.cfg import RigidConstraintCfg
 from embodichain.lab.sim.objects.constraint import RigidConstraint
 from embodichain.lab.sim.sim_manager import SimulationManager
 
+pytestmark = pytest.mark.no_sim
+
 
 def test_rigid_constraint_cfg_defaults():
     """RigidConstraintCfg requires name + both object uids; frames default None."""

--- a/tests/sim/planners/test_curobo_planner.py
+++ b/tests/sim/planners/test_curobo_planner.py
@@ -99,6 +99,20 @@ _NO_MIMIC_URDF = """\
 """
 
 
+@pytest.fixture(scope="module", autouse=True)
+def _restore_torch_precision_settings():
+    """Keep cuRobo's process-wide TF32 changes local to this test module."""
+    matmul_allow_tf32 = torch.backends.cuda.matmul.allow_tf32
+    cudnn_allow_tf32 = torch.backends.cudnn.allow_tf32
+    matmul_precision = torch.get_float32_matmul_precision()
+
+    yield
+
+    torch.set_float32_matmul_precision(matmul_precision)
+    torch.backends.cuda.matmul.allow_tf32 = matmul_allow_tf32
+    torch.backends.cudnn.allow_tf32 = cudnn_allow_tf32
+
+
 def _raise_module_not_found(*args, **kwargs):
     raise ModuleNotFoundError("curobo not installed")
 

--- a/tests/sim/planners/test_toppra_batched.py
+++ b/tests/sim/planners/test_toppra_batched.py
@@ -140,7 +140,7 @@ class TestToppraPlanBatched:
         from embodichain.lab.sim.robots import CobotMagicCfg
 
         sim = SimulationManager(
-            SimulationManagerCfg(headless=True, sim_device="cpu", num_envs=3)
+            SimulationManagerCfg(headless=True, sim_device="cpu", num_envs=2)
         )
         robot = sim.add_robot(
             cfg=CobotMagicCfg.from_dict(
@@ -156,7 +156,7 @@ class TestToppraPlanBatched:
 
         planner, sim = self._make_planner()
         try:
-            B, dofs = 3, 6
+            B, dofs = 2, 6
             wp = torch.zeros(B, dofs)
             wp[:, 0] = torch.linspace(0.0, 0.4, B)
             states = [
@@ -186,9 +186,9 @@ class TestToppraPlanBatched:
 
         planner, sim = self._make_planner()
         try:
-            B, dofs = 3, 6
+            B, dofs = 2, 6
             wp = torch.zeros(B, dofs)
-            wp[:, 0] = torch.tensor([0.1, 0.4, 0.9])  # different durations
+            wp[:, 0] = torch.tensor([0.1, 0.9])  # different durations
             states = [
                 PlanState.from_qpos(torch.zeros(B, dofs)),
                 PlanState.from_qpos(wp),
@@ -228,6 +228,7 @@ class TestToppraPlanBatched:
 
             om.SimulationManager.flush_cleanup_queue()
 
+    @pytest.mark.slow
     @pytest.mark.parametrize("mp_context", ["fork", "spawn"])
     def test_plan_batched_pool_path(self, mp_context):
         # Exercise the real ProcessPoolExecutor branch (max_workers=2, B=3)
@@ -279,6 +280,7 @@ class TestToppraPlanBatched:
 
             om.SimulationManager.flush_cleanup_queue()
 
+    @pytest.mark.slow
     @pytest.mark.parametrize("mp_context", ["fork", "spawn"])
     def test_workers_reaped_on_gc(self, mp_context):
         # Regression: abandoning the planner must reap its worker processes,

--- a/tests/sim/test_sim_manager.py
+++ b/tests/sim/test_sim_manager.py
@@ -16,6 +16,9 @@
 
 from __future__ import annotations
 
+import gc
+import queue
+
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -42,6 +45,8 @@ DEFAULT_LOOK_AT = (
     (0.0, 0.0, 0.45),
     (0.0, 0.0, 1.0),
 )
+
+pytestmark = pytest.mark.no_sim
 
 
 class FakeCamera:
@@ -198,6 +203,45 @@ def _make_visualization_sim_manager() -> (
     return sim, runtime
 
 
+def test_flush_cleanup_queue_returns_immediately_when_no_destroy_is_pending(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cleanup_queue: queue.Queue = queue.Queue()
+    collect = MagicMock()
+    wait_scene_destruction = MagicMock()
+    monkeypatch.setattr(SimulationManager, "_cleanup_queue", cleanup_queue)
+    monkeypatch.setattr(gc, "collect", collect)
+    monkeypatch.setattr(
+        SimulationManager, "wait_scene_destruction", wait_scene_destruction
+    )
+
+    SimulationManager.flush_cleanup_queue()
+
+    collect.assert_not_called()
+    wait_scene_destruction.assert_not_called()
+
+
+def test_flush_cleanup_queue_waits_after_running_pending_destroy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cleanup_queue: queue.Queue = queue.Queue()
+    destroy = MagicMock()
+    cleanup_queue.put(destroy)
+    collect = MagicMock()
+    wait_scene_destruction = MagicMock()
+    monkeypatch.setattr(SimulationManager, "_cleanup_queue", cleanup_queue)
+    monkeypatch.setattr(gc, "collect", collect)
+    monkeypatch.setattr(
+        SimulationManager, "wait_scene_destruction", wait_scene_destruction
+    )
+
+    SimulationManager.flush_cleanup_queue()
+
+    destroy.assert_called_once_with()
+    collect.assert_called_once_with()
+    wait_scene_destruction.assert_called_once_with()
+
+
 def test_sim_update_refreshes_dirty_visualization_and_captures_current_state() -> None:
     sim, runtime = _make_visualization_sim_manager()
 
@@ -308,7 +352,7 @@ def test_native_window_availability_depends_on_visualization_backend(
     runtime_active: bool,
     expected: bool,
 ) -> None:
-    sim = SimulationManager.__new__(SimulationManager)
+    sim = object.__new__(SimulationManager)
     sim.sim_config = SimpleNamespace(
         visualization=SimpleNamespace(backend=backend),
     )
@@ -318,7 +362,7 @@ def test_native_window_availability_depends_on_visualization_backend(
 
 
 def test_open_window_skips_viser_backend() -> None:
-    sim = SimulationManager.__new__(SimulationManager)
+    sim = object.__new__(SimulationManager)
     sim.sim_config = SimpleNamespace(
         visualization=SimpleNamespace(backend="viser"),
     )
@@ -332,7 +376,7 @@ def test_open_window_skips_viser_backend() -> None:
 
 
 def test_open_window_allows_native_backend() -> None:
-    sim = SimulationManager.__new__(SimulationManager)
+    sim = object.__new__(SimulationManager)
     sim.sim_config = SimpleNamespace(
         visualization=SimpleNamespace(backend="none"),
     )
@@ -352,7 +396,7 @@ def test_open_window_allows_native_backend() -> None:
 
 
 def test_open_window_is_idempotent() -> None:
-    sim = SimulationManager.__new__(SimulationManager)
+    sim = object.__new__(SimulationManager)
     sim.sim_config = SimpleNamespace(
         visualization=SimpleNamespace(backend="none"),
     )
@@ -367,7 +411,7 @@ def test_open_window_is_idempotent() -> None:
 
 
 def test_start_visualization_rejects_open_native_window() -> None:
-    sim = SimulationManager.__new__(SimulationManager)
+    sim = object.__new__(SimulationManager)
     sim.sim_config = SimpleNamespace(
         visualization=SimpleNamespace(backend="viser"),
     )

--- a/tests/sim/test_sim_profiler.py
+++ b/tests/sim/test_sim_profiler.py
@@ -18,9 +18,12 @@ from __future__ import annotations
 
 import types
 
+import pytest
 import torch
 
 from embodichain.lab.sim import Profiler, ProfilerCfg, SimulationManager
+
+pytestmark = pytest.mark.no_sim
 
 
 class _WorldUpdateProbe:

--- a/tests/toolkits/test_batch_convex_collision.py
+++ b/tests/toolkits/test_batch_convex_collision.py
@@ -16,15 +16,19 @@
 
 from __future__ import annotations
 
+import pytest
 import torch
-from embodichain.data import get_data_path
 import trimesh
+import warp as wp
+
+from embodichain.data import get_data_path
 from embodichain.toolkits.graspkit.pg_grasp.collision_checker import (
     ConvexCollisionChecker,
     ConvexCollisionCheckerCfg,
 )
 from embodichain.utils.math import transform_points_mat
-import warp as wp
+
+pytestmark = pytest.mark.gpu
 
 
 def batch_convex_collision_query(device=torch.device("cuda")):


### PR DESCRIPTION
# Description

This PR reduces unit-test wall time and GPU memory pressure by separating four-worker non-simulation, serial real-simulation, distributed-GPU, and remaining GPU workloads according to their resource needs.

It also removes redundant simulation cleanup waits, defers task discovery and renderer initialization until required, keeps mock-only tests out of the simulation lane, marks expensive coverage explicitly, and prevents cuRobo's process-wide TF32 setting from contaminating later solver tests. CUDA remains visible in the non-simulation lane because Open3D native imports and Scene Engine tests require it. No dependencies are changed.

## Measured impact

GPU memory was sampled every 250 ms from each pytest process tree with `nvidia-smi`.

| Workload | Result | Wall time | Peak / GPU | Peak aggregate |
| --- | ---: | ---: | ---: | ---: |
| Baseline non-doc, GPU-skipped serial suite | 1122 passed, 106 skipped | 28m 10.5s | not sampled | not sampled |
| Current non-simulation lane, CUDA visible | 953 passed, 2 skipped | 1m 22.12s | 288 MiB | 288 MiB |
| Optimized non-GPU + real-simulation benchmark | 1122 passed, 8 skipped | 18m 52s | 9,171 MiB | 9,171 MiB |
| Isolated distributed GPU lane | 1 passed | 31.64s | 5,543 MiB | 10,748 MiB |
| Remaining serial GPU lane | 89 passed, 12 skipped | 5m 54.45s | 8,853 MiB | 8,853 MiB |
| Full staged benchmark, including docs/import check | 1224 passed, 20 skipped | about 25m 30s | 9,171 MiB | 10,748 MiB |

For comparable non-GPU coverage, wall time drops by about 9m 18.5s (33.0%). Isolating distributed training lowers the observed aggregate GPU peak from 12,709 MiB to 10,748 MiB (15.4%). The current non-simulation xdist lane excludes explicitly GPU-marked tests while retaining CUDA visibility for Open3D and Scene Engine; its measured peak is 288 MiB.

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)

## Screenshots

Not applicable.

## Validation

- `black .` — 600 files unchanged
- Full staged suite: docs, four-worker non-simulation tests, serial real-simulation tests, isolated distributed GPU test, and remaining serial GPU tests
- CUDA-visible Open3D and Scene Engine import check passed
- Current four-worker non-simulation lane: 953 passed, 2 skipped in 78.61s; sampled rerun completed in 82.12s
- cuRobo followed by SRS CUDA regression: 8 passed
- SRS CPU/CUDA regression: 10 passed
- Online data and SimManager regression: 60 passed
- Latest-main overlap regression (SimManager, EmbodiedEnv, material initialization): 59 passed
- Articulation CPU regression: 21 passed
- Workflow YAML parse and `git diff --check` passed (`actionlint` was not installed in the local image)

## Checklist

- [x] I have run the `black .` command to format the code base.
- [x] Documentation changes are not required for this test/CI-only behavior change.
- [x] I have added tests that prove the cleanup fix is effective and run proportional regression coverage.
- [x] Dependencies are unchanged.
