### PR TITLE
Fix stale GitHub Pages release deployments

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -29,6 +29,31 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Release-triggered deploys can report success while continuing to serve the
+  # previous artifact when the release reuses an already deployed commit SHA.
+  # Dispatching the build avoids that GitHub Pages failure mode:
+  # https://github.com/actions/deploy-pages/issues/383
+  redispatch-release:
+    if: >
+      github.event_name == 'release' &&
+      github.event.action == 'published' &&
+      startsWith(github.event.release.tag_name, 'v')
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Dispatch release docs build
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          gh workflow run docs-pages.yml \
+            --repo "${GITHUB_REPOSITORY}" \
+            --ref "${DEFAULT_BRANCH}" \
+            -f ref="${RELEASE_TAG}"
+
   deploy-from-artifact:
     if: >
       (github.event_name == 'workflow_run' &&
@@ -50,6 +75,9 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path: ./docs-site
 
+      - name: Stamp Pages artifact
+        run: printf '%s\n' "${GITHUB_RUN_ID}" > ./docs-site/pages-deployment-id.txt
+
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
@@ -59,12 +87,26 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@v4
 
+      - name: Verify deployed artifact
+        env:
+          EXPECTED_DEPLOYMENT_ID: ${{ github.run_id }}
+          PAGE_URL: ${{ steps.deployment.outputs.page_url }}
+        run: |
+          for attempt in {1..30}; do
+            marker_url="${PAGE_URL%/}/pages-deployment-id.txt?run=${EXPECTED_DEPLOYMENT_ID}&attempt=${attempt}"
+            deployed_id="$(curl --fail --silent --show-error "${marker_url}" || true)"
+            if [[ "${deployed_id}" == "${EXPECTED_DEPLOYMENT_ID}" ]]; then
+              echo "Verified Pages deployment ${EXPECTED_DEPLOYMENT_ID}."
+              exit 0
+            fi
+            echo "Waiting for Pages deployment ${EXPECTED_DEPLOYMENT_ID} (attempt ${attempt}/30)..."
+            sleep 10
+          done
+          echo "Pages did not serve deployment ${EXPECTED_DEPLOYMENT_ID}." >&2
+          exit 1
+
   build-and-deploy:
-    if: >
-      (github.event_name == 'workflow_dispatch' && inputs.artifact_run_id == '') ||
-      (github.event_name == 'release' &&
-       github.event.action == 'published' &&
-       startsWith(github.event.release.tag_name, 'v'))
+    if: github.event_name == 'workflow_dispatch' && inputs.artifact_run_id == ''
     runs-on: Linux
     env:
       NVIDIA_DRIVER_CAPABILITIES: all
@@ -152,11 +194,7 @@ jobs:
           path: ${{ github.workspace }}/docs/build/html
 
   deploy-manual-build:
-    if: >
-      (github.event_name == 'workflow_dispatch' && inputs.artifact_run_id == '') ||
-      (github.event_name == 'release' &&
-       github.event.action == 'published' &&
-       startsWith(github.event.release.tag_name, 'v'))
+    if: github.event_name == 'workflow_dispatch' && inputs.artifact_run_id == ''
     needs: build-and-deploy
     runs-on: ubuntu-latest
     environment:
@@ -169,6 +207,9 @@ jobs:
           name: docs-site-manual
           path: ./docs-site
 
+      - name: Stamp Pages artifact
+        run: printf '%s\n' "${GITHUB_RUN_ID}" > ./docs-site/pages-deployment-id.txt
+
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
@@ -177,3 +218,21 @@ jobs:
       - name: Deploy GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+      - name: Verify deployed artifact
+        env:
+          EXPECTED_DEPLOYMENT_ID: ${{ github.run_id }}
+          PAGE_URL: ${{ steps.deployment.outputs.page_url }}
+        run: |
+          for attempt in {1..30}; do
+            marker_url="${PAGE_URL%/}/pages-deployment-id.txt?run=${EXPECTED_DEPLOYMENT_ID}&attempt=${attempt}"
+            deployed_id="$(curl --fail --silent --show-error "${marker_url}" || true)"
+            if [[ "${deployed_id}" == "${EXPECTED_DEPLOYMENT_ID}" ]]; then
+              echo "Verified Pages deployment ${EXPECTED_DEPLOYMENT_ID}."
+              exit 0
+            fi
+            echo "Waiting for Pages deployment ${EXPECTED_DEPLOYMENT_ID} (attempt ${attempt}/30)..."
+            sleep 10
+          done
+          echo "Pages did not serve deployment ${EXPECTED_DEPLOYMENT_ID}." >&2
+          exit 1

--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -25,7 +25,9 @@ permissions:
   id-token: write
 
 concurrency:
-  group: github-pages
+  # The release run waits for its dispatched deployment, so it must not hold
+  # the deployment concurrency group while the child workflow is queued.
+  group: ${{ github.event_name == 'release' && format('github-pages-release-{0}', github.run_id) || 'github-pages' }}
   cancel-in-progress: false
 
 jobs:
@@ -39,8 +41,10 @@ jobs:
       github.event.action == 'published' &&
       startsWith(github.event.release.tag_name, 'v')
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       actions: write
+      checks: read
       contents: read
     steps:
       - name: Dispatch release docs build
@@ -49,10 +53,21 @@ jobs:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          gh workflow run docs-pages.yml \
+          dispatched_url="$(gh workflow run docs-pages.yml \
             --repo "${GITHUB_REPOSITORY}" \
             --ref "${DEFAULT_BRANCH}" \
-            -f ref="${RELEASE_TAG}"
+            -f ref="${RELEASE_TAG}")"
+          dispatched_run_id="${dispatched_url##*/}"
+          if [[ ! "${dispatched_run_id}" =~ ^[0-9]+$ ]]; then
+            echo "Could not determine dispatched workflow run ID from: ${dispatched_url}" >&2
+            exit 1
+          fi
+          echo "Waiting for dispatched docs workflow ${dispatched_run_id}."
+          gh run watch "${dispatched_run_id}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --compact \
+            --exit-status \
+            --interval 10
 
   deploy-from-artifact:
     if: >

