### PR TITLE
Fix PyPI metadata for cuRobo installation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -141,7 +141,8 @@ jobs:
       - uses: ./.github/actions/activate-conda
       - name: Install test package
         run: |
-          pip install -e ".[gensim, curobo-cu12]" \
+          pip install -e ".[gensim]" \
+            "nvidia-curobo[cu12] @ git+https://github.com/NVlabs/curobo.git@v0.8.0" \
             --extra-index-url http://pyp.open3dv.site:2345/simple/ \
             --trusted-host pyp.open3dv.site \
             --extra-index-url https://download.blender.org/pypi/
@@ -207,9 +208,12 @@ jobs:
       - name: Build and validate distributions
         run: |
           python -m pip install --upgrade pip
-          python -m pip install build twine
+          python -m pip install build packaging twine
           python -m build
           python -m twine check dist/*
+
+      - name: Validate PyPI dependency metadata
+        run: python scripts/validate_wheel_metadata.py dist/*.whl
 
       - name: Validate wheel contents
         shell: bash

--- a/docs/source/overview/sim/planners/curobo_planner.md
+++ b/docs/source/overview/sim/planners/curobo_planner.md
@@ -12,27 +12,28 @@ cuRobo, and constructing this planner requires a CUDA-capable NVIDIA GPU.
 
 ## Install cuRobo V2
 
-EmbodiChain exposes cuRobo V2 as CUDA-matched optional dependencies. From the
-EmbodiChain repository root, select exactly one extra:
+cuRobo V2 is installed separately from EmbodiChain because public package
+indexes do not accept Git dependencies in published package metadata. Select
+exactly one CUDA-matched source requirement:
 
 ~~~bash
 # Recommended for the normal EmbodiChain environment, where PyTorch is present.
-uv pip install ".[curobo-cu12]"  # CUDA 12.x
-uv pip install ".[curobo-cu13]"  # CUDA 13.x
+uv pip install "nvidia-curobo[cu12] @ git+https://github.com/NVlabs/curobo.git@v0.8.0"
+uv pip install "nvidia-curobo[cu13] @ git+https://github.com/NVlabs/curobo.git@v0.8.0"
 
 # For a fresh environment that also needs PyTorch.
-uv pip install ".[curobo-cu12-torch]"  # CUDA 12.x
-uv pip install ".[curobo-cu13-torch]"  # CUDA 13.x
+uv pip install "nvidia-curobo[cu12-torch] @ git+https://github.com/NVlabs/curobo.git@v0.8.0"
+uv pip install "nvidia-curobo[cu13-torch] @ git+https://github.com/NVlabs/curobo.git@v0.8.0"
 
 python -c "import curobo; print(curobo.__version__)"
 pytest --pyargs curobo.tests
 ~~~
 
-The extras follow [NVIDIA's official cuRobo installation
+These commands follow [NVIDIA's official cuRobo installation
 guide](https://nvlabs.github.io/curobo/latest/getting-started/installation.html)
 and pin the source dependency to the cuRobo V2 `v0.8.0` release. Use a Python
 3.10--3.13 environment on Linux with a supported NVIDIA GPU and driver. The
-non-`torch` extras are preferred for EmbodiChain because the simulation
+non-`torch` variants are preferred for EmbodiChain because the simulation
 environment normally already provides PyTorch; the `-torch` variants delegate
 the PyTorch version requirement to cuRobo. Keep cuRobo in the same Python
 environment that runs the simulator.

--- a/docs/source/overview/sim/planners/index.rst
+++ b/docs/source/overview/sim/planners/index.rst
@@ -25,7 +25,7 @@ The `embodichain` project provides a unified interface for robot trajectory plan
 - **CuroboPlanner** (optional): A cuRobo V2 backend that plans on CUDA and supports either CPU or CUDA physics simulation for collision-aware single-arm Cartesian and joint-space planning.
 - **TrajectorySampleMethod**: An enumeration for trajectory sampling strategies, supporting sampling by time, quantity, or distance.
 
-These tools can be used to generate smooth and dynamically feasible robot trajectories. Install a CUDA-matched EmbodiChain cuRobo extra when collision-aware planning against an explicit cuRobo world is required.
+These tools can be used to generate smooth and dynamically feasible robot trajectories. Install NVIDIA's CUDA-matched cuRobo source package separately when collision-aware planning against an explicit cuRobo world is required.
 
 Use NeuralPlanner (experimental) when you have a trained APG checkpoint and need
 learned EEF waypoint rollout on Franka Panda.

--- a/docs/source/quick_start/install.md
+++ b/docs/source/quick_start/install.md
@@ -175,27 +175,36 @@ wheel.
 
 ## Optional: cuRobo V2 motion planning
 
-Install a cuRobo extra to use EmbodiChain's CUDA-accelerated, collision-aware
-motion planner. cuRobo is intentionally not part of the core dependency set:
-select exactly one extra that matches the CUDA version reported by
-`nvidia-smi`.
+Install cuRobo separately to use EmbodiChain's CUDA-accelerated,
+collision-aware motion planner. cuRobo is intentionally not part of the core
+dependency set, and its Git source requirement cannot be included in metadata
+published to PyPI. Select exactly one command that matches the CUDA version
+reported by `nvidia-smi`.
 
 The normal EmbodiChain environment already provides PyTorch, so prefer one of
-the non-`torch` extras:
+the non-`torch` variants:
 
-| CUDA | Published package | Source checkout |
-|------|-------------------|-----------------|
-| 12.x | `uv pip install "embodichain[curobo-cu12]" ${PIP_EXTRA_ARGS}` | `uv pip install -e ".[curobo-cu12]" ${PIP_EXTRA_ARGS}` |
-| 13.x | `uv pip install "embodichain[curobo-cu13]" ${PIP_EXTRA_ARGS}` | `uv pip install -e ".[curobo-cu13]" ${PIP_EXTRA_ARGS}` |
+```bash
+# CUDA 12.x
+uv pip install \
+  "nvidia-curobo[cu12] @ git+https://github.com/NVlabs/curobo.git@v0.8.0" \
+  ${PIP_EXTRA_ARGS}
+
+# CUDA 13.x
+uv pip install \
+  "nvidia-curobo[cu13] @ git+https://github.com/NVlabs/curobo.git@v0.8.0" \
+  ${PIP_EXTRA_ARGS}
+```
 
 For a fresh environment that also needs cuRobo to select and install PyTorch,
-use `curobo-cu12-torch` or `curobo-cu13-torch` instead. The same extras work
-with `pip`; replace `uv pip install` with `pip install`.
+replace `cu12` or `cu13` with `cu12-torch` or `cu13-torch`. The same source
+requirements work with `pip`; replace `uv pip install` with `pip install`.
 
 **Recommended for the current CUDA 12.x EmbodiChain stack:**
 
 ```bash
-uv pip install -e ".[curobo-cu12]" \
+uv pip install \
+  "nvidia-curobo[cu12] @ git+https://github.com/NVlabs/curobo.git@v0.8.0" \
   --extra-index-url http://pyp.open3dv.site:2345/simple/ \
   --trusted-host pyp.open3dv.site
 
@@ -299,7 +308,7 @@ Press `Ctrl+C` to stop; the script cleans up the simulation on exit.
 | Docker Vulkan / EGL warnings from `docker_run.sh` | Install host NVIDIA drivers and Vulkan user-space packages; paths must be files under `/etc` or `/usr/share`, not directories. |
 | Viewer does not open | Export `DISPLAY`, allow X11 access (`xhost +local:` on the host), and ensure `~/.Xauthority` is mounted (the run script does this by default). |
 | PyTorch / CUDA errors at runtime | Reinstall a PyTorch build that matches your driver/CUDA from [pytorch.org](https://pytorch.org/get-started/locally/). |
-| `No module named 'curobo'` | Install exactly one CUDA-matched cuRobo extra, such as `uv pip install -e ".[curobo-cu12]"`, from the EmbodiChain repository root. |
+| `No module named 'curobo'` | Install the CUDA-matched cuRobo source requirement separately, such as `uv pip install "nvidia-curobo[cu12] @ git+https://github.com/NVlabs/curobo.git@v0.8.0"`. |
 | `bpy` install fails | Include the Blender index (`https://download.blender.org/pypi/`) and use Python 3.10 or 3.11. |
 
 ## Next steps

--- a/embodichain/lab/sim/planners/curobo/curobo_planner.py
+++ b/embodichain/lab/sim/planners/curobo/curobo_planner.py
@@ -640,7 +640,7 @@ def _require_curobo(log_level: str = "error") -> "Any":
 
     Raises:
         ImportError: If cuRobo V2 is not installed, with an actionable message
-            naming NVIDIA's CUDA-matched extras.
+            naming NVIDIA's CUDA-matched source variants.
     """
     _configure_curobo_logging(log_level)
     # cuRobo 0.8 references ``wp.torch.*``, which Warp >= 1.13 relocated.
@@ -652,10 +652,10 @@ def _require_curobo(log_level: str = "error") -> "Any":
     except ModuleNotFoundError as exc:
         raise ImportError(
             "cuRobo V2 is required for the 'curobo' planner but was not found. "
-            "From the EmbodiChain repository root, install the CUDA-matched "
-            "extra, e.g. `pip install -e '.[curobo-cu12]'` for CUDA 12.x or "
-            "`pip install -e '.[curobo-cu13]'` for CUDA 13.x "
-            "(also `.[curobo-cu12-torch]` / `.[curobo-cu13-torch]`). "
+            "Install NVIDIA's CUDA-matched source package separately, e.g. "
+            "`pip install 'nvidia-curobo[cu12] @ "
+            "git+https://github.com/NVlabs/curobo.git@v0.8.0'` for CUDA 12.x "
+            "or replace `cu12` with `cu13` for CUDA 13.x. "
             f"See {_CUROBO_INSTALL_URL} for details."
         ) from exc
     return SimpleNamespace(

--- a/examples/sim/planners/curobo_planner.py
+++ b/examples/sim/planners/curobo_planner.py
@@ -30,8 +30,8 @@ Run from the repository root::
     python examples/sim/planners/curobo_planner.py --headless --num_envs 4
     python examples/sim/planners/curobo_planner.py --headless --device cuda:1
 
-Requirements: an NVIDIA CUDA device and the CUDA-matched EmbodiChain cuRobo V2
-extra installed in the active environment.  Installation instructions:
+Requirements: an NVIDIA CUDA device and the CUDA-matched cuRobo V2 source
+package installed in the active environment. Installation instructions:
 https://nvlabs.github.io/curobo/latest/getting-started/installation.html
 """
 
@@ -220,10 +220,11 @@ def _check_runtime(curobo_gpu_id: int) -> None:
         import curobo  # noqa: F401
     except ImportError as exc:
         raise ImportError(
-            "cuRobo V2 is not installed. From the EmbodiChain repository root, "
-            "install the extra matching the CUDA environment: "
-            '`uv pip install ".[curobo-cu12]"` for CUDA 12.x or '
-            '`uv pip install ".[curobo-cu13]"` for CUDA 13.x '
+            "cuRobo V2 is not installed. Install NVIDIA's source package "
+            "matching the CUDA environment: "
+            "`uv pip install 'nvidia-curobo[cu12] @ "
+            "git+https://github.com/NVlabs/curobo.git@v0.8.0'` for CUDA 12.x "
+            "or replace `cu12` with `cu13` for CUDA 13.x "
             f"(see {CUROBO_INSTALL_URL})."
         ) from exc
     if curobo_gpu_id < 0 or curobo_gpu_id >= torch.cuda.device_count():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,7 @@ authors = [ { name = "EmbodiChain Developers" } ]
 requires-python = ">=3.10"
 dynamic = ["version"]
 
-# Core install dependencies (kept from requirements.txt). Some VCS links are
-# specified using PEP 508 direct references where present.
+# Core install dependencies (kept from requirements.txt).
 dependencies = [
   "dexsim_engine==0.4.3",
   "setuptools>=78.1.1",
@@ -59,22 +58,6 @@ gensim = [
   "Pillow",
   "scipy",
   "matplotlib",
-]
-# cuRobo V2 is distributed from its source repository and provides separate
-# dependency sets for CUDA 12 and CUDA 13. Keep it optional so CPU-only and
-# non-NVIDIA EmbodiChain installations do not pull in CUDA packages. Select
-# exactly one of these extras for the target environment.
-curobo-cu12 = [
-  "nvidia-curobo[cu12] @ git+https://github.com/NVlabs/curobo.git@v0.8.0"
-]
-curobo-cu12-torch = [
-  "nvidia-curobo[cu12-torch] @ git+https://github.com/NVlabs/curobo.git@v0.8.0"
-]
-curobo-cu13 = [
-  "nvidia-curobo[cu13] @ git+https://github.com/NVlabs/curobo.git@v0.8.0"
-]
-curobo-cu13-torch = [
-  "nvidia-curobo[cu13-torch] @ git+https://github.com/NVlabs/curobo.git@v0.8.0"
 ]
 
 [project.scripts]

--- a/scripts/validate_wheel_metadata.py
+++ b/scripts/validate_wheel_metadata.py
@@ -1,0 +1,118 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+"""Validate wheel dependency metadata against public-index requirements."""
+
+from __future__ import annotations
+
+import argparse
+from email import policy
+from email.message import Message
+from email.parser import BytesParser
+from pathlib import Path
+from zipfile import BadZipFile, ZipFile
+
+from packaging.requirements import InvalidRequirement, Requirement
+
+__all__ = ["WheelMetadataError", "read_wheel_metadata", "validate_wheel"]
+
+
+class WheelMetadataError(ValueError):
+    """Raised when wheel metadata cannot be published to a public index."""
+
+
+def read_wheel_metadata(wheel_path: Path) -> Message:
+    """Read the single ``METADATA`` document from a wheel.
+
+    Args:
+        wheel_path: Path to the wheel archive.
+
+    Returns:
+        Parsed core metadata for the wheel.
+
+    Raises:
+        WheelMetadataError: If the wheel is missing, invalid, or does not
+            contain exactly one ``.dist-info/METADATA`` document.
+    """
+    if not wheel_path.is_file():
+        raise WheelMetadataError(f"Wheel does not exist: {wheel_path}")
+
+    try:
+        with ZipFile(wheel_path) as wheel:
+            metadata_names = [
+                name
+                for name in wheel.namelist()
+                if name.endswith(".dist-info/METADATA")
+            ]
+            if len(metadata_names) != 1:
+                raise WheelMetadataError(
+                    f"Expected one METADATA document in {wheel_path}, "
+                    f"found {metadata_names}"
+                )
+            metadata_bytes = wheel.read(metadata_names[0])
+    except BadZipFile as exc:
+        raise WheelMetadataError(f"Invalid wheel archive: {wheel_path}") from exc
+
+    return BytesParser(policy=policy.default).parsebytes(metadata_bytes)
+
+
+def validate_wheel(wheel_path: Path) -> None:
+    """Reject direct URL dependencies that public indexes do not accept.
+
+    Args:
+        wheel_path: Path to the wheel archive.
+
+    Raises:
+        WheelMetadataError: If dependency metadata is invalid or contains a
+            direct URL reference.
+    """
+    metadata = read_wheel_metadata(wheel_path)
+    direct_dependencies: list[str] = []
+
+    for raw_requirement in metadata.get_all("Requires-Dist", []):
+        try:
+            requirement = Requirement(raw_requirement)
+        except InvalidRequirement as exc:
+            raise WheelMetadataError(
+                f"Invalid Requires-Dist in {wheel_path}: {raw_requirement}"
+            ) from exc
+        if requirement.url is not None:
+            direct_dependencies.append(raw_requirement)
+
+    if direct_dependencies:
+        details = "\n".join(f"- {requirement}" for requirement in direct_dependencies)
+        raise WheelMetadataError(
+            f"PyPI does not accept direct dependency references in {wheel_path}:\n"
+            f"{details}"
+        )
+
+
+def main() -> int:
+    """Validate wheel paths supplied on the command line."""
+    parser = argparse.ArgumentParser(
+        description="Reject wheel dependencies that use direct URL references."
+    )
+    parser.add_argument("wheels", nargs="+", type=Path)
+    args = parser.parse_args()
+
+    for wheel_path in args.wheels:
+        validate_wheel(wheel_path)
+        print(f"Validated PyPI dependency metadata: {wheel_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -18,15 +18,38 @@ from __future__ import annotations
 
 import tomllib
 from pathlib import Path
+from zipfile import ZipFile
 
+import pytest
+from packaging.requirements import Requirement
+
+from scripts.validate_wheel_metadata import WheelMetadataError, validate_wheel
 from setup import get_package_dir, get_packages
 
 _REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+_TEST_VERSION = "0.2.4"
 
 
 def _read_project_metadata() -> dict:
     with (_REPOSITORY_ROOT / "pyproject.toml").open("rb") as stream:
         return tomllib.load(stream)
+
+
+def _write_test_wheel(tmp_path: Path, requirements: list[str]) -> Path:
+    metadata_lines = [
+        "Metadata-Version: 2.4",
+        "Name: embodichain",
+        f"Version: {_TEST_VERSION}",
+        *(f"Requires-Dist: {requirement}" for requirement in requirements),
+        "",
+    ]
+    wheel_path = tmp_path / f"embodichain-{_TEST_VERSION}-py3-none-any.whl"
+    with ZipFile(wheel_path, "w") as wheel:
+        wheel.writestr(
+            f"embodichain-{_TEST_VERSION}.dist-info/METADATA",
+            "\n".join(metadata_lines),
+        )
+    return wheel_path
 
 
 def test_official_tasks_share_core_distribution_metadata() -> None:
@@ -55,3 +78,38 @@ def test_package_discovery_includes_only_runtime_trees() -> None:
         "embodichain_tasks": "embodichain_tasks/embodichain_tasks",
         "embodichain_tasks.configs": "embodichain_tasks/configs",
     }
+
+
+def test_project_metadata_has_no_direct_dependencies() -> None:
+    project = _read_project_metadata()["project"]
+    requirements = list(project["dependencies"])
+    for optional_requirements in project["optional-dependencies"].values():
+        requirements.extend(optional_requirements)
+
+    direct_dependencies = [
+        requirement
+        for requirement in requirements
+        if Requirement(requirement).url is not None
+    ]
+
+    assert direct_dependencies == []
+
+
+def test_wheel_metadata_accepts_index_dependencies(tmp_path: Path) -> None:
+    wheel_path = _write_test_wheel(
+        tmp_path,
+        ["gymnasium>=0.29.1", 'viser==1.0.21; python_version >= "3.10"'],
+    )
+
+    validate_wheel(wheel_path)
+
+
+def test_wheel_metadata_rejects_direct_dependencies(tmp_path: Path) -> None:
+    direct_dependency = (
+        "nvidia-curobo[cu12] @ "
+        'git+https://github.com/NVlabs/curobo.git@v0.8.0; extra == "curobo-cu12"'
+    )
+    wheel_path = _write_test_wheel(tmp_path, [direct_dependency])
+
+    with pytest.raises(WheelMetadataError, match="nvidia-curobo"):
+        validate_wheel(wheel_path)


### PR DESCRIPTION
## Description

This PR fixes the `v0.2.4` PyPI publication failure caused by cuRobo Git direct references in the published `Requires-Dist` metadata.

It removes the four cuRobo VCS-backed extras, installs cuRobo explicitly where CI needs it, and updates the public installation guidance and runtime errors to use a separate CUDA-matched source install. It also adds a release-build validator that rejects direct URL requirements in built wheel metadata before upload.

Dependencies: no new runtime dependencies. The release job now installs `packaging` explicitly for metadata validation.

Related CI failure: https://github.com/DexForce/EmbodiChain/actions/runs/31089512880/job/92576853705

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (existing functionality will not work without user modification)
- [ ] Documentation update

## Screenshots

Not applicable.

## Validation

- `black --check --diff --color ./` — 849 files unchanged
- `pytest tests/test_release_metadata.py tests/sim/planners/test_curobo_planner.py::test_missing_curobo_is_actionable -q` — 6 passed
- `pytest tests/docs -q --confcutdir=tests/docs` — 12 passed
- Built `embodichain-0.2.4` wheel and sdist with `python -m build`
- `python -m twine check` passed for both artifacts
- `python scripts/validate_wheel_metadata.py <wheel>` passed
- Confirmed wheel and sdist contain no direct URL requirements
- Existing wheel runtime-content contract passed
- Workflow YAML parsed successfully with PyYAML; `actionlint` was not installed locally
- Full simulation/GPU suite not run; the change is covered by focused packaging, metadata, docs, and error-path validation

## Checklist

- [x] I have run the `black .` command to format the code base.
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Dependencies have been updated, if applicable.
