### PR TITLE
feat(sim): add semantic call catalog

### DIFF
--- a/embodichain/lab/sim/atomic_actions/engine.py
+++ b/embodichain/lab/sim/atomic_actions/engine.py
@@ -133,6 +133,7 @@ class AtomicActionEngine:
             control_profiles=control_profiles,
         )
         self._actions: dict[str, AtomicAction] = {}
+        self._skill_catalog_revision = 0
         self._skill_profile: BoundRobotSkillProfile | None = None
         if load_builtins:
             self._load_builtin_actions()
@@ -195,6 +196,16 @@ class AtomicActionEngine:
                 and descriptor.binding_contract is not None
             }
         )
+
+    @property
+    def skill_catalog_revision(self) -> int:
+        """Return the monotonic installed semantic-skill catalog revision.
+
+        Replacing an agent-visible implementation advances the revision even
+        when its public descriptor is equal. Bound profiles and semantic
+        compilers can therefore reject stale implementation ownership.
+        """
+        return self._skill_catalog_revision
 
     @property
     def skill_profile(self) -> BoundRobotSkillProfile | None:
@@ -294,6 +305,13 @@ class AtomicActionEngine:
             )
         action._bind(self._planning_services)
         self._actions[descriptor.skill_id] = action
+        existing_descriptor = None if existing is None else existing.descriptor()
+        if (descriptor.agent_visible and descriptor.binding_contract is not None) or (
+            existing_descriptor is not None
+            and existing_descriptor.agent_visible
+            and existing_descriptor.binding_contract is not None
+        ):
+            self._skill_catalog_revision += 1
         self._skill_profile = None
 
     def _load_builtin_actions(self) -> None:

--- a/embodichain/lab/sim/skills/__init__.py
+++ b/embodichain/lab/sim/skills/__init__.py
@@ -18,6 +18,19 @@
 
 from __future__ import annotations
 