--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -76,25 +76,30 @@ jobs:
           path: ./docs-site
 
       - name: Stamp Pages artifact
-        run: printf '%s\n' "${GITHUB_RUN_ID}" > ./docs-site/pages-deployment-id.txt
+        env:
+          DEPLOYMENT_ID: ${{ github.run_id }}-${{ github.run_attempt }}
+        run: printf '%s\n' "${DEPLOYMENT_ID}" > ./docs-site/pages-deployment-id.txt
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
+          name: github-pages-${{ github.run_attempt }}
           path: ./docs-site
 
       - name: Deploy GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+        with:
+          artifact_name: github-pages-${{ github.run_attempt }}
 
       - name: Verify deployed artifact
         env:
-          EXPECTED_DEPLOYMENT_ID: ${{ github.run_id }}
+          EXPECTED_DEPLOYMENT_ID: ${{ github.run_id }}-${{ github.run_attempt }}
           PAGE_URL: ${{ steps.deployment.outputs.page_url }}
         run: |
           for attempt in {1..30}; do
             marker_url="${PAGE_URL%/}/pages-deployment-id.txt?run=${EXPECTED_DEPLOYMENT_ID}&attempt=${attempt}"
-            deployed_id="$(curl --fail --silent --show-error "${marker_url}" || true)"
+            deployed_id="$(curl --location --connect-timeout 5 --max-time 10 --fail --silent --show-error "${marker_url}" || true)"
             if [[ "${deployed_id}" == "${EXPECTED_DEPLOYMENT_ID}" ]]; then
               echo "Verified Pages deployment ${EXPECTED_DEPLOYMENT_ID}."
               exit 0
@@ -208,25 +213,30 @@ jobs:
           path: ./docs-site
 
       - name: Stamp Pages artifact
-        run: printf '%s\n' "${GITHUB_RUN_ID}" > ./docs-site/pages-deployment-id.txt
+        env:
+          DEPLOYMENT_ID: ${{ github.run_id }}-${{ github.run_attempt }}
+        run: printf '%s\n' "${DEPLOYMENT_ID}" > ./docs-site/pages-deployment-id.txt
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
+          name: github-pages-${{ github.run_attempt }}
           path: ./docs-site
 
       - name: Deploy GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+        with:
+          artifact_name: github-pages-${{ github.run_attempt }}
 
       - name: Verify deployed artifact
         env:
-          EXPECTED_DEPLOYMENT_ID: ${{ github.run_id }}
+          EXPECTED_DEPLOYMENT_ID: ${{ github.run_id }}-${{ github.run_attempt }}
           PAGE_URL: ${{ steps.deployment.outputs.page_url }}
         run: |
           for attempt in {1..30}; do
             marker_url="${PAGE_URL%/}/pages-deployment-id.txt?run=${EXPECTED_DEPLOYMENT_ID}&attempt=${attempt}"
-            deployed_id="$(curl --fail --silent --show-error "${marker_url}" || true)"
+            deployed_id="$(curl --location --connect-timeout 5 --max-time 10 --fail --silent --show-error "${marker_url}" || true)"
             if [[ "${deployed_id}" == "${EXPECTED_DEPLOYMENT_ID}" ]]; then
               echo "Verified Pages deployment ${EXPECTED_DEPLOYMENT_ID}."
               exit 0


### PR DESCRIPTION
## Description

This PR prevents GitHub Pages release deployments from reporting success while continuing to serve a stale artifact.

- Re-dispatches published release events as `workflow_dispatch`, preserving the release tag through the existing `ref` input.
- Stamps every Pages artifact with the deploying workflow run ID.
- Polls a cache-busted online marker after deployment and fails if Pages is not serving the current artifact.

The v0.2.4 docs build produced the correct four-version site, but the release-triggered deployment reused an already deployed commit SHA and left the previous site online. This matches the open upstream `actions/deploy-pages` issue: https://github.com/actions/deploy-pages/issues/383.

Dependencies: None.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (existing functionality will not work without user modification)
- [ ] Documentation update

## Screenshots

Not applicable.

## Validation

- `black .` — 849 files unchanged
- `actionlint .github/workflows/docs-pages.yml`
- `git diff --check`
- Full pytest suite not run; this is an isolated workflow-only change with no Python behavior changes.

## Checklist

- [x] I have run the `black .` command to format the code base.
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Dependencies have been updated, if applicable.