### PR TITLE
Show all sensor and record camera previews in Viser

### DIFF
--- a/docs/source/guides/run_env.md
+++ b/docs/source/guides/run_env.md
@@ -118,10 +118,12 @@ embodichain run-env \
     --viser-port 8080
 ```
 
-Use Viser to inspect selected environments, camera frustums, RGB previews, and
-overlays locally or remotely. Limit the published batch with
-`--viser-env-ids`, and tune scene, image, or soft-body publication rates with
-the corresponding `--viser-*-fps` options. See
+Use Viser to inspect selected environments, camera frustums, and all camera RGB
+previews locally or remotely. The expanded preview panel separates cameras
+created by `record_camera_data` under **Record cameras** from configured
+observation sensors under **Sensor cameras**.
+Limit the published batch with `--viser-env-ids`, and tune scene, image, or
+soft-body publication rates with the corresponding `--viser-*-fps` options. See
 {doc}`/overview/sim/viser_visualization` for browser controls and remote-access
 details.
 

--- a/docs/source/overview/sim/viser_visualization.md
+++ b/docs/source/overview/sim/viser_visualization.md
@@ -102,7 +102,8 @@ The browser scene currently includes:
 - each constituent object in a `RigidObjectGroup`;
 - every visible link of `Robot` and `Articulation`;
 - dynamic `SoftObject` and `ClothObject` geometry;
-- camera frustums and low-frequency RGB previews;
+- camera frustums and low-frequency RGB previews, including the primary (left)
+  RGB view of stereo sensors;
 - read-only Gizmo frames, or interactive transform controls when commands are
   explicitly enabled;
 - a default XY ground grid with 1 m cells and 10 m major sections;
@@ -192,17 +193,24 @@ for large deformable meshes or multiple visible environments.
 
 ## Cameras and browser controls
 
-The **Cameras** panel lets you select one environment and sensor. It provides:
+The **Cameras** panel lets you select one environment and a sensor frustum. It
+provides:
 
 - a camera-frustum visibility switch;
-- an RGB-preview switch;
-- independent environment and camera selectors.
+- an RGB-previews switch;
+- independent environment and frustum-camera selectors.
 
-Only the selected frustum and RGB preview are shown. RGB images use a separate
-latest-frame queue and `sensor_image_fps`, so image rendering cannot build up a
-backlog behind simulation frames. Setting `sensor_image_fps=None` captures
-after each eligible simulation step; `run-env --viser` uses this mode by
-default.
+Only the selected frustum is shown. The expanded **RGB previews** folder shows
+every RGB-capable camera in the selected environment at the same time, split
+into separate **Record cameras** and **Sensor cameras** folders. Record cameras
+are created by event functors such as `record_camera_data`; sensor cameras
+include the primary (left) RGB observation of each `StereoCamera`. Both groups
+are expanded by default, and the camera selector controls only the frustum.
+
+RGB images use a separate latest-frame queue and `sensor_image_fps`, so image
+rendering cannot build up a backlog behind simulation frames. Setting
+`sensor_image_fps=None` captures after each eligible simulation step;
+`run-env --viser` uses this mode by default.
 
 The **Environments** panel independently hides or shows exported environments.
 For more than 16 environments, it switches to a scalable **Show all

--- a/docs/source/tutorial/sensor.rst
+++ b/docs/source/tutorial/sensor.rst
@@ -87,7 +87,7 @@ You can customize the simulation with the following command-line options:
    # Run in headless mode (no GUI, images saved to disk)
    python scripts/tutorials/sim/create_sensor.py --headless
 
-   # View the selected camera frustum and RGB preview in Viser
+   # View camera frustums and all sensor RGB previews in Viser
    python scripts/tutorials/sim/create_sensor.py --viser
 
    # Enable ray tracing rendering
@@ -97,10 +97,11 @@ You can customize the simulation with the following command-line options:
    python scripts/tutorials/sim/create_sensor.py --attach_sensor
 
 With ``--viser``, use the browser's **Cameras** panel to select the environment
-and camera, toggle its frustum, and show or hide the RGB preview. The preview
-defaults to 2 FPS and can be changed with ``--viser-image-fps``. Depth, masks,
-and normals remain available through the sensor API but are not currently
-shown in the Viser image panel.
+and camera frustum. Its expanded **RGB previews** folder shows every camera
+in that environment at once, with separate **Record cameras** and **Sensor
+cameras** subfolders. The previews default to 2 FPS and can be changed with
+``--viser-image-fps``. Depth, masks, and normals remain available through the
+sensor API but are not currently shown in the Viser image panel.
 
 Key Features Demonstrated
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -112,7 +113,7 @@ This tutorial demonstrates:
 3. **Camera configuration** (intrinsics, extrinsics, clipping planes)
 4. **Real-time visualization** of color, depth, mask, and normal images
 5. **Robot-sensor integration** in a simulation loop
-6. **Browser camera inspection** with a selected frustum and low-frequency RGB preview
+6. **Browser camera inspection** with a selected frustum and all low-frequency RGB previews
 
 Next Steps
 ~~~~~~~~~~

--- a/embodichain/lab/gym/envs/managers/record.py
+++ b/embodichain/lab/gym/envs/managers/record.py
@@ -29,6 +29,8 @@ from embodichain.lab.sim.sensors.camera import CameraCfg, Camera
 if TYPE_CHECKING:
     from embodichain.lab.gym.envs import EmbodiedEnv
 
+__all__ = ["record_camera_data", "record_camera_data_async", "validation_cameras"]
+
 
 class record_camera_data(Functor):
     """Record camera data in the environment. The camera is usually setup with third-person view, and
@@ -76,6 +78,7 @@ class record_camera_data(Functor):
                 height=resolution[1],
                 extrinsics=CameraCfg.ExtrinsicsCfg(eye=eye, target=target, up=up),
                 intrinsics=intrinsics,
+                visualization_role="record",
             )
         )
 

--- a/embodichain/lab/sim/sensors/camera.py
+++ b/embodichain/lab/sim/sensors/camera.py
@@ -21,11 +21,13 @@ import torch
 import dexsim.render as dr
 
 from functools import cached_property
-from typing import Tuple, Sequence, List
+from typing import List, Literal, Sequence, Tuple
 
 from embodichain.lab.sim.sensors import BaseSensor, SensorCfg
 from embodichain.utils.math import matrix_from_quat, quat_from_matrix, look_at_to_pose
 from embodichain.utils import logger, configclass
+
+__all__ = ["Camera", "CameraCfg"]
 
 
 @configclass
@@ -55,6 +57,9 @@ class CameraCfg(SensorCfg):
                 return super().transformation
 
     sensor_type: str = "Camera"
+
+    visualization_role: Literal["sensor", "record"] = "sensor"
+    """Role used to group this camera in live visualization previews."""
 
     # Camera parameters
     width: int = 640

--- a/embodichain/lab/sim/sim_manager.py
+++ b/embodichain/lab/sim/sim_manager.py
@@ -2183,7 +2183,7 @@ class SimulationManager:
         sensor = self.SUPPORTED_SENSOR_TYPES[sensor_type](sensor_cfg, self.device)
 
         self._sensors[sensor_uid] = sensor
-        if sensor_type == "Camera":
+        if isinstance(sensor, Camera):
             self.notify_visualization_topology_changed()
 
         # Check if the sensor needs to change the parent frame.

--- a/embodichain/lab/visualization/backends/viser.py
+++ b/embodichain/lab/visualization/backends/viser.py
@@ -110,6 +110,10 @@ class ViserBackend(VisualizationBackend):
     """
 
     _INDIVIDUAL_ENV_CONTROL_LIMIT = 16
+    _CAMERA_PREVIEW_GROUPS = (
+        ("record", "Record cameras"),
+        ("sensor", "Sensor cameras"),
+    )
 
     def __init__(
         self,
@@ -152,7 +156,9 @@ class ViserBackend(VisualizationBackend):
         self._show_camera_rgb = True
         self._camera_env_dropdown: object | None = None
         self._camera_uid_dropdown: object | None = None
-        self._camera_image_handle: object | None = None
+        self._camera_preview_folder: object | None = None
+        self._camera_preview_group_folders: dict[str, object] = {}
+        self._camera_image_handles: dict[str, object] = {}
         self._overlay_handles: dict[tuple[str, str], object] = {}
         self._overlay_base_visibility: dict[tuple[str, str], bool] = {}
         self._env_visibility: dict[int, bool] = {}
@@ -230,9 +236,11 @@ class ViserBackend(VisualizationBackend):
             except queue.Empty:
                 break
         self._server.gui.reset()
-        self._camera_image_handle = None
         self._camera_env_dropdown = None
         self._camera_uid_dropdown = None
+        self._camera_preview_folder = None
+        self._camera_preview_group_folders.clear()
+        self._camera_image_handles.clear()
         self._server.gui.add_markdown(
             f"**Run:** `{manifest.run_id}`  \n**Scene revision:** {manifest.scene_revision}"
         )
@@ -779,28 +787,51 @@ class ViserBackend(VisualizationBackend):
                 return camera_id
         return None
 
-    def _selected_camera_image(self) -> np.ndarray:
-        camera_id = self._selected_camera_id()
-        if camera_id is None or camera_id not in self._latest_camera_images:
+    def _camera_image(self, camera_id: str) -> np.ndarray:
+        if camera_id not in self._latest_camera_images:
             return np.zeros((120, 160, 3), dtype=np.uint8)
         return self._latest_camera_images[camera_id]
 
-    def _replace_camera_image_handle(self) -> None:
-        if self._camera_image_handle is not None:
-            self._camera_image_handle.remove()
-            self._camera_image_handle = None
-        if not self._show_camera_rgb or self._selected_camera_uid is None:
+    def _replace_camera_image_handles(self) -> None:
+        for handle in self._camera_image_handles.values():
+            handle.remove()
+        self._camera_image_handles.clear()
+
+        previews_visible = (
+            self._show_camera_rgb and self._selected_camera_env is not None
+        )
+        if self._camera_preview_folder is not None:
+            self._camera_preview_folder.visible = previews_visible
+
+        grouped_cameras: dict[str, list[tuple[str, CameraSpec]]] = {
+            role: [] for role, _ in self._CAMERA_PREVIEW_GROUPS
+        }
+        if previews_visible:
+            for camera_id, spec in sorted(
+                self._camera_specs.items(),
+                key=lambda item: item[1].sensor_uid,
+            ):
+                if spec.env_id == self._selected_camera_env:
+                    grouped_cameras[spec.role].append((camera_id, spec))
+
+        for role, folder in self._camera_preview_group_folders.items():
+            folder.visible = previews_visible and bool(grouped_cameras[role])
+
+        if not previews_visible or self._camera_preview_folder is None:
             return
-        label = (
-            f"Environment {self._selected_camera_env} / "
-            f"{self._selected_camera_uid} RGB"
-        )
-        self._camera_image_handle = self._server.gui.add_image(
-            self._selected_camera_image(),
-            label=label,
-            format="jpeg",
-            jpeg_quality=80,
-        )
+
+        for role, _ in self._CAMERA_PREVIEW_GROUPS:
+            folder = self._camera_preview_group_folders.get(role)
+            if folder is None or not grouped_cameras[role]:
+                continue
+            with folder:
+                for camera_id, spec in grouped_cameras[role]:
+                    self._camera_image_handles[camera_id] = self._server.gui.add_image(
+                        self._camera_image(camera_id),
+                        label=f"{spec.sensor_uid} RGB",
+                        format="jpeg",
+                        jpeg_quality=80,
+                    )
 
     def _register_camera_controls(self, manifest: SceneManifest) -> None:
         self._reconcile_camera_selection()
@@ -810,7 +841,7 @@ class ViserBackend(VisualizationBackend):
             str(env_id) for env_id in sorted({c.env_id for c in manifest.cameras})
         ]
         camera_options = self._camera_uids_for_env(self._selected_camera_env)
-        with self._server.gui.add_folder("Cameras"):
+        with self._server.gui.add_folder("Cameras", expand_by_default=True):
             self._camera_env_dropdown = self._server.gui.add_dropdown(
                 "Environment",
                 options=env_options,
@@ -824,7 +855,7 @@ class ViserBackend(VisualizationBackend):
                 )
 
             self._camera_uid_dropdown = self._server.gui.add_dropdown(
-                "Camera",
+                "Frustum camera",
                 options=camera_options,
                 initial_value=self._selected_camera_uid,
             )
@@ -850,7 +881,7 @@ class ViserBackend(VisualizationBackend):
                 )
 
             rgb_checkbox = self._server.gui.add_checkbox(
-                "RGB preview",
+                "RGB previews",
                 initial_value=self._show_camera_rgb,
             )
 
@@ -863,7 +894,22 @@ class ViserBackend(VisualizationBackend):
                     )
                 )
 
-        self._replace_camera_image_handle()
+            self._camera_preview_folder = self._server.gui.add_folder(
+                "RGB previews",
+                expand_by_default=True,
+                visible=self._show_camera_rgb,
+            )
+            with self._camera_preview_folder:
+                for role, label in self._CAMERA_PREVIEW_GROUPS:
+                    self._camera_preview_group_folders[role] = (
+                        self._server.gui.add_folder(
+                            label,
+                            expand_by_default=True,
+                            visible=False,
+                        )
+                    )
+
+        self._replace_camera_image_handles()
 
     def publish_manifest(self, manifest: SceneManifest) -> None:
         """Replace the browser's static scene topology.
@@ -1058,8 +1104,7 @@ class ViserBackend(VisualizationBackend):
     def _apply_gui_events(self) -> None:
         self._apply_gizmo_events()
         changed = False
-        camera_selection_changed = False
-        camera_rgb_changed = False
+        camera_previews_changed = False
         while True:
             try:
                 event = self._gui_events.get_nowait()
@@ -1092,15 +1137,14 @@ class ViserBackend(VisualizationBackend):
                 if self._camera_uid_dropdown is not None:
                     self._camera_uid_dropdown.options = camera_uids
                     self._camera_uid_dropdown.value = self._selected_camera_uid
-                camera_selection_changed = True
+                camera_previews_changed = True
             elif event.category == "camera_uid":
                 self._selected_camera_uid = str(event.value)
-                camera_selection_changed = True
             elif event.category == "camera_frustum":
                 self._show_camera_frustum = bool(event.value)
             elif event.category == "camera_rgb":
                 self._show_camera_rgb = bool(event.value)
-                camera_rgb_changed = True
+                camera_previews_changed = True
             elif event.category == "joint_control":
                 client_id, control_id, value = event.value
                 joint_handle = self._joint_control_handles.get(str(control_id))
@@ -1127,8 +1171,8 @@ class ViserBackend(VisualizationBackend):
             ) and self._overlay_visibility.get(key[0], True)
         self._apply_camera_visibility()
         self._apply_gizmo_visibility()
-        if camera_selection_changed or camera_rgb_changed:
-            self._replace_camera_image_handle()
+        if camera_previews_changed:
+            self._replace_camera_image_handles()
 
     def _apply_camera_visibility(self) -> None:
         selected_camera_id = self._selected_camera_id()
@@ -1390,15 +1434,9 @@ class ViserBackend(VisualizationBackend):
         for image in frame.images:
             if image.camera_id in self._camera_specs:
                 self._latest_camera_images[image.camera_id] = image.image
-        selected_camera_id = self._selected_camera_id()
-        if (
-            self._show_camera_rgb
-            and self._camera_image_handle is not None
-            and selected_camera_id in self._latest_camera_images
-        ):
-            self._camera_image_handle.image = self._latest_camera_images[
-                selected_camera_id
-            ]
+                handle = self._camera_image_handles.get(image.camera_id)
+                if handle is not None:
+                    handle.image = image.image
         return True
 
     def poll(self) -> None:
@@ -1437,9 +1475,11 @@ class ViserBackend(VisualizationBackend):
         self._camera_handles.clear()
         self._camera_specs.clear()
         self._latest_camera_images.clear()
-        self._camera_image_handle = None
         self._camera_env_dropdown = None
         self._camera_uid_dropdown = None
+        self._camera_preview_folder = None
+        self._camera_preview_group_folders.clear()
+        self._camera_image_handles.clear()
         self._overlay_handles.clear()
         self._overlay_base_visibility.clear()
         while True:

--- a/embodichain/lab/visualization/protocol.py
+++ b/embodichain/lab/visualization/protocol.py
@@ -198,6 +198,7 @@ class CameraSpec:
     aspect: float
     near: float
     far: float
+    role: Literal["sensor", "record"] = "sensor"
 
     def __post_init__(self) -> None:
         if self.env_id < 0:
@@ -208,6 +209,8 @@ class CameraSpec:
             raise ValueError("Camera aspect ratio must be greater than zero.")
         if self.near <= 0.0 or self.far <= self.near:
             raise ValueError("Camera clipping planes must satisfy 0 < near < far.")
+        if self.role not in {"sensor", "record"}:
+            raise ValueError("Camera role must be either 'sensor' or 'record'.")
 
 
 @dataclass(frozen=True)

--- a/embodichain/lab/visualization/scene_exporter.py
+++ b/embodichain/lab/visualization/scene_exporter.py
@@ -618,9 +618,16 @@ class SceneExporter:
     def _append_cameras(self, sources: list[_CameraSource]) -> None:
         for uid in self._sim.get_sensor_uid_list():
             camera = self._sim.get_sensor(uid)
-            if camera is None or getattr(camera.cfg, "sensor_type", None) != "Camera":
+            sensor_type = getattr(getattr(camera, "cfg", None), "sensor_type", None)
+            if camera is None or sensor_type not in {"Camera", "StereoCamera"}:
                 continue
-            intrinsics = _to_numpy(camera.get_intrinsics(), np.float32)
+            camera_intrinsics = camera.get_intrinsics()
+            if sensor_type == "StereoCamera":
+                # A stereo sensor is represented by its primary (left) RGB
+                # observation. This keeps one preview per configured sensor,
+                # matching the environment's ``color`` observation key.
+                camera_intrinsics = camera_intrinsics[0]
+            intrinsics = _to_numpy(camera_intrinsics, np.float32)
             if intrinsics.shape[0] != self._sim.num_envs:
                 raise ValueError(
                     f"Camera {uid!r} returned {intrinsics.shape[0]} intrinsics "
@@ -642,6 +649,7 @@ class SceneExporter:
                             aspect=float(width) / float(height),
                             near=float(camera.cfg.near),
                             far=float(camera.cfg.far),
+                            role=getattr(camera.cfg, "visualization_role", "sensor"),
                         ),
                         camera=camera,
                     )
@@ -819,7 +827,14 @@ class SceneExporter:
             uid = source.spec.sensor_uid
             if uid in camera_pose_cache:
                 continue
-            pose = _to_numpy(source.camera.get_arena_pose(to_matrix=True), np.float32)
+            if getattr(source.camera.cfg, "sensor_type", None) == "StereoCamera":
+                primary_pose, _ = source.camera.get_left_right_arena_pose()
+                pose = _to_numpy(primary_pose, np.float32)
+            else:
+                pose = _to_numpy(
+                    source.camera.get_arena_pose(to_matrix=True),
+                    np.float32,
+                )
             if pose.shape != (self._sim.num_envs, 4, 4):
                 raise ValueError(
                     f"Camera {uid!r} arena poses must have shape "

--- a/tests/gym/envs/managers/test_record.py
+++ b/tests/gym/envs/managers/test_record.py
@@ -1,0 +1,54 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+from __future__ import annotations
+
+from embodichain.lab.gym.envs.managers import FunctorCfg
+from embodichain.lab.gym.envs.managers.record import record_camera_data
+from embodichain.lab.sim.sensors import CameraCfg
+
+
+class _CameraHandle:
+    group_id = 7
+
+
+class _Simulation:
+    def __init__(self) -> None:
+        self.camera = _CameraHandle()
+        self.sensor_cfg: CameraCfg | None = None
+
+    def add_sensor(self, sensor_cfg: CameraCfg) -> _CameraHandle:
+        self.sensor_cfg = sensor_cfg
+        return self.camera
+
+
+class _Environment:
+    def __init__(self) -> None:
+        self.sim = _Simulation()
+        self.camera_group_ids: list[int] = []
+
+    def add_camera_group_id(self, group_id: int) -> None:
+        self.camera_group_ids.append(group_id)
+
+
+def test_record_camera_is_marked_for_visualization() -> None:
+    env = _Environment()
+    cfg = FunctorCfg(func=record_camera_data, params={"name": "episode_camera"})
+
+    record_camera_data(cfg, env)
+
+    assert env.sim.sensor_cfg is not None
+    assert env.sim.sensor_cfg.visualization_role == "record"

--- a/tests/sim/test_sim_manager.py
+++ b/tests/sim/test_sim_manager.py
@@ -508,6 +508,21 @@ def test_remove_asset_marks_visualization_topology_dirty() -> None:
     assert runtime.stopped
 
 
+def test_add_stereo_camera_marks_visualization_topology_dirty() -> None:
+    sim = object.__new__(SimulationManager)
+    sensor = object.__new__(sim_manager_module.StereoCamera)
+    sim.device = torch.device("cpu")
+    sim._sensors = {}
+    sim._visualization_topology_revision = 2
+    sim.SUPPORTED_SENSOR_TYPES = {
+        "StereoCamera": lambda cfg, device: sensor,
+    }
+    cfg = SimpleNamespace(sensor_type="StereoCamera", uid="cam_high")
+
+    assert sim.add_sensor(cfg) is sensor
+    assert sim._visualization_topology_revision == 3
+
+
 def test_window_camera_pose_to_look_at_uses_dexsim_world_up() -> None:
     """Captured look-at snippets preserve DexSim's default Z-up controls."""
     pose = np.eye(4, dtype=np.float32)

--- a/tests/visualization/test_protocol.py
+++ b/tests/visualization/test_protocol.py
@@ -103,6 +103,22 @@ def test_camera_spec_accepts_valid_pinhole_parameters() -> None:
     )
 
     assert spec.aspect == 4.0 / 3.0
+    assert spec.role == "sensor"
+
+
+def test_camera_spec_rejects_unknown_role() -> None:
+    with pytest.raises(ValueError, match="Camera role"):
+        CameraSpec(
+            camera_id="env:0/camera:wrist",
+            sensor_uid="wrist",
+            env_id=0,
+            path="/envs/0/cameras/wrist",
+            fov_y=0.8,
+            aspect=4.0 / 3.0,
+            near=0.01,
+            far=10.0,
+            role="debug",  # type: ignore[arg-type]
+        )
 
 
 def test_camera_image_owns_rgb_copy() -> None:

--- a/tests/visualization/test_scene_exporter.py
+++ b/tests/visualization/test_scene_exporter.py
@@ -343,7 +343,7 @@ class _GizmoSimulation(_EmptySimulation):
 
 
 class _Camera:
-    def __init__(self) -> None:
+    def __init__(self, visualization_role: str = "sensor") -> None:
         self.cfg = SimpleNamespace(
             sensor_type="Camera",
             width=4,
@@ -351,6 +351,7 @@ class _Camera:
             near=0.01,
             far=10.0,
             enable_color=True,
+            visualization_role=visualization_role,
         )
         self.update_count = 0
         self._poses = np.tile(np.eye(4, dtype=np.float32), (2, 1, 1))
@@ -390,6 +391,37 @@ class _CameraSimulation(_Simulation):
     def get_sensor(self, uid: str) -> _Camera:
         assert uid == "wrist/camera"
         return self.camera
+
+
+class _StereoCamera(_Camera):
+    def __init__(self) -> None:
+        super().__init__()
+        self.cfg.sensor_type = "StereoCamera"
+
+    def get_intrinsics(self) -> tuple[np.ndarray, np.ndarray]:
+        intrinsics = super().get_intrinsics()
+        return intrinsics, intrinsics.copy()
+
+    def get_left_right_arena_pose(self) -> tuple[np.ndarray, np.ndarray]:
+        return self._poses, self._poses.copy()
+
+    def get_arena_pose(self, to_matrix: bool) -> np.ndarray:
+        raise AssertionError("Stereo cameras should use their primary eye pose.")
+
+
+class _SensorPreviewSimulation(_Simulation):
+    def __init__(self) -> None:
+        super().__init__()
+        self.cameras = {
+            "cam_high": _StereoCamera(),
+            "record_camera": _Camera(visualization_role="record"),
+        }
+
+    def get_sensor_uid_list(self) -> list[str]:
+        return list(self.cameras)
+
+    def get_sensor(self, uid: str) -> _Camera:
+        return self.cameras[uid]
 
 
 class _CompleteSimulation(_Simulation):
@@ -566,6 +598,36 @@ def test_camera_frustum_pose_and_low_frequency_rgb_are_exported() -> None:
         image_result.frame.images[1].image[0, 0],
         [40, 50, 60],
     )
+
+
+def test_stereo_sensor_and_record_camera_primary_rgb_are_exported() -> None:
+    simulation = _SensorPreviewSimulation()
+    exporter = SceneExporter(
+        simulation,
+        VisualizationCfg(backend="viser", env_ids=[0]),
+        run_id="sensor-preview-run",
+    )
+
+    manifest = exporter.build_manifest()
+    scene_result = exporter.capture(sim_step=1, sim_time=0.01)
+    image_result = exporter.capture_camera_images(sim_step=1, sim_time=0.01)
+
+    assert [camera.sensor_uid for camera in manifest.cameras] == [
+        "cam_high",
+        "record_camera",
+    ]
+    assert [camera.role for camera in manifest.cameras] == ["sensor", "record"]
+    assert [image.camera_id for image in image_result.frame.images] == [
+        "env:0/camera:cam_high",
+        "env:0/camera:record_camera",
+    ]
+    np.testing.assert_allclose(scene_result.frame.camera_positions[0], [0.1, 0.2, 0.3])
+    np.testing.assert_array_equal(
+        image_result.frame.images[0].image[0, 0],
+        [10, 20, 30],
+    )
+    assert simulation.cameras["cam_high"].update_count == 1
+    assert simulation.cameras["record_camera"].update_count == 1
 
 
 def test_rigid_groups_and_deformable_meshes_are_exported() -> None:

--- a/tests/visualization/test_viser_backend.py
+++ b/tests/visualization/test_viser_backend.py
@@ -41,6 +41,8 @@ from embodichain.lab.visualization.backends.viser import ViserBackend
 class _Handle(SimpleNamespace):
     def remove(self) -> None:
         self.removed = True
+        if hasattr(self, "visible"):
+            self.visible = False
 
 
 class _TransformControls(_Handle):
@@ -57,12 +59,13 @@ class _TransformControls(_Handle):
         return callback
 
 
-class _Folder:
+class _Folder(_Handle):
     def __enter__(self) -> _Folder:
+        self.gui._folder_stack.append(self.label)
         return self
 
     def __exit__(self, *args: object) -> None:
-        pass
+        assert self.gui._folder_stack.pop() == self.label
 
 
 class _Checkbox:
@@ -103,7 +106,9 @@ class _Gui:
         self.sliders: dict[str, _ValueControl] = {}
         self.numbers: dict[str, _ValueControl] = {}
         self.buttons: dict[str, _Button] = {}
+        self.folders: dict[str, _Folder] = {}
         self.image_handles: list[_Handle] = []
+        self._folder_stack: list[str] = []
 
     def reset(self) -> None:
         self.checkboxes.clear()
@@ -111,13 +116,23 @@ class _Gui:
         self.sliders.clear()
         self.numbers.clear()
         self.buttons.clear()
+        self.folders.clear()
         self.image_handles.clear()
+        self._folder_stack.clear()
 
     def add_markdown(self, content: str) -> _Handle:
         return _Handle(content=content)
 
-    def add_folder(self, label: str) -> _Folder:
-        return _Folder()
+    def add_folder(self, label: str, **kwargs: object) -> _Folder:
+        folder = _Folder(
+            gui=self,
+            label=label,
+            parent_folder=self._folder_stack[-1] if self._folder_stack else None,
+            removed=False,
+            **kwargs,
+        )
+        self.folders[label] = folder
+        return folder
 
     def add_checkbox(self, label: str, initial_value: bool) -> _Checkbox:
         checkbox = _Checkbox(initial_value)
@@ -186,6 +201,11 @@ class _Gui:
         return button
 
     def add_image(self, image: np.ndarray, **kwargs: object) -> _Handle:
+        kwargs.setdefault("visible", True)
+        kwargs.setdefault(
+            "parent_folder",
+            self._folder_stack[-1] if self._folder_stack else None,
+        )
         handle = _Handle(image=image, removed=False, **kwargs)
         self.image_handles.append(handle)
         return handle
@@ -373,13 +393,25 @@ def test_viser_backend_uploads_static_mesh_once_and_updates_only_poses() -> None
         ),
     )
     assert backend.publish_camera_images(image_frame)
-    assert np.all(server.gui.image_handles[-1].image == 1)
+    visible_images = [
+        handle
+        for handle in server.gui.image_handles
+        if not handle.removed and handle.visible
+    ]
+    assert len(visible_images) == 1
+    assert np.all(visible_images[0].image == 1)
     camera_environment = server.gui.dropdowns["Environment"]
     camera_environment.callback(SimpleNamespace(target=SimpleNamespace(value="1")))
     backend.poll()
     assert not server.scene.camera_handles[0].visible
     assert server.scene.camera_handles[1].visible
-    assert np.all(server.gui.image_handles[-1].image == 2)
+    visible_images = [
+        handle
+        for handle in server.gui.image_handles
+        if not handle.removed and handle.visible
+    ]
+    assert len(visible_images) == 1
+    assert np.all(visible_images[0].image == 2)
 
     environment_one = server.gui.checkboxes["Environment 1"]
     environment_one.callback(SimpleNamespace(target=SimpleNamespace(value=False)))
@@ -416,6 +448,83 @@ def test_viser_backend_uploads_static_mesh_once_and_updates_only_poses() -> None
 
     assert server.scene.mesh_uploads == 1
     assert server.stopped
+
+
+def test_viser_backend_groups_sensor_and_record_camera_previews() -> None:
+    server = _Server()
+    backend = ViserBackend(ViserServerCfg(port=8765), server_factory=lambda **_: server)
+    cameras = tuple(
+        CameraSpec(
+            camera_id=f"env:0/camera:{sensor_uid}",
+            sensor_uid=sensor_uid,
+            env_id=0,
+            path=f"/envs/0/cameras/{sensor_uid}",
+            fov_y=0.8,
+            aspect=4.0 / 3.0,
+            near=0.01,
+            far=10.0,
+            role=role,
+        )
+        for sensor_uid, role in (
+            ("cam_high", "sensor"),
+            ("record_camera", "record"),
+        )
+    )
+    manifest = SceneManifest("run", 1, (), (), cameras)
+
+    backend.start()
+    backend.publish_manifest(manifest)
+
+    preview_folder = server.gui.folders["RGB previews"]
+    record_folder = server.gui.folders["Record cameras"]
+    sensor_folder = server.gui.folders["Sensor cameras"]
+    assert preview_folder.expand_by_default is True
+    assert preview_folder.visible is True
+    assert record_folder.parent_folder == "RGB previews"
+    assert sensor_folder.parent_folder == "RGB previews"
+    assert record_folder.expand_by_default is True
+    assert sensor_folder.expand_by_default is True
+    previews = {
+        handle.label: handle
+        for handle in server.gui.image_handles
+        if not handle.removed and handle.visible
+    }
+    assert previews["record_camera RGB"].parent_folder == "Record cameras"
+    assert previews["cam_high RGB"].parent_folder == "Sensor cameras"
+
+    image_frame = CameraImageFrame(
+        run_id="run",
+        scene_revision=1,
+        sequence=1,
+        sim_step=1,
+        sim_time=0.01,
+        images=tuple(
+            CameraImage(
+                camera_id=camera.camera_id,
+                image=np.full((2, 3, 3), index + 1, dtype=np.uint8),
+            )
+            for index, camera in enumerate(cameras)
+        ),
+    )
+    assert backend.publish_camera_images(image_frame)
+    previews = {
+        handle.label: handle.image
+        for handle in server.gui.image_handles
+        if not handle.removed
+    }
+    assert np.all(previews["cam_high RGB"] == 1)
+    assert np.all(previews["record_camera RGB"] == 2)
+
+    rgb_preview = server.gui.checkboxes["RGB previews"]
+    rgb_preview.callback(SimpleNamespace(target=SimpleNamespace(value=False)))
+    backend.poll()
+    assert preview_folder.visible is False
+    assert record_folder.visible is False
+    assert sensor_folder.visible is False
+    assert not any(
+        not handle.removed and handle.visible for handle in server.gui.image_handles
+    )
+    backend.stop()
 
 
 def test_viser_backend_batches_large_scenes_without_per_env_gui_nodes() -> None:


### PR DESCRIPTION
## Description

This PR expands the Viser camera panel to show every RGB-capable camera for the selected environment instead of only the frustum-selected camera.

It groups previews into **Record cameras** and **Sensor cameras**, marks cameras created by `record_camera_data` as record views, and exports the primary left RGB view and pose for `StereoCamera`. Frustum selection remains independent from the expanded preview list.

Dependencies: None.

Issue: None.

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)

## Validation

- `black --check --diff --color ./`
- `pytest -q tests/gym/envs/managers/test_record.py tests/sim/test_sim_manager.py tests/visualization -x` — 79 passed
- `make -C docs html` — succeeded with 668 pre-existing warnings

## Screenshots

Not included; GUI grouping and visibility behavior are covered by backend tests.

## Checklist

- [x] I have run the `black .` command to format the code base.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove the feature works.
- [x] Dependencies have been updated, if applicable. No dependency changes were required.