### PR TITLE
Document Codex and Claude Code contribution support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,103 +49,41 @@ To contribute a new environment, please check the documentation on [Embodied Env
 
 If you want to implement your tasks in a new repo and with some customized functors and utilities, you can also use the [Task Template Repo](https://github.com/DexForce/embodichain_task_template).
 
-## Using Claude Code for Contributions
+## Using AI Coding Agents for Contributions
 
-<details>
-<summary>Setup, skills, and tips for using Claude Code</summary>
-
-[Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) is an AI-powered CLI that can assist you throughout the contribution workflow — from understanding the codebase to writing, reviewing, and debugging code.
+EmbodiChain supports both [OpenAI Codex](https://developers.openai.com/codex/cli) and [Claude Code](https://docs.anthropic.com/en/docs/claude-code/getting-started). Either agent can help explore the codebase, implement focused changes, write tests, review diffs, and prepare pull requests.
 
 ### Setup
 
-Install Claude Code and authenticate:
+Follow the official setup guide for your preferred agent, then start it from the repository root:
 
-```bash
-npm install -g @anthropic-ai/claude-code
-claude
+| Agent | Setup guide | Start command |
+|-------|-------------|---------------|
+| OpenAI Codex | [Codex CLI](https://developers.openai.com/codex/cli) | `codex` |
+| Claude Code | [Claude Code setup](https://docs.anthropic.com/en/docs/claude-code/getting-started) | `claude` |
+
+The repository uses [`AGENTS.md`](AGENTS.md) as the canonical source for project structure, conventions, and contribution instructions. Codex reads it directly; Claude Code reads [`CLAUDE.md`](CLAUDE.md), which imports the same instructions. Run either agent from the repository root so it can discover these files and the project skills.
+
+### Agent development context
+
+Agent-facing development context lives in [`agent_context/`](agent_context/). The registry at [`agent_context/MAP.yaml`](agent_context/MAP.yaml) maps topic IDs, aliases, and keywords to focused Markdown files. When a task depends on project internals, ask the agent to reference the relevant project context before making changes, for example:
+
+```text
+Reference the project context for manager-functor before implementing this change.
 ```
 
-A `CLAUDE.md` file is present at the root of this repository. Claude Code reads it automatically at startup to load project conventions, structure, and style rules, so it is context-aware from the first prompt.
+Both agents are instructed to read `agent_context/MAP.yaml` first, resolve the requested topic, and load only the matching context files. The files under `docs/source/` remain the human-facing Sphinx documentation and should be consulted only when explicitly requested.
 
-### Skills
+### Shared project skills
 
-Claude Code skills are built-in slash commands that automate common development tasks. They scaffold code, run checks, and enforce project conventions so you can focus on your logic instead of boilerplate. Invoke any skill by typing its command in the Claude Code prompt.
+Canonical skills live in [`.agents/skills/`](.agents/skills/). Claude Code uses thin adapters under [`.claude/skills/`](.claude/skills/) that point back to the same instructions, so both agents follow a consistent workflow. Ask the agent to use the relevant skill by name; common examples include:
 
-| Skill | Command | Purpose |
-|-------|---------|---------|
-| Add Functor | `/add-functor` | Scaffold a new observation, reward, event, action, dataset, or randomization functor with the correct signature, style, and module placement |
-| Add Task Env | `/add-task-env` | Scaffold a new task environment with the correct file structure, `@register_env` decorator, base class, and test stub |
-| Add Test | `/add-test` | Scaffold tests with the correct file placement, style (pytest vs class), mock patterns, and project conventions |
-| Pre-Commit Check | `/pre-commit-check` | Run all local CI checks — code style, headers, annotations, exports, and docstrings — before committing |
-| Create PR | `/pr` | Create a pull request following the project template and label conventions |
-| Benchmark | `/benchmark` | Write benchmark scripts for measuring performance of solvers, samplers, and other computationally intensive components |
+| Skill | Purpose |
+|-------|---------|
+| `/project-dev-context` | Resolve or update agent development context |
+| `/add-functor`, `/add-task-env`, `/add-robot`, `/add-solver`, `/add-atomic-action` | Scaffold project components following repository conventions |
+| `/add-test`, `/benchmark` | Add validation or performance benchmarks |
+| `/pre-commit-check` | Run proportional checks before committing |
+| `/pr`, `/release` | Prepare a pull request or release |
 
-#### When to use each skill
-
-**`/add-functor`** — Use when adding a new observation, event, reward, action, dataset, or randomization functor to an EmbodiChain environment. The skill will ask for the functor type and name, then generate the function- or class-style implementation with proper docstrings, type hints, and `__all__` exports.
-
-**`/add-task-env`** — Use when creating a new task environment, including expert demonstration tasks, RL tasks, or any `EmbodiedEnv` subclass. The skill scaffolds the task file with `_setup_scene`, `_reset_idx`, and evaluation logic, plus a test stub.
-
-**`/add-test`** — Use when writing tests for any EmbodiChain module — functors, solvers, sensors, environments, or utilities. The skill determines the correct test file location, style (pytest function vs class), and generates tests with the standard Apache 2.0 header and named constants.
-
-**`/pre-commit-check`** — Run this before committing or creating a PR. It verifies code formatting (`black`), file headers, type annotations, `__all__` exports, and docstring completeness — the same checks the CI pipeline enforces.
-
-**`/pr`** — Use after committing your changes to create a pull request. The skill checks git state, determines the PR type, drafts a description following the project template, runs formatting, creates a feature branch, and opens the PR via `gh` CLI with the correct labels.
-
-**`/benchmark`** — Use when you need to measure the performance of a module (IK solvers, grasp samplers, metrics, etc.). The skill generates a well-structured benchmark script following project conventions.
-
-### Suggested workflows
-
-**Explore the codebase before making changes**
-
-```
-> Explain how the Functor/Manager pattern works in embodichain/lab/gym/envs/managers/
-> How does the Action Manager work with EmbodiedEnv for RL tasks?
-> Show me an example of how a randomization functor is registered in a task config.
-```
-
-**Implement a new feature**
-
-```
-> I want to add a new observation functor that returns the end-effector velocity.
-  Which existing functor should I model it after?
-> /add-functor
-```
-
-**Validate style and formatting before submitting**
-
-```
-> Review my changes in embodichain/lab/gym/envs/managers/randomization/visual.py
-  for style issues, missing type hints, and docstring completeness.
-> /pre-commit-check
-```
-
-**Write or update tests**
-
-```
-> /add-test
-```
-
-**Understand a bug**
-
-```
-> I'm getting a KeyError in observation_manager.py at line 42 when env_ids is None.
-  What could cause this and how should it be fixed?
-```
-
-**Create a pull request**
-
-After you've made your changes and committed them:
-
-```
-> /pr
-```
-
-The `/pr` skill will guide you through checking git state, determining the PR type, drafting a description, running formatting, and creating the PR with proper labels.
-
-### Tips
-
-*   Always run `/pre-commit-check` after making changes — it catches the same issues the CI pipeline checks.
-*   Claude Code respects the `CLAUDE.md` conventions. If you notice it deviating (wrong docstring style, missing `__all__`, etc.), point it out and it will correct the output.
-*   For large features, break the work into small, focused tasks and handle them one at a time using the appropriate skill for each step.
-*   If you add a new skill to `.claude/skills/`, make sure to also add it to the Skills table and "When to use each skill" list in this document so contributors can discover it.
+Review all agent-generated changes, run the relevant tests, and use `/pre-commit-check` before submitting a pull request.


### PR DESCRIPTION
## Description

This PR updates CONTRIBUTING.md to document the AI coding agents supported by EmbodiChain.

- States that both OpenAI Codex and Claude Code are supported.
- Simplifies setup instructions to official guides and start commands.
- Explains how AGENTS.md and CLAUDE.md share project instructions.
- Documents agent_context/MAP.yaml topic routing and shared project skills.

The previous section only covered Claude Code and duplicated detailed workflow guidance. This focused section now reflects the current shared agent infrastructure.

Dependencies: None.
Related issue: None.

## Type of change

- [x] Documentation update

## Screenshots

Not applicable.

## Validation

- black --check --diff --color ./ (passed; 656 files unchanged)
- black . (passed; 656 files unchanged)
- git diff --check (passed)
- Local Markdown link targets (passed)
- Python tests were not run because no executable code changed.
- Sphinx was not built because CONTRIBUTING.md is outside docs/source and no documentation tooling changed.

## Checklist

- [x] I have run the black . command to format the code base.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works. Not applicable for this documentation-only change.
- [x] Dependencies have been updated, if applicable. No dependency changes were required.