+from .calls import (
+    DeclarativeValue,
+    HandOver,
+    Pick,
+    Place,
+    PlaceRelationTarget,
+    RegisteredSemanticCall,
+    SemanticCallCatalog,
+    SemanticCallDescriptor,
+    SemanticCallSpec,
+    SemanticPose,
+    builtin_semantic_call_catalog,
+)
 from .profiles import (
     AmbiguousSkillBindingError,
     BoundRobotSkillProfile,
@@ -65,10 +78,15 @@ __all__ = [
     "BoundRobotSkillProfile",
     "ControlPartEndpoint",
     "ControlPartEndpointAdapter",
+    "DeclarativeValue",
     "EndpointResolution",
     "GRASP_AFFORDANCE_CAPABILITY",
+    "HandOver",
     "PLACE_IN_AFFORDANCE_CAPABILITY",
     "PLACE_ON_AFFORDANCE_CAPABILITY",
+    "Pick",
+    "Place",
+    "PlaceRelationTarget",
     "ProfileValidationError",
     "RegistrySceneProvider",
     "ResolvedRobotResource",
@@ -78,6 +96,7 @@ __all__ = [
     "ResourceClaim",
     "ResourceEndpoint",
     "ResourceEndpointAdapter",
+    "RegisteredSemanticCall",
     "RobotResource",
     "RobotSkillProfile",
     "SceneAffordanceRef",
@@ -93,7 +112,12 @@ __all__ = [
     "SceneLinkRef",
     "SceneObjectRef",
     "SceneRegistry",
+    "SemanticCallCatalog",
+    "SemanticCallDescriptor",
+    "SemanticCallSpec",
+    "SemanticPose",
     "SkillPolicyPreset",
     "UnsupportedSkillError",
     "UnsupportedSceneAffordanceError",
+    "builtin_semantic_call_catalog",
 ]

--- a/embodichain/lab/sim/skills/calls.py
+++ b/embodichain/lab/sim/skills/calls.py
@@ -1,0 +1,822 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+"""Immutable, robot-independent semantic call specifications."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+import math
+import re
+from types import MappingProxyType
+from typing import ClassVar, TypeAlias
+
+import torch
+
+from embodichain.lab.sim.atomic_actions import (
+    DisjointResourceSlots,
+    DisjointSlotEndpoints,
+    SkillBindingContract,
+    SkillDescriptor,
+    SkillEndpointRequirement,
+    SkillResourceSlot,
+)
+
+from .scene import (
+    SceneAffordanceRef,
+    SceneArticulationRef,
+    SceneEntityRef,
+    SceneLinkRef,
+    SceneObjectRef,
+)
+
+
+def _validate_identifier(value: str, *, field_name: str) -> str:
+    """Return one exact, non-empty identifier.
+
+    Args:
+        value: Candidate identifier.
+        field_name: Diagnostic field name.
+
+    Returns:
+        The validated input value.
+
+    Raises:
+        ValueError: If the value is empty or has outer whitespace.
+    """
+    if type(value) is not str or not value or value != value.strip():
+        raise ValueError(
+            f"{field_name} must be a non-empty string without outer whitespace."
+        )
+    return value
+
+
+def _validate_registered_call_id(value: str) -> str:
+    """Validate one lowercase, multi-segment extension identifier."""
+    _validate_identifier(value, field_name="registered semantic call ID")
+    if re.fullmatch(r"[a-z][a-z0-9_]*(?:\.[a-z][a-z0-9_]*)+", value) is None:
+        raise ValueError(
+            "Registered semantic call IDs must contain two or more lowercase "
+            "identifier segments separated by single dots."
+        )
+    return value
+
+
+def _snapshot_resources(values: Mapping[str, str]) -> Mapping[str, str]:
+    """Validate and own a generic slot-to-resource mapping."""
+    if not isinstance(values, Mapping):
+        raise TypeError("resources must be a mapping from slot IDs to resource IDs.")
+    resources: dict[str, str] = {}
+    for slot_id, resource_id in values.items():
+        _validate_identifier(slot_id, field_name="resource slot IDs")
+        _validate_identifier(resource_id, field_name="resource IDs")
+        resources[slot_id] = resource_id
+    return MappingProxyType(resources)
+
+
+def _validate_static_binding_contract(
+    contract: SkillBindingContract,
+    *,
+    field_name: str,
+) -> None:
+    """Reject runtime-bearing subclasses anywhere in a binding contract."""
+    if type(contract) is not SkillBindingContract:
+        raise TypeError(f"{field_name} must be exactly SkillBindingContract.")
+    if type(contract.slots) is not tuple or type(contract.constraints) is not tuple:
+        raise TypeError(f"{field_name} must contain exact immutable tuples.")
+    for slot in contract.slots:
+        if type(slot) is not SkillResourceSlot:
+            raise TypeError(
+                f"{field_name}.slots must contain exact SkillResourceSlot values."
+            )
+        _validate_identifier(slot.slot_id, field_name=f"{field_name} slot IDs")
+        if type(slot.endpoints) is not tuple or type(slot.constraints) is not tuple:
+            raise TypeError(f"{field_name}.slots must contain exact immutable tuples.")
+        for endpoint in slot.endpoints:
+            if type(endpoint) is not SkillEndpointRequirement:
+                raise TypeError(
+                    f"{field_name}.slots.endpoints must contain exact "
+                    "SkillEndpointRequirement values."
+                )
+            _validate_identifier(
+                endpoint.endpoint_id,
+                field_name=f"{field_name} endpoint IDs",
+            )
+            if type(endpoint.capabilities) is not frozenset:
+                raise TypeError(
+                    f"{field_name} endpoint capabilities must be exact frozensets."
+                )
+            for capability in endpoint.capabilities:
+                _validate_identifier(
+                    capability,
+                    field_name=f"{field_name} endpoint capabilities",
+                )
+            if type(endpoint.required_commands) is not MappingProxyType:
+                raise TypeError(
+                    f"{field_name} required commands must be an immutable snapshot."
+                )
+            for command_name, command_type in endpoint.required_commands.items():
+                _validate_identifier(
+                    command_name,
+                    field_name=f"{field_name} required command names",
+                )
+                if not isinstance(command_type, type):
+                    raise TypeError(
+                        f"{field_name} required command contracts must be class "
+                        "objects."
+                    )
+        for constraint in slot.constraints:
+            if type(constraint) is not DisjointSlotEndpoints:
+                raise TypeError(
+                    f"{field_name}.slots.constraints must contain exact "
+                    "DisjointSlotEndpoints values."
+                )
+            if type(constraint.endpoint_ids) is not tuple:
+                raise TypeError(
+                    f"{field_name} endpoint constraints must contain exact tuples."
+                )
+            for endpoint_id in constraint.endpoint_ids:
+                _validate_identifier(
+                    endpoint_id,
+                    field_name=f"{field_name} constrained endpoint IDs",
+                )
+    for constraint in contract.constraints:
+        if type(constraint) is not DisjointResourceSlots:
+            raise TypeError(
+                f"{field_name}.constraints must contain exact "
+                "DisjointResourceSlots values."
+            )
+        if type(constraint.slots) is not tuple:
+            raise TypeError(
+                f"{field_name} resource constraints must contain exact tuples."
+            )
+        for slot_id in constraint.slots:
+            _validate_identifier(
+                slot_id,
+                field_name=f"{field_name} constrained slot IDs",
+            )
+
+
+def _validate_static_skill_descriptor(
+    descriptor: SkillDescriptor,
+    *,
+    field_name: str,
+) -> None:
+    """Validate one exact, provider-free atomic target descriptor."""
+    if type(descriptor) is not SkillDescriptor:
+        raise TypeError(f"{field_name} must be exactly SkillDescriptor.")
+    _validate_identifier(descriptor.skill_id, field_name=f"{field_name}.skill_id")
+    if type(descriptor.agent_visible) is not bool:
+        raise TypeError(f"{field_name}.agent_visible must be exactly bool.")
+    if type(descriptor.goal_type) is tuple:
+        if not descriptor.goal_type or not all(
+            type(goal_type) is type for goal_type in descriptor.goal_type
+        ):
+            raise TypeError(f"{field_name}.goal_type must contain exact class objects.")
+    elif type(descriptor.goal_type) is not type:
+        raise TypeError(
+            f"{field_name}.goal_type must be an exact class or tuple of classes."
+        )
+    if type(descriptor.options_type) is not type:
+        raise TypeError(f"{field_name}.options_type must be an exact class object.")
+    if descriptor.binding_contract is None:
+        raise TypeError(f"{field_name}.binding_contract must be declared.")
+    _validate_static_binding_contract(
+        descriptor.binding_contract,
+        field_name=f"{field_name}.binding_contract",
+    )
+
+
+@dataclass(frozen=True, slots=True, init=False, eq=False)
+class SemanticPose:
+    """Object-space pose expressed as position and a WXYZ quaternion.
+
+    The value owns normalized tensor snapshots and never exposes its internal
+    tensors directly. A single pose or an environment batch is accepted.
+
+    Args:
+        position: Shape ``(3,)`` or ``(B, 3)``.
+        quaternion_wxyz: Shape ``(4,)`` or ``(B, 4)``. Finite, non-zero
+            quaternions are normalized at construction.
+    """
+
+    _position: torch.Tensor = field(repr=False)
+    _quaternion_wxyz: torch.Tensor = field(repr=False)
+
+    def __init__(
+        self,
+        position: torch.Tensor | tuple[float, float, float] | list[float],
+        quaternion_wxyz: torch.Tensor | tuple[float, float, float, float] | list[float],
+    ) -> None:
+        position_tensor = torch.as_tensor(position, dtype=torch.float32)
+        quaternion_tensor = torch.as_tensor(quaternion_wxyz, dtype=torch.float32)
+        if position_tensor.dim() not in (1, 2) or position_tensor.shape[-1] != 3:
+            raise ValueError("position must have shape (3,) or (B, 3).")
+        if quaternion_tensor.dim() not in (1, 2) or quaternion_tensor.shape[-1] != 4:
+            raise ValueError("quaternion_wxyz must have shape (4,) or (B, 4).")
+        if position_tensor.dim() != quaternion_tensor.dim():
+            raise ValueError(
+                "position and quaternion_wxyz must both be unbatched or batched."
+            )
+        if position_tensor.dim() == 2 and (
+            position_tensor.shape[0] != quaternion_tensor.shape[0]
+        ):
+            raise ValueError("position and quaternion_wxyz batch sizes must match.")
+        if position_tensor.dim() == 2 and position_tensor.shape[0] == 0:
+            raise ValueError("SemanticPose batches must contain at least one pose.")
+        if not torch.isfinite(position_tensor).all():
+            raise ValueError("position must contain only finite values.")
+        if not torch.isfinite(quaternion_tensor).all():
+            raise ValueError("quaternion_wxyz must contain only finite values.")
+        norms = torch.linalg.vector_norm(quaternion_tensor, dim=-1, keepdim=True)
+        if torch.any(norms <= torch.finfo(torch.float32).eps):
+            raise ValueError("quaternion_wxyz must be non-zero.")
+        object.__setattr__(self, "_position", position_tensor.clone())
+        object.__setattr__(
+            self,
+            "_quaternion_wxyz",
+            (quaternion_tensor / norms).clone(),
+        )
+
+    @property
+    def position(self) -> torch.Tensor:
+        """Return an independent position tensor."""
+        return self._position.clone()
+
+    @property
+    def quaternion_wxyz(self) -> torch.Tensor:
+        """Return an independent normalized quaternion tensor."""
+        return self._quaternion_wxyz.clone()
+
+    @property
+    def batch_size(self) -> int | None:
+        """Return the explicit batch size, or ``None`` for one broadcast pose."""
+        return None if self._position.dim() == 1 else self._position.shape[0]
+
+    def snapshot(self) -> SemanticPose:
+        """Return an independently owned pose value."""
+        return SemanticPose(self._position, self._quaternion_wxyz)
+
+    def to_matrix(self) -> torch.Tensor:
+        """Convert the semantic pose to a homogeneous transform.
+
+        Returns:
+            Shape ``(4, 4)`` for an unbatched pose or ``(B, 4, 4)`` for a
+            batched pose.
+        """
+        quaternion = self._quaternion_wxyz
+        was_unbatched = quaternion.dim() == 1
+        if was_unbatched:
+            quaternion = quaternion.unsqueeze(0)
+            position = self._position.unsqueeze(0)
+        else:
+            position = self._position
+        w, x, y, z = quaternion.unbind(dim=-1)
+        output = torch.zeros(
+            quaternion.shape[0],
+            4,
+            4,
+            dtype=quaternion.dtype,
+            device=quaternion.device,
+        )
+        output[:, 0, 0] = 1.0 - 2.0 * (y * y + z * z)
+        output[:, 0, 1] = 2.0 * (x * y - z * w)
+        output[:, 0, 2] = 2.0 * (x * z + y * w)
+        output[:, 1, 0] = 2.0 * (x * y + z * w)
+        output[:, 1, 1] = 1.0 - 2.0 * (x * x + z * z)
+        output[:, 1, 2] = 2.0 * (y * z - x * w)
+        output[:, 2, 0] = 2.0 * (x * z - y * w)
+        output[:, 2, 1] = 2.0 * (y * z + x * w)
+        output[:, 2, 2] = 1.0 - 2.0 * (x * x + y * y)
+        output[:, :3, 3] = position
+        output[:, 3, 3] = 1.0
+        return output[0] if was_unbatched else output
+
+
+@dataclass(frozen=True, slots=True, kw_only=True, eq=False)
+class SemanticCallSpec:
+    """Base value contract shared by every declarative semantic call.
+
+    Args:
+        resources: Optional skill-local slot to robot-resource overrides.
+    """
+
+    call_kind: ClassVar[str] = "semantic"
+
+    resources: Mapping[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "resources", _snapshot_resources(self.resources))
+
+    @property
+    def semantic_id(self) -> str:
+        """Return the stable catalog identifier for this call."""
+        return self.call_kind
+
+
+@dataclass(frozen=True, slots=True, eq=False)
+class Pick(SemanticCallSpec):
+    """Pick one registered object using an optional explicit grasp affordance.
+
+    Args:
+        object: Authoritative semantic object reference.
+        grasp: Optional explicit grasp affordance. Omission requests deterministic
+            registry selection.
+        resources: Optional skill-local resource overrides.
+    """
+
+    call_kind: ClassVar[str] = "pick"
+
+    object: SceneObjectRef
+    grasp: SceneAffordanceRef | None = None
+
+    def __post_init__(self) -> None:
+        SemanticCallSpec.__post_init__(self)
+        if type(self.object) is not SceneObjectRef:
+            raise TypeError("Pick.object must be a SceneObjectRef.")
+        if self.grasp is not None and type(self.grasp) is not SceneAffordanceRef:
+            raise TypeError("Pick.grasp must be a SceneAffordanceRef or None.")
+
+
+PlaceRelationTarget: TypeAlias = SceneObjectRef | SceneAffordanceRef
+
+
+@dataclass(frozen=True, slots=True, eq=False)
+class Place(SemanticCallSpec):
+    """Place a held object at exactly one semantic destination.
+
+    Args:
+        object: Authoritative held-object reference.
+        at: Absolute object-space pose.
+        on: Object or affordance supporting an ``on`` relation.
+        inside: Object or affordance supporting an ``inside`` relation.
+        resources: Optional skill-local resource overrides.
+    """
+
+    call_kind: ClassVar[str] = "place"
+
+    object: SceneObjectRef
+    at: SemanticPose | None = None
+    on: PlaceRelationTarget | None = None
+    inside: PlaceRelationTarget | None = None
+
+    def __post_init__(self) -> None:
+        SemanticCallSpec.__post_init__(self)
+        if type(self.object) is not SceneObjectRef:
+            raise TypeError("Place.object must be a SceneObjectRef.")
+        destinations = {
+            "at": self.at,
+            "on": self.on,
+            "inside": self.inside,
+        }
+        selected = [name for name, value in destinations.items() if value is not None]
+        if len(selected) != 1:
+            raise ValueError(
+                "Place requires exactly one of at, on, or inside; selected "
+                f"{selected}."
+            )
+        if self.at is not None:
+            if type(self.at) is not SemanticPose:
+                raise TypeError("Place.at must be a SemanticPose or None.")
+            object.__setattr__(self, "at", self.at.snapshot())
+        for field_name in ("on", "inside"):
+            target = getattr(self, field_name)
+            if target is not None and type(target) not in (
+                SceneObjectRef,
+                SceneAffordanceRef,
+            ):
+                raise TypeError(
+                    f"Place.{field_name} must be a SceneObjectRef, "
+                    "SceneAffordanceRef, or None."
+                )
+
+
+@dataclass(frozen=True, slots=True, eq=False)
+class HandOver(SemanticCallSpec):
+    """Transfer a held object to another robot resource.
+
+    Args:
+        object: Authoritative held-object reference.
+        receiver: Optional destination resource ID. It is equivalent to the
+            ``destination`` resource slot and must agree with an explicit map.
+        final_target: Optional final object-space delivery pose.
+        resources: Optional skill-local resource overrides.
+    """
+
+    call_kind: ClassVar[str] = "hand_over"
+
+    object: SceneObjectRef
+    receiver: str | None = None
+    final_target: SemanticPose | None = None
+
+    def __post_init__(self) -> None:
+        SemanticCallSpec.__post_init__(self)
+        if type(self.object) is not SceneObjectRef:
+            raise TypeError("HandOver.object must be a SceneObjectRef.")
+        resources = dict(self.resources)
+        if self.receiver is not None:
+            _validate_identifier(self.receiver, field_name="HandOver.receiver")
+            selected = resources.get("destination")
+            if selected is not None and selected != self.receiver:
+                raise ValueError(
+                    "HandOver.receiver conflicts with resources['destination']."
+                )
+            resources["destination"] = self.receiver
+        object.__setattr__(self, "resources", _snapshot_resources(resources))
+        if self.final_target is not None:
+            if type(self.final_target) is not SemanticPose:
+                raise TypeError("HandOver.final_target must be a SemanticPose or None.")
+            object.__setattr__(
+                self,
+                "final_target",
+                self.final_target.snapshot(),
+            )
+
+
+DeclarativeValue: TypeAlias = (
+    None
+    | bool
+    | int
+    | float
+    | str
+    | SceneEntityRef
+    | SemanticPose
+    | tuple["DeclarativeValue", ...]
+    | Mapping[str, "DeclarativeValue"]
+)
+
+
+def _snapshot_declarative_value(
+    value: object,
+    *,
+    path: str,
+    _active: set[int] | None = None,
+    _budget: list[int] | None = None,
+    _depth: int = 0,
+) -> DeclarativeValue:
+    """Recursively own a bounded, acyclic, non-executable payload."""
+    if _active is None:
+        _active = set()
+    if _budget is None:
+        _budget = [4096]
+    if _depth > 32:
+        raise ValueError(f"{path} exceeds the maximum declarative depth of 32.")
+    _budget[0] -= 1
+    if _budget[0] < 0:
+        raise ValueError(f"{path} exceeds the maximum declarative node count.")
+    if value is None or type(value) in (bool, int, str):
+        return value
+    if type(value) is float:
+        if not math.isfinite(value):
+            raise ValueError(f"{path} must be finite.")
+        return value
+    if type(value) in (
+        SceneEntityRef,
+        SceneObjectRef,
+        SceneArticulationRef,
+        SceneLinkRef,
+        SceneAffordanceRef,
+    ):
+        return value
+    if type(value) is SemanticPose:
+        snapshot = value.snapshot()
+        if type(snapshot) is not SemanticPose or snapshot is value:
+            raise TypeError(
+                f"{path}.snapshot() must return an independent SemanticPose."
+            )
+        return snapshot
+    if type(value) in (dict, MappingProxyType):
+        container_id = id(value)
+        if container_id in _active:
+            raise ValueError(f"{path} contains a cyclic declarative mapping.")
+        _active.add(container_id)
+        try:
+            snapshot: dict[str, DeclarativeValue] = {}
+            for key, nested in value.items():
+                _validate_identifier(key, field_name=f"{path} keys")
+                snapshot[key] = _snapshot_declarative_value(
+                    nested,
+                    path=f"{path}.{key}",
+                    _active=_active,
+                    _budget=_budget,
+                    _depth=_depth + 1,
+                )
+            return MappingProxyType(snapshot)
+        finally:
+            _active.remove(container_id)
+    if type(value) in (tuple, list):
+        container_id = id(value)
+        if container_id in _active:
+            raise ValueError(f"{path} contains a cyclic declarative sequence.")
+        _active.add(container_id)
+        try:
+            return tuple(
+                _snapshot_declarative_value(
+                    nested,
+                    path=f"{path}[{index}]",
+                    _active=_active,
+                    _budget=_budget,
+                    _depth=_depth + 1,
+                )
+                for index, nested in enumerate(value)
+            )
+        finally:
+            _active.remove(container_id)
+    raise TypeError(
+        f"{path} contains non-declarative {type(value).__name__}; callables, "
+        "classes, modules, tensors, and live objects are not allowed."
+    )
+
+
+@dataclass(frozen=True, slots=True, eq=False)
+class RegisteredSemanticCall(SemanticCallSpec):
+    """Safe value payload for a catalog-registered semantic extension.
+
+    Args:
+        call_id: Stable extension identifier discovered in a semantic catalog.
+        arguments: Nested declarative data. Executable or live values are
+            rejected at construction.
+        resources: Optional skill-local resource overrides.
+    """
+
+    call_kind: ClassVar[str] = "registered"
+
+    call_id: str
+    arguments: Mapping[str, DeclarativeValue] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        SemanticCallSpec.__post_init__(self)
+        _validate_registered_call_id(self.call_id)
+        if type(self.arguments) not in (dict, MappingProxyType):
+            raise TypeError(
+                "RegisteredSemanticCall.arguments must be an exact dict or "
+                "immutable mapping proxy."
+            )
+        object.__setattr__(
+            self,
+            "arguments",
+            _snapshot_declarative_value(
+                self.arguments,
+                path="RegisteredSemanticCall.arguments",
+            ),
+        )
+
+    @property
+    def semantic_id(self) -> str:
+        """Return the registered extension identifier."""
+        return self.call_id
+
+
+@dataclass(frozen=True, slots=True)
+class SemanticCallDescriptor:
+    """Static catalog metadata for one semantic call kind.
+
+    Args:
+        call_id: Stable semantic call identifier.
+        spec_type: Exact public call value type.
+        skill_id: Atomic skill identifier installed separately on an engine.
+        binding_contract: Robot-independent resource requirements.
+        schema_version: Explicit configuration payload schema version.
+        target_descriptor: Exact atomic goal/options/resource contract. It is
+            inferred and non-overridable for curated calls and required for
+            registered extensions.
+    """
+
+    call_id: str
+    spec_type: type[SemanticCallSpec]
+    skill_id: str
+    binding_contract: SkillBindingContract
+    schema_version: int = 1
+    target_descriptor: SkillDescriptor | None = None
+
+    def __post_init__(self) -> None:
+        _validate_identifier(self.call_id, field_name="SemanticCallDescriptor.call_id")
+        _validate_identifier(
+            self.skill_id, field_name="SemanticCallDescriptor.skill_id"
+        )
+        if self.spec_type not in (Pick, Place, HandOver, RegisteredSemanticCall):
+            raise TypeError(
+                "spec_type must be exactly Pick, Place, HandOver, or "
+                "RegisteredSemanticCall; extensions use the registered payload "
+                "contract rather than executable call subclasses."
+            )
+        _validate_static_binding_contract(
+            self.binding_contract,
+            field_name="SemanticCallDescriptor.binding_contract",
+        )
+        if not isinstance(self.schema_version, int) or isinstance(
+            self.schema_version, bool
+        ):
+            raise TypeError("schema_version must be an integer.")
+        if self.schema_version != 1:
+            raise ValueError(
+                "Unsupported semantic call schema_version "
+                f"{self.schema_version}; supported versions are [1]."
+            )
+        if self.spec_type is not RegisteredSemanticCall and (
+            self.call_id != self.spec_type.call_kind
+        ):
+            raise ValueError(
+                f"Descriptor ID {self.call_id!r} must match "
+                f"{self.spec_type.__name__}.call_kind "
+                f"{self.spec_type.call_kind!r}."
+            )
+        if self.spec_type is not RegisteredSemanticCall:
+            expected = _builtin_call_target(self.spec_type)
+            if (
+                self.skill_id != expected.skill_id
+                or (self.binding_contract != expected.binding_contract)
+                or (
+                    self.target_descriptor is not None
+                    and self.target_descriptor != expected
+                )
+            ):
+                raise ValueError(
+                    f"Built-in semantic call {self.call_id!r} must target skill "
+                    f"{expected.skill_id!r} with its exact curated descriptor. "
+                    "Use RegisteredSemanticCall for extensions."
+                )
+            object.__setattr__(self, "target_descriptor", expected)
+        else:
+            if self.target_descriptor is None:
+                raise TypeError(
+                    "Registered semantic descriptors require target_descriptor."
+                )
+            _validate_static_skill_descriptor(
+                self.target_descriptor,
+                field_name="SemanticCallDescriptor.target_descriptor",
+            )
+            if (
+                self.target_descriptor.skill_id != self.skill_id
+                or self.target_descriptor.binding_contract != self.binding_contract
+                or not self.target_descriptor.agent_visible
+                or self.target_descriptor.binding_contract is None
+            ):
+                raise ValueError(
+                    "Registered target_descriptor must be agent-visible and match "
+                    "skill_id plus binding_contract exactly."
+                )
+        if self.spec_type is RegisteredSemanticCall and self.call_id in {
+            Pick.call_kind,
+            Place.call_kind,
+            HandOver.call_kind,
+            RegisteredSemanticCall.call_kind,
+        }:
+            raise ValueError(
+                f"Registered semantic call ID {self.call_id!r} is reserved."
+            )
+        if self.spec_type is RegisteredSemanticCall:
+            _validate_registered_call_id(self.call_id)
+
+
+@dataclass(frozen=True, slots=True, init=False)
+class SemanticCallCatalog:
+    """Immutable discovery catalog separated from engine installation."""
+
+    _descriptors: Mapping[str, SemanticCallDescriptor]
+
+    def __init__(
+        self,
+        descriptors: Iterable[SemanticCallDescriptor],
+    ) -> None:
+        if isinstance(descriptors, (str, bytes)):
+            raise TypeError("descriptors must be an iterable of descriptors.")
+        try:
+            supplied = tuple(descriptors)
+        except TypeError as exc:
+            raise TypeError("descriptors must be an iterable of descriptors.") from exc
+        normalized: dict[str, SemanticCallDescriptor] = {}
+        for descriptor in supplied:
+            if type(descriptor) is not SemanticCallDescriptor:
+                raise TypeError(
+                    "descriptors must contain exact SemanticCallDescriptor values."
+                )
+            if descriptor.call_id in normalized:
+                raise ValueError(f"Duplicate semantic call ID {descriptor.call_id!r}.")
+            normalized[descriptor.call_id] = descriptor
+        object.__setattr__(
+            self,
+            "_descriptors",
+            MappingProxyType(normalized),
+        )
+
+    @property
+    def descriptors(self) -> Mapping[str, SemanticCallDescriptor]:
+        """Return immutable descriptors keyed by exact semantic ID."""
+        return self._descriptors
+
+    def discover(
+        self,
+        call: str | SemanticCallSpec,
+    ) -> SemanticCallDescriptor:
+        """Discover metadata without installing or executing an implementation.
+
+        Args:
+            call: Exact semantic ID or a call value.
+
+        Returns:
+            Matching immutable descriptor.
+
+        Raises:
+            KeyError: If the exact call ID is unknown.
+            TypeError: If the call type disagrees with its descriptor.
+        """
+        if type(call) is str:
+            call_id = _validate_identifier(call, field_name="semantic call ID")
+            call_value = None
+        elif type(call) in (Pick, Place, HandOver, RegisteredSemanticCall):
+            call_id = call.semantic_id
+            call_value = call
+        else:
+            raise TypeError(
+                "call must be an exact semantic call ID or supported call value."
+            )
+        descriptor = self._descriptors.get(call_id)
+        if descriptor is None:
+            raise KeyError(
+                f"Unknown semantic call {call_id!r}; available calls are "
+                f"{sorted(self._descriptors)}."
+            )
+        if call_value is not None and type(call_value) is not descriptor.spec_type:
+            raise TypeError(
+                f"Semantic call {call_id!r} expects "
+                f"{descriptor.spec_type.__name__}, got "
+                f"{type(call_value).__name__}."
+            )
+        return descriptor
+
+    def with_descriptor(
+        self,
+        descriptor: SemanticCallDescriptor,
+    ) -> SemanticCallCatalog:
+        """Return a new catalog containing one additional descriptor."""
+        return SemanticCallCatalog((*self._descriptors.values(), descriptor))
+
+
+def _builtin_call_target(
+    spec_type: type[SemanticCallSpec],
+) -> SkillDescriptor:
+    """Return the non-overridable atomic target for one curated call type."""
+    from embodichain.lab.sim.atomic_actions.primitives.hand_over import (
+        HandOver as HandOverAction,
+    )
+    from embodichain.lab.sim.atomic_actions.primitives.pick_up import PickUp
+    from embodichain.lab.sim.atomic_actions.primitives.place import Place as PlaceAction
+
+    targets = {
+        Pick: PickUp.descriptor(),
+        Place: PlaceAction.descriptor(),
+        HandOver: HandOverAction.descriptor(),
+    }
+    try:
+        return targets[spec_type]
+    except KeyError as exc:
+        raise TypeError(f"Unsupported curated call type {spec_type!r}.") from exc
+
+
+def builtin_semantic_call_catalog() -> SemanticCallCatalog:
+    """Build the curated catalog for installed manipulation primitives.
+
+    Returns:
+        A fresh immutable catalog. Atomic implementations remain uninstalled;
+        callers bind them to an engine through the separate runtime path.
+    """
+    descriptors = tuple(
+        SemanticCallDescriptor(
+            call_id=spec_type.call_kind,
+            spec_type=spec_type,
+            skill_id=_builtin_call_target(spec_type).skill_id,
+            binding_contract=_builtin_call_target(spec_type).binding_contract,
+        )
+        for spec_type in (Pick, Place, HandOver)
+    )
+    return SemanticCallCatalog(descriptors)
+
+
+__all__ = [
+    "DeclarativeValue",
+    "HandOver",
+    "Pick",
+    "Place",
+    "PlaceRelationTarget",
+    "RegisteredSemanticCall",
+    "SemanticCallCatalog",
+    "SemanticCallDescriptor",
+    "SemanticCallSpec",
+    "SemanticPose",
+    "builtin_semantic_call_catalog",
+]

--- a/embodichain/lab/sim/skills/profiles.py
+++ b/embodichain/lab/sim/skills/profiles.py
@@ -1131,6 +1131,7 @@ class BoundRobotSkillProfile:
         self._resources = self._resolve_resources()
         self._validate_engine_control_profiles()
         self._validate_leaf_ownership()
+        self._skill_catalog_revision = engine.skill_catalog_revision
         self._installed_skills = MappingProxyType(dict(engine.skills))
         self._validate_named_skill_configuration()
         self._validate_defaults()
@@ -1146,6 +1147,16 @@ class BoundRobotSkillProfile:
     def profile_id(self) -> str:
         """Return the stable profile identifier."""
         return self._profile.profile_id
+
+    @property
+    def engine(self) -> AtomicActionEngine:
+        """Return the exact action engine that owns this bound profile."""
+        return self._engine
+
+    @property
+    def source_profile(self) -> RobotSkillProfile:
+        """Return the immutable profile object used to create this binding."""
+        return self._profile
 
     @property
     def resources(self) -> Mapping[str, ResolvedRobotResource]:
@@ -1274,7 +1285,7 @@ class BoundRobotSkillProfile:
 
     def _assert_catalog_current(self) -> None:
         """Prevent stale contracts after engine registration or replacement."""
-        if dict(self._engine.skills) != dict(self._installed_skills):
+        if self._engine.skill_catalog_revision != self._skill_catalog_revision:
             raise RuntimeError(
                 "AtomicActionEngine semantic skills changed after the robot skill "
                 "profile was bound; bind the profile again before discovery or "

--- a/tests/sim/skills/test_calls.py
+++ b/tests/sim/skills/test_calls.py
@@ -1,0 +1,434 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+"""Tests for immutable, declarative semantic call values."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+import math
+
+import pytest
+import torch
+
+from embodichain.lab.sim.atomic_actions import (
+    SkillBindingContract,
+    SkillDescriptor,
+    SkillEndpointRequirement,
+    SkillResourceSlot,
+)
+from embodichain.lab.sim.skills.calls import (
+    HandOver,
+    Pick,
+    Place,
+    RegisteredSemanticCall,
+    SemanticCallCatalog,
+    SemanticCallDescriptor,
+    SemanticCallSpec,
+    SemanticPose,
+    builtin_semantic_call_catalog,
+)
+from embodichain.lab.sim.skills.scene import (
+    SceneAffordanceRef,
+    SceneEntityRef,
+    SceneObjectRef,
+)
+
+
+def _identity_pose() -> SemanticPose:
+    return SemanticPose((0.0, 0.0, 0.0), (1.0, 0.0, 0.0, 0.0))
+
+
+def _call_descriptor(
+    call_id: str,
+    spec_type: type[SemanticCallSpec],
+) -> SemanticCallDescriptor:
+    if spec_type is not RegisteredSemanticCall:
+        return builtin_semantic_call_catalog().discover(call_id)
+    target = builtin_semantic_call_catalog().discover("pick").target_descriptor
+    assert target is not None
+    assert target.binding_contract is not None
+    return SemanticCallDescriptor(
+        call_id=call_id,
+        spec_type=spec_type,
+        skill_id=target.skill_id,
+        binding_contract=target.binding_contract,
+        target_descriptor=target,
+    )
+
+
+def test_semantic_pose_owns_inputs_and_returns_independent_tensors() -> None:
+    position = torch.tensor([1.0, 2.0, 3.0])
+    quaternion = torch.tensor([1.0, 0.0, 0.0, 0.0])
+    pose = SemanticPose(position, quaternion)
+
+    position.zero_()
+    quaternion.zero_()
+    returned_position = pose.position
+    returned_quaternion = pose.quaternion_wxyz
+    returned_position.fill_(9.0)
+    returned_quaternion.fill_(9.0)
+
+    torch.testing.assert_close(pose.position, torch.tensor([1.0, 2.0, 3.0]))
+    torch.testing.assert_close(
+        pose.quaternion_wxyz,
+        torch.tensor([1.0, 0.0, 0.0, 0.0]),
+    )
+
+
+def test_semantic_pose_normalizes_wxyz_quaternion() -> None:
+    pose = SemanticPose((0.0, 0.0, 0.0), (2.0, 0.0, 0.0, 2.0))
+
+    expected = torch.tensor(
+        [math.sqrt(0.5), 0.0, 0.0, math.sqrt(0.5)],
+        dtype=torch.float32,
+    )
+    torch.testing.assert_close(pose.quaternion_wxyz, expected)
+
+
+def test_semantic_pose_converts_to_homogeneous_matrix() -> None:
+    pose = SemanticPose((1.0, 2.0, 3.0), (2.0, 0.0, 0.0, 2.0))
+
+    expected = torch.tensor(
+        [
+            [0.0, -1.0, 0.0, 1.0],
+            [1.0, 0.0, 0.0, 2.0],
+            [0.0, 0.0, 1.0, 3.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ]
+    )
+    torch.testing.assert_close(pose.to_matrix(), expected, atol=1.0e-6, rtol=1.0e-6)
+
+
+@pytest.mark.parametrize(
+    "factory",
+    (
+        pytest.param(
+            lambda resources: Pick(
+                object=SceneObjectRef("cube"),
+                resources=resources,
+            ),
+            id="pick",
+        ),
+        pytest.param(
+            lambda resources: Place(
+                object=SceneObjectRef("cube"),
+                at=_identity_pose(),
+                resources=resources,
+            ),
+            id="place",
+        ),
+        pytest.param(
+            lambda resources: HandOver(
+                object=SceneObjectRef("cube"),
+                resources=resources,
+            ),
+            id="hand-over",
+        ),
+        pytest.param(
+            lambda resources: RegisteredSemanticCall(
+                call_id="vendor.navigate",
+                resources=resources,
+            ),
+            id="registered",
+        ),
+    ),
+)
+def test_semantic_calls_snapshot_and_freeze_resources(
+    factory: Callable[[Mapping[str, str]], SemanticCallSpec],
+) -> None:
+    source = {"actor": "left_arm"}
+    call = factory(source)
+
+    source["actor"] = "right_arm"
+
+    assert call.resources == {"actor": "left_arm"}
+    with pytest.raises(TypeError):
+        call.resources["actor"] = "right_arm"  # type: ignore[index]
+
+
+def test_pick_requires_typed_object_and_affordance_references() -> None:
+    with pytest.raises(TypeError, match="Pick.object"):
+        Pick(object=SceneEntityRef("cube"))  # type: ignore[arg-type]
+
+    with pytest.raises(TypeError, match="Pick.grasp"):
+        Pick(
+            object=SceneObjectRef("cube"),
+            grasp=SceneObjectRef("cube.grasp"),  # type: ignore[arg-type]
+        )
+
+
+def test_place_requires_exactly_one_destination() -> None:
+    object_ref = SceneObjectRef("cube")
+
+    with pytest.raises(ValueError, match="exactly one"):
+        Place(object=object_ref)
+    with pytest.raises(ValueError, match="exactly one"):
+        Place(
+            object=object_ref,
+            at=_identity_pose(),
+            on=SceneObjectRef("table"),
+        )
+
+
+def test_place_snapshots_absolute_destination_pose() -> None:
+    destination = _identity_pose()
+
+    call = Place(object=SceneObjectRef("cube"), at=destination)
+
+    assert call.at is not destination
+    assert call.at is not None
+    torch.testing.assert_close(call.at.to_matrix(), destination.to_matrix())
+
+
+def test_handover_normalizes_receiver_as_destination_resource() -> None:
+    call = HandOver(object=SceneObjectRef("cube"), receiver="right_actor")
+
+    assert call.receiver == "right_actor"
+    assert call.resources == {"destination": "right_actor"}
+
+
+def test_handover_rejects_conflicting_receiver_resource() -> None:
+    with pytest.raises(ValueError, match="conflicts"):
+        HandOver(
+            object=SceneObjectRef("cube"),
+            receiver="right_actor",
+            resources={"destination": "left_actor"},
+        )
+
+
+def test_handover_snapshots_optional_final_target() -> None:
+    final_target = _identity_pose()
+
+    call = HandOver(
+        object=SceneObjectRef("cube"),
+        final_target=final_target,
+    )
+
+    assert call.final_target is not final_target
+    assert call.final_target is not None
+    torch.testing.assert_close(call.final_target.to_matrix(), final_target.to_matrix())
+
+
+def test_registered_call_recursively_snapshots_declarative_arguments() -> None:
+    step = {"object": SceneObjectRef("cube")}
+    steps = [step]
+    pose = _identity_pose()
+    arguments = {"steps": steps, "target": pose}
+
+    call = RegisteredSemanticCall(
+        call_id="vendor.navigate",
+        arguments=arguments,
+    )
+    step["object"] = SceneObjectRef("changed")
+    steps.append({"object": SceneObjectRef("extra")})
+
+    saved_steps = call.arguments["steps"]
+    assert isinstance(saved_steps, tuple)
+    assert len(saved_steps) == 1
+    assert saved_steps[0] == {"object": SceneObjectRef("cube")}
+    saved_target = call.arguments["target"]
+    assert isinstance(saved_target, SemanticPose)
+    assert saved_target is not pose
+    with pytest.raises(TypeError):
+        call.arguments["new"] = 1  # type: ignore[index]
+
+
+@pytest.mark.parametrize(
+    "unsafe_value",
+    (
+        pytest.param(lambda: None, id="callable"),
+        pytest.param(torch.tensor([1.0]), id="tensor"),
+        pytest.param(object(), id="live-object"),
+    ),
+)
+def test_registered_call_rejects_executable_or_live_payloads(
+    unsafe_value: object,
+) -> None:
+    with pytest.raises(TypeError, match="non-declarative"):
+        RegisteredSemanticCall(
+            call_id="vendor.navigate",
+            arguments={"unsafe": unsafe_value},
+        )
+
+
+def test_registered_call_rejects_non_finite_payload_numbers() -> None:
+    with pytest.raises(ValueError, match="finite"):
+        RegisteredSemanticCall(
+            call_id="vendor.navigate",
+            arguments={"speed": float("nan")},
+        )
+
+
+@pytest.mark.parametrize(
+    "call_id",
+    (".", "vendor.", ".inspect", "vendor..inspect", "Vendor.inspect"),
+)
+def test_registered_call_rejects_malformed_namespace(call_id: str) -> None:
+    with pytest.raises(ValueError, match="segments"):
+        RegisteredSemanticCall(call_id=call_id)
+
+
+def test_registered_call_rejects_cyclic_payload() -> None:
+    payload: dict[str, object] = {}
+    payload["self"] = payload
+
+    with pytest.raises(ValueError, match="cyclic"):
+        RegisteredSemanticCall(
+            call_id="vendor.inspect",
+            arguments=payload,
+        )
+
+
+def test_registered_call_rejects_string_subclass_identifier() -> None:
+    class LiveString(str):
+        live_handle = object()
+
+    with pytest.raises(ValueError, match="non-empty string"):
+        RegisteredSemanticCall(call_id=LiveString("vendor.inspect"))
+
+
+def test_semantic_call_catalog_discovers_without_mutable_runtime_state() -> None:
+    pick_descriptor = _call_descriptor(Pick.call_kind, Pick)
+    catalog = SemanticCallCatalog([pick_descriptor])
+
+    assert catalog.discover("pick") is pick_descriptor
+    assert catalog.discover(Pick(object=SceneObjectRef("cube"))) is pick_descriptor
+    with pytest.raises(TypeError):
+        catalog.descriptors["other"] = pick_descriptor  # type: ignore[index]
+
+
+def test_semantic_call_catalog_extension_does_not_mutate_original() -> None:
+    pick_descriptor = _call_descriptor(Pick.call_kind, Pick)
+    extension = _call_descriptor("vendor.navigate", RegisteredSemanticCall)
+    original = SemanticCallCatalog([pick_descriptor])
+
+    extended = original.with_descriptor(extension)
+
+    with pytest.raises(KeyError, match="Unknown semantic call"):
+        original.discover("vendor.navigate")
+    assert (
+        extended.discover(RegisteredSemanticCall(call_id="vendor.navigate"))
+        is extension
+    )
+
+
+def test_semantic_call_catalog_rejects_duplicate_ids() -> None:
+    descriptor = _call_descriptor(Pick.call_kind, Pick)
+
+    with pytest.raises(ValueError, match="Duplicate semantic call ID"):
+        SemanticCallCatalog([descriptor, descriptor])
+
+
+def test_catalog_rejects_executable_call_subclasses() -> None:
+    class UnsafeRegisteredCall(RegisteredSemanticCall):
+        pass
+
+    with pytest.raises(TypeError, match="exactly"):
+        SemanticCallDescriptor(
+            call_id="vendor.unsafe",
+            spec_type=UnsafeRegisteredCall,
+            skill_id="unsafe",
+            binding_contract=SkillBindingContract(),
+        )
+
+
+def test_registered_payload_rejects_value_subclasses() -> None:
+    class LiveInteger(int):
+        live_handle = object()
+
+    with pytest.raises(TypeError, match="non-declarative"):
+        RegisteredSemanticCall(
+            call_id="vendor.unsafe",
+            arguments={"value": LiveInteger(1)},
+        )
+
+
+def test_builtin_descriptor_target_cannot_be_remapped() -> None:
+    with pytest.raises(ValueError, match="exact curated"):
+        SemanticCallDescriptor(
+            call_id=Pick.call_kind,
+            spec_type=Pick,
+            skill_id="move_joints",
+            binding_contract=SkillBindingContract(),
+        )
+
+
+def test_catalog_rejects_descriptor_subclass_with_live_state() -> None:
+    class LiveDescriptor(SemanticCallDescriptor):
+        live_handle = object()
+
+    source = _call_descriptor("vendor.inspect", RegisteredSemanticCall)
+    descriptor = LiveDescriptor(
+        call_id=source.call_id,
+        spec_type=source.spec_type,
+        skill_id=source.skill_id,
+        binding_contract=source.binding_contract,
+        target_descriptor=source.target_descriptor,
+    )
+
+    with pytest.raises(TypeError, match="exact SemanticCallDescriptor"):
+        SemanticCallCatalog((descriptor,))
+
+
+def test_descriptor_rejects_runtime_bearing_binding_contract_subclasses() -> None:
+    class LiveSlot(SkillResourceSlot):
+        live_handle = object()
+
+    target = builtin_semantic_call_catalog().discover("pick").target_descriptor
+    assert target is not None
+    endpoint = SkillEndpointRequirement("motion")
+    contract = SkillBindingContract(slots=(LiveSlot("primary", (endpoint,)),))
+    remapped_target = SkillDescriptor(
+        skill_id=target.skill_id,
+        goal_type=target.goal_type,
+        options_type=target.options_type,
+        binding_contract=contract,
+    )
+
+    with pytest.raises(TypeError, match="exact SkillResourceSlot"):
+        SemanticCallDescriptor(
+            call_id="vendor.inspect",
+            spec_type=RegisteredSemanticCall,
+            skill_id=target.skill_id,
+            binding_contract=contract,
+            target_descriptor=remapped_target,
+        )
+
+
+def test_descriptor_rejects_target_descriptor_subclass() -> None:
+    class LiveTarget(SkillDescriptor):
+        live_handle = object()
+
+    target = builtin_semantic_call_catalog().discover("pick").target_descriptor
+    assert target is not None
+    live_target = LiveTarget(
+        skill_id=target.skill_id,
+        goal_type=target.goal_type,
+        options_type=target.options_type,
+        agent_visible=target.agent_visible,
+        binding_contract=target.binding_contract,
+    )
+    assert target.binding_contract is not None
+
+    with pytest.raises(TypeError, match="exactly SkillDescriptor"):
+        SemanticCallDescriptor(
+            call_id="vendor.inspect",
+            spec_type=RegisteredSemanticCall,
+            skill_id=target.skill_id,
+            binding_contract=target.binding_contract,
+            target_descriptor=live_target,
+        )

--- a/tests/sim/skills/test_profiles.py
+++ b/tests/sim/skills/test_profiles.py
@@ -1404,4 +1404,20 @@ def test_bound_profile_rejects_stale_engine_skill_catalog() -> None:
         _ = bound.skills
 
 
+def test_bound_profile_rejects_equal_descriptor_implementation_replacement() -> None:
+    engine = _engine(control_profiles=_command_profiles())
+    bound = _profile().bind(engine)
+    action_type = BUILTIN_ACTION_TYPES[0]
+
+    class EquivalentReplacement(action_type):
+        binding_contract: ClassVar[SkillBindingContract] = action_type.binding_contract
+
+    assert EquivalentReplacement.descriptor() == action_type.descriptor()
+
+    engine.register(EquivalentReplacement(), replace=True)
+
+    with pytest.raises(RuntimeError, match="changed after"):
+        _ = bound.skills
+
+
 __all__ = []


### PR DESCRIPTION
# Description

## Stack

- Layer: 6/28
- Base: `feat/expert-program-semantic-ir`
- Depends on: https://github.com/DexForce/EmbodiChain/pull/489
- Followed by: https://github.com/DexForce/EmbodiChain/pull/491

Add strict typed semantic calls and an explicit call catalog for built-in and registered capabilities. Descriptors own argument schemas, revisions, resource requirements, effect contracts, and exact lowerer identity.

Unknown calls, duplicate registrations, invalid references, and catalog/profile mismatches fail during validation rather than reaching motion execution.

Refs #471
Refs #474

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshots

Not applicable.

## Validation

- Focused coverage: `tests/sim/skills/test_calls.py` and `test_profiles.py`
- Final affected-suite regression on the stack tip: 1215 passed, 2 skipped, 8 deselected
- Changed Python files pass Black 26.3.1; the Sphinx build and rollout-report drift check pass at the stack tip

## Checklist

- [x] Changed Python files pass Black 26.3.1.
- [x] Corresponding public/design documentation is included in this stack.
- [x] Tests cover the affected behavior.
- [x] No dependency update is required.
