### PR TITLE
Simplify atomic action planning contracts

### DIFF
--- a/agent_context/MAP.yaml
+++ b/agent_context/MAP.yaml
@@ -455,6 +455,7 @@ topics:
       - dynamic obstacle
       - StateDelta
       - held_objects
+      - HeldObjectState
       - ActionBinding
       - SceneEntityPose
       - dynamic goal
@@ -474,7 +475,7 @@ topics:
       - trajectory_ops
       - build_pose_plan_states
       - build_joint_plan_states
-      - register_action
+      - engine.register
       - BUILTIN_ACTION_TYPES
       - load_builtins
       - engine.plan

--- a/agent_context/topics/atomic-actions/atomic-actions.md
+++ b/agent_context/topics/atomic-actions/atomic-actions.md
@@ -245,7 +245,11 @@ indices. Built-ins use the binding as the only source for participating arm and
 hand names; attachment state and `StateDelta` keys use the bound manipulator.
 `TaskState.held_objects` is the sole attachment map. A multi-manipulator grasp
 stores one `HeldObjectState` per manipulator with the same `ObjectSemantics`
-instance, so coordinated outputs are directly consumable by later skills.
+instance. `TaskState.held_object_mask()` exposes active rows, while
+`exclusive_held_object_mask()` excludes rows where another manipulator holds
+the same semantic object or live entity. Single-arm transport, release, and
+handover operations only succeed on exclusive rows; coordinated placement
+likewise requires two distinct, exclusively held objects.
 
 Embodiment-specific joint commands do not belong to Action options. Register
 them once by actual control-part name:

--- a/agent_context/topics/atomic-actions/atomic-actions.md
+++ b/agent_context/topics/atomic-actions/atomic-actions.md
@@ -13,7 +13,7 @@ There is no `ActionTarget`, `WorldState`, `ActionResult`, `execute()`, or
 
 `ActionInvocation` separates:
 
-- an action-owned typed goal (`goal_kind` is its stable discriminator);
+- an action-owned typed goal, validated against the action's `GoalType`;
 - `ActionBinding`, which maps semantic roles to names from the engine robot's
   `control_parts` mapping;
 - reusable `MotionPolicy` planner/timing choices;
@@ -68,8 +68,8 @@ must remain active during execution.
 called by the engine, not a fourth application entry point. It binds collision
 entities from the current scene into a copied motion policy before delegating
 to the skill-specific `_plan()` hook. New actions implement `_plan()` and must
-not override `plan()`. `engine.plan_action(...)` is only an extension/testing
-escape hatch for an unregistered instance.
+not override `plan()`. Custom actions must be installed with
+`engine.register()` before using the same public entry points.
 
 ## Static compilation
 
@@ -228,9 +228,10 @@ built-in can be replaced only with explicit `replace=True`. Registration means
 an implementation is installed; it does not prove that the current embodiment
 has compatible control parts, profiles, bindings, or task state. Capability
 adapters must filter registered descriptors before exposing skills to an Agent.
-The module-level `register_action()` API is a process-wide extension-type
-discovery catalog only; it neither binds actions nor changes an engine's
-default built-in set.
+Registration is engine-local; there is no independent process-wide action
+catalog. Construct extensions explicitly and install them with
+`engine.register()` so discovery and execution cannot observe disconnected
+registries.
 
 `ExecutionRunnerCfg` is intentionally separate from action options. It
 configures controller acknowledgement deadlines, scheduler cadence, and final
@@ -242,6 +243,9 @@ TCP-frame, joint, or scene-object name. Planning services validate those names
 and resolve immutable `ResolvedControlPart` values containing full-robot joint
 indices. Built-ins use the binding as the only source for participating arm and
 hand names; attachment state and `StateDelta` keys use the bound manipulator.
+`TaskState.held_objects` is the sole attachment map. A multi-manipulator grasp
+stores one `HeldObjectState` per manipulator with the same `ObjectSemantics`
+instance, so coordinated outputs are directly consumable by later skills.
 
 Embodiment-specific joint commands do not belong to Action options. Register
 them once by actual control-part name:
@@ -286,7 +290,7 @@ registers the referenced entity as a recovery dependency, allowing an executing
 
 ## Extension rules
 
-1. Define a frozen action-owned goal dataclass with `goal_kind`.
+1. Define a frozen action-owned goal dataclass.
 2. Define a frozen `ActionOptions` subclass only when runtime behavior exists.
 3. Declare `skill_id`, `GoalType`, `OptionsType`, and required semantic roles.
 4. Implement `_plan()`; do not override the framework-owned `plan()` method.

--- a/docs/design/declarative_expert_program_plan.md
+++ b/docs/design/declarative_expert_program_plan.md
@@ -191,10 +191,11 @@ callers.
 
 #### Core/advanced layer
 
-The current `ActionGoal`, `ActionInvocation`, `ActionBinding`, policies,
-`PlanningContext`, `ActionPlan`, `ExecutionSession`, `ExecutionRunner`, and
-provider protocols remain available for framework authors and unusual
-integrations. They are no longer prerequisites for ordinary task authoring.
+The current action-owned goal dataclasses, `ActionInvocation`, `ActionBinding`,
+policies, `PlanningContext`, `ActionPlan`, `ExecutionSession`,
+`ExecutionRunner`, and provider protocols remain available for framework
+authors and unusual integrations. They are no longer prerequisites for
+ordinary task authoring.
 
 ### 6.2 Proposed package ownership
 

--- a/docs/source/api_reference/embodichain/embodichain.lab.sim.atomic_actions.rst
+++ b/docs/source/api_reference/embodichain/embodichain.lab.sim.atomic_actions.rst
@@ -7,7 +7,6 @@ embodichain.lab.sim.atomic_actions
 
    .. autosummary::
 
-      ActionGoal
       ActionBinding
       ResolvedActionBinding
       ResolvedControlPart
@@ -228,7 +227,4 @@ Semantic objects and helpers
    :members:
 
 .. autoclass:: HeldObjectState
-   :members:
-
-.. autoclass:: CoordinatedHeldObjectState
    :members:

--- a/docs/source/overview/sim/atomic_actions/builtin_actions.md
+++ b/docs/source/overview/sim/atomic_actions/builtin_actions.md
@@ -140,12 +140,12 @@ The animations below are the focused simulator demos under
 | `move_end_effector` | `EndEffectorPoseGoal` | manipulator `primary` | none | none | none |
 | `move_joints` | `JointPositionGoal` | manipulator `primary` | named target only: command matching `target` | none | none |
 | `pick_up` | `GraspGoal` | manipulator + end effector `primary` | primary: `open`, `grasp` | semantic object/entity | attach object to `primary` manipulator |
-| `move_held_object` | `HeldObjectPoseGoal` | manipulator + end effector `primary` | primary: `grasp` | object held by `primary` | preserve attachment |
-| `place` | `PlaceGoal`, `AssembleGoal` | manipulator + end effector `primary` | primary: `open`, `grasp` | `AssembleGoal` requires an object held by `primary`; ordinary `PlaceGoal` has no planner-enforced attachment precondition | detach object |
+| `move_held_object` | `HeldObjectPoseGoal` | manipulator + end effector `primary` | primary: `grasp` | object held exclusively by `primary` | preserve attachment |
+| `place` | `PlaceGoal`, `AssembleGoal` | manipulator + end effector `primary` | primary: `open`, `grasp` | an active attachment must be exclusive to `primary`; `AssembleGoal` requires one | detach object |
 | `press` | `PressGoal` | manipulator + end effector `primary` | primary: `grasp` | none | none |
 | `coordinated_pickment` | `CoordinatedPickGoal` | manipulator + end effector `left`, `right` | both: `open`, `grasp` | semantic object/entity | attach the shared object to both manipulators |
-| `coordinated_placement` | `CoordinatedPlacementGoal` | manipulator + end effector `placing`, `support` | placing: `open`, `grasp`; support: `grasp` | one individually held object per arm | optionally detach placing object; preserve support attachment |
-| `hand_over` | `GraspGoal` | manipulator + end effector `source`, `destination` | both: `open`, `grasp` | object held by source arm | transfer attachment to destination arm |
+| `coordinated_placement` | `CoordinatedPlacementGoal` | manipulator + end effector `placing`, `support` | placing: `open`, `grasp`; support: `grasp` | two distinct objects, each held exclusively by its arm | optionally detach placing object; preserve support attachment |
+| `hand_over` | `GraspGoal` | manipulator + end effector `source`, `destination` | both: `open`, `grasp` | object held exclusively by source arm | transfer attachment to destination arm |
 
 ### Binding role meanings
 
@@ -349,7 +349,7 @@ the action derives `target_object_pose @ object_to_eef` from verified task state
 | Skill ID | `move_held_object` |
 | Goal | `HeldObjectPoseGoal(object_target_pose=...)` |
 | Binding | manipulator + end effector role `primary` |
-| Precondition | a `HeldObjectState` exists for the bound manipulator, normally from `PickUp` |
+| Precondition | a `HeldObjectState` exists exclusively for the bound manipulator, normally from `PickUp` |
 | Motion | single object-centric transport segment with closed-hand qpos |
 | Effect | none; the existing attachment is preserved |
 | Dynamic target | explicit pose or `SceneEntityPose` |
@@ -357,7 +357,8 @@ the action derives `target_object_pose @ object_to_eef` from verified task state
 The bound end-effector profile must provide `grasp`; optional upright-transport
 settings belong to `MoveHeldObjectOptions`. The arm and hand are selected by
 `ActionBinding`; generic timing and trajectory sampling remain in
-`MotionPolicy`.
+`MotionPolicy`. In a vectorized batch, rows where another manipulator holds the
+same semantic object or live entity are marked unsuccessful and held in place.
 
 **Example:** `scripts/tutorials/atomic_action/move_held_object.py`
 
@@ -374,7 +375,7 @@ one.
 | Skill ID | `place` |
 | Goal | `PlaceGoal(xpos=..., tcp_symmetry="none")` |
 | Binding | manipulator + end effector role `primary` |
-| State | consumes the bound manipulator's attachment when present |
+| State | consumes the bound manipulator's attachment when present and exclusive |
 | Effect | detach the object from the bound manipulator |
 | Verification | release must be verified during closed-loop execution |
 | Dynamic target | explicit pose/waypoints or `SceneEntityPose` |
@@ -382,7 +383,8 @@ one.
 Set `tcp_symmetry="z_roll_180"` only if TCP x/y can be flipped while TCP z and
 translation remain physically equivalent. The action selects the closer
 orientation variant from the observed starting state and uses it consistently
-across all waypoints.
+across all waypoints. An ordinary `PlaceGoal` may still open an unattached
+gripper, but it will not release one side of a shared multi-manipulator object.
 
 The bound end-effector profile must provide `open` and `grasp`. Important
 `PlaceOptions` fields:
@@ -411,8 +413,9 @@ assemble_object_target_pose @ held.object_to_eef = release_eef_pose
 
 The `AssembleAffordance` identifies the base and assemble objects, stores the
 relative pose, and must provide `base_object_entity`. A prior verified `PickUp`
-must have populated the held object's `object_to_eef` transform. Planning then
-declares the same detach effect as a normal place.
+must have populated the held object's `object_to_eef` transform and that
+attachment must be exclusive. Planning then declares the same detach effect as
+a normal place.
 
 The base entity's current pose is read each time `plan()` runs. Because the
 goal does not yet encode that entity through `SceneEntityPose`, base movement by
@@ -469,8 +472,10 @@ action calls `AntipodalAffordance.get_dual_arm_valid_grasp_poses` with the
 options to partition the object into left/right grasp regions and select the
 lowest-cost grasp on each side. Each derived `object_to_eef` transform is stored
 in the corresponding projected `HeldObjectState`. Later object-centric skills
-can consume those per-manipulator entries directly; sharing the same
-`ObjectSemantics` instance identifies the common object.
+can inspect those per-manipulator entries directly; sharing the same
+`ObjectSemantics` instance identifies the common object. Single-arm transport,
+release, and handover skills reject those shared rows rather than moving or
+detaching just one participant.
 
 The object target and optional initial pose may use `SceneEntityPose`. When no
 initial pose is supplied, `ObjectSemantics.entity` provides the object's current
@@ -503,13 +508,15 @@ hold -> optionally release the placing hand -> retreat the placing arm**.
 | Skill ID | `coordinated_placement` |
 | Goal | `CoordinatedPlacementGoal` |
 | Binding | manipulator + end effector roles `placing` and `support` |
-| Precondition | separate `HeldObjectState` entries exist for both bound arms |
+| Precondition | each bound arm exclusively holds a different object |
 | Goal geometry | placing/support object target poses, optional height offsets, optional release override |
 | Effect | preserve support attachment; remove or preserve placing attachment according to `release` |
 
 Both object targets may use `SceneEntityPose`, so either can participate in
 dynamic-goal invalidation. Goal-level height/release values override
-`CoordinatedPlacementOptions` for that invocation.
+`CoordinatedPlacementOptions` for that invocation. Two entries that identify
+the same semantic object or live entity are a shared grasp, not a placing and
+support pair, and their environment rows are rejected.
 
 The placing profile must provide `open` and `grasp`; the support profile must
 provide `grasp`. Important `CoordinatedPlacementOptions` fields group into:
@@ -536,7 +543,7 @@ retreats -> destination delivers**.
 | Skill ID | `hand_over` |
 | Goal | `GraspGoal(semantics=...)` |
 | Binding | manipulator + end effector roles `source` and `destination` |
-| Precondition | source arm has a verified `HeldObjectState`; semantic object supports destination grasp selection |
+| Precondition | source arm exclusively has a verified `HeldObjectState`; goal semantics identify that object and support destination grasp selection |
 | Effect | remove source attachment and create destination `HeldObjectState` |
 | Verification | attachment transfer must be externally verified |
 
@@ -544,7 +551,8 @@ Both source and destination end-effector profiles must provide `open` and
 `grasp`. `HandOverOptions` owns the destination grasp region and approach
 direction, middle/final object poses, and segment distances/counts. The
 source/destination arm and hand control parts come exclusively from the
-corresponding `ActionBinding` roles.
+corresponding `ActionBinding` roles. The destination attachment reuses the
+source relation's canonical `ObjectSemantics` instance.
 
 The middle and final poses are currently option tensors rather than
 `SceneEntityPose` goal fields. Consequently, handover supports tracking-error

--- a/docs/source/overview/sim/atomic_actions/builtin_actions.md
+++ b/docs/source/overview/sim/atomic_actions/builtin_actions.md
@@ -143,7 +143,7 @@ The animations below are the focused simulator demos under
 | `move_held_object` | `HeldObjectPoseGoal` | manipulator + end effector `primary` | primary: `grasp` | object held by `primary` | preserve attachment |
 | `place` | `PlaceGoal`, `AssembleGoal` | manipulator + end effector `primary` | primary: `open`, `grasp` | `AssembleGoal` requires an object held by `primary`; ordinary `PlaceGoal` has no planner-enforced attachment precondition | detach object |
 | `press` | `PressGoal` | manipulator + end effector `primary` | primary: `grasp` | none | none |
-| `coordinated_pickment` | `CoordinatedPickGoal` | manipulator + end effector `left`, `right` | both: `open`, `grasp` | semantic object/entity | create coordinated attachment; clear individual attachments |
+| `coordinated_pickment` | `CoordinatedPickGoal` | manipulator + end effector `left`, `right` | both: `open`, `grasp` | semantic object/entity | attach the shared object to both manipulators |
 | `coordinated_placement` | `CoordinatedPlacementGoal` | manipulator + end effector `placing`, `support` | placing: `open`, `grasp`; support: `grasp` | one individually held object per arm | optionally detach placing object; preserve support attachment |
 | `hand_over` | `GraspGoal` | manipulator + end effector `source`, `destination` | both: `open`, `grasp` | object held by source arm | transfer attachment to destination arm |
 
@@ -308,7 +308,7 @@ bound manipulator.
 | Goal | `GraspGoal(semantics=..., grasp_xpos=None)` |
 | Binding | manipulator + end effector role `primary` |
 | Precondition | `ObjectSemantics.entity` is set; an `AntipodalAffordance` is required when no explicit grasp pose is supplied |
-| Effect | write `HeldObjectState` for the bound manipulator and clear overlapping coordinated attachment state |
+| Effect | write `HeldObjectState` for the bound manipulator |
 | Verification | the attachment effect must be verified during closed-loop execution |
 
 `grasp_xpos` may be `(4, 4)`, `(B, 4, 4)`, or a `SceneEntityPose`. A scene
@@ -375,7 +375,7 @@ one.
 | Goal | `PlaceGoal(xpos=..., tcp_symmetry="none")` |
 | Binding | manipulator + end effector role `primary` |
 | State | consumes the bound manipulator's attachment when present |
-| Effect | detach the object and clear overlapping coordinated attachment state |
+| Effect | detach the object from the bound manipulator |
 | Verification | release must be verified during closed-loop execution |
 | Dynamic target | explicit pose/waypoints or `SceneEntityPose` |
 
@@ -460,16 +460,17 @@ both hands -> lift -> move object -> hold**.
 | Binding | manipulator + end effector roles `left` and `right` |
 | Precondition | `ObjectSemantics.entity` is set and the affordance is an `AntipodalAffordance` |
 | Goal geometry | shared-object target pose and optional initial object pose; left/right grasps are sampled from the affordance |
-| Effect | clear individual left/right attachments and create `CoordinatedHeldObjectState[(left, right)]` |
+| Effect | write one `HeldObjectState` per bound manipulator; both entries share the same object semantics |
 | Verification | coordinated attachment must be externally verified |
 
 The left/right grasp poses are not supplied by the caller. At planning time the
 action calls `AntipodalAffordance.get_dual_arm_valid_grasp_poses` with the
 `approach_direction`, `left_to_right_arm_direction`, and `middle_empty_ratio`
 options to partition the object into left/right grasp regions and select the
-lowest-cost grasp on each side. The derived `object_to_eef` transforms are
-stored in the projected `CoordinatedHeldObjectState` and reused by later
-object-centric skills.
+lowest-cost grasp on each side. Each derived `object_to_eef` transform is stored
+in the corresponding projected `HeldObjectState`. Later object-centric skills
+can consume those per-manipulator entries directly; sharing the same
+`ObjectSemantics` instance identifies the common object.
 
 The object target and optional initial pose may use `SceneEntityPose`. When no
 initial pose is supplied, `ObjectSemantics.entity` provides the object's current
@@ -504,7 +505,7 @@ hold -> optionally release the placing hand -> retreat the placing arm**.
 | Binding | manipulator + end effector roles `placing` and `support` |
 | Precondition | separate `HeldObjectState` entries exist for both bound arms |
 | Goal geometry | placing/support object target poses, optional height offsets, optional release override |
-| Effect | preserve support attachment; remove or preserve placing attachment according to `release`; clear overlapping coordinated state |
+| Effect | preserve support attachment; remove or preserve placing attachment according to `release` |
 
 Both object targets may use `SceneEntityPose`, so either can participate in
 dynamic-goal invalidation. Goal-level height/release values override

--- a/docs/source/overview/sim/atomic_actions/index.md
+++ b/docs/source/overview/sim/atomic_actions/index.md
@@ -165,7 +165,7 @@ from leaking into an Action Agent schema.
 
 | Contract | Contains | Does not contain |
 |---|---|---|
-| `ActionGoal` | Action-specific desired outcome, such as an EEF pose or object pose | Arm names, planner instances, recovery counters |
+| Action-owned goal dataclass | Action-specific desired outcome, such as an EEF pose or object pose | Arm names, planner instances, recovery counters |
 | `ActionBinding` | Semantic-role mappings to keys from the engine robot's `control_parts`, such as `primary -> left_arm` and `primary -> left_hand` | Link/TCP names, arbitrary scene objects, motion settings, or task geometry |
 | `ActionOptions` / built-in `*Options` | Frozen invocation-varying skill behavior: segment counts, offsets, grasp-selection rules | Robot resource names, hand qpos, planner backend |
 | `ControlPartCommandProfile` | Embodiment-specific semantic commands such as `open`, `grasp`, and `ready`, keyed by actual control-part name | Action roles, task goals, recovery state |
@@ -179,9 +179,11 @@ from leaking into an Action Agent schema.
 `MotionPolicy.strategy` accepts exactly `"motion_gen"` or `"ik_interp"`; the
 same value is forwarded to `MotionGenOptions.strategy` without an adapter layer.
 
-Goals follow the structural `ActionGoal` protocol: each action owns one or more
-frozen dataclasses with a stable `goal_kind`. There is no shared `ActionTarget`
-base class and no closed union that must change whenever a skill is added.
+Each action owns one or more frozen goal dataclasses and declares the accepted
+type through `AtomicAction.GoalType`. The action validates that type when the
+engine resolves an invocation. There is no marker protocol, shared
+`ActionTarget` base class, or closed union that must change whenever a skill is
+added.
 
 ### Semantic resource binding
 
@@ -355,10 +357,9 @@ custom_engine.register(MyAction())
 engine.register(CustomPickUp(), replace=True)
 ```
 
-The module-level `register_action()` catalog is only for process-wide extension
-type discovery. It does not mutate existing engines or join their default
-built-in set; instantiate a discovered extension and pass it to
-`engine.register()` explicitly.
+Registration is deliberately engine-local. Construct an extension and pass it
+to `engine.register()` explicitly; there is no separate process-wide catalog
+whose contents can drift from the actions installed in an engine.
 
 ### Implementation and advanced APIs
 
@@ -370,7 +371,6 @@ resolving an invocation; skill implementations provide `_plan()`:
 |---|---|---|
 | `AtomicAction.plan(request, context)` | `AtomicActionEngine` | Binds the current collision scene into a copied policy, then delegates to `_plan()` |
 | `AtomicAction._plan(request, context)` | Atomic-action implementer | Consumes the prepared immutable `ResolvedActionRequest` and returns an `ActionPlan` |
-| `engine.plan_action(action, invocation, context)` | Extension or isolated test | Temporarily binds and plans an unregistered action instance; built-in parameter variants should use invocation `skill_options` instead |
 | `session.revise_current(invocation)` | Runtime orchestrator or Action Agent | Replaces the active logical call with a newer revision and replans from the latest observed context |
 | `runner.step(effect_success=...)` | Non-blocking controller integration | Observes and dispatches only when the next timed command is due |
 | `runner.run_until_blocked(...)` | Simple blocking application or tutorial | Advances the injected clock until terminal or external effect verification is required |
@@ -641,6 +641,10 @@ environment row. Pick, place, handover, and coordinated skills also return an
 uncommitted `StateDelta` describing the attachment state expected after
 execution.
 
+`TaskState.held_objects` uses one `HeldObjectState` per bound manipulator.
+Multi-arm grasps use multiple entries that share the same `ObjectSemantics`;
+there is no parallel coordinated-attachment representation to synchronize.
+
 At the terminal waypoint, an `ExecutionSession` requests an external
 per-environment verification mask before committing a non-empty effect:
 
@@ -688,7 +692,7 @@ decision without mutating an in-flight request implicitly.
 
 A new primitive should:
 
-1. define a frozen, action-owned goal dataclass with a stable `goal_kind`;
+1. define a frozen, action-owned goal dataclass;
 2. define a frozen `ActionOptions` subclass only for behavior that can vary per
    invocation;
 3. declare `skill_id`, `GoalType`, `OptionsType`, required semantic roles, and

--- a/docs/source/overview/sim/atomic_actions/index.md
+++ b/docs/source/overview/sim/atomic_actions/index.md
@@ -644,6 +644,9 @@ execution.
 `TaskState.held_objects` uses one `HeldObjectState` per bound manipulator.
 Multi-arm grasps use multiple entries that share the same `ObjectSemantics`;
 there is no parallel coordinated-attachment representation to synchronize.
+Consumers query per-environment active and exclusive-hold masks from that one
+map. A single-arm transport, release, or handover row fails safely while a
+second manipulator still holds the same semantic object or live entity.
 
 At the terminal waypoint, an `ExecutionSession` requests an external
 per-environment verification mask before committing a non-empty effect:

--- a/docs/source/overview/sim/sim_cloth.md
+++ b/docs/source/overview/sim/sim_cloth.md
@@ -135,9 +135,9 @@ For cloth objects, the state is represented by the positions and velocities of i
 
 | Method | Return Shape | Description |
 | :--- | :--- | :--- |
-| `get_current_vertex_position()` | `(n_envs, n_vert, 3)` | Current positions of mesh vertices. |
-| `get_current_vertex_velocity()` | `(n_envs, n_vert, 3)` | Current positions of  mesh vertices. |
-| `get_rest_vertex_position()` | `(n_envs, n_vert, 3` | Rest (initial) positions of collision vertices. |
+| `get_current_vertex_position()` | `(num_envs, n_vert, 3)` | Current positions of mesh vertices. |
+| `get_current_vertex_velocity()` | `(num_envs, n_vert, 3)` | Current positions of  mesh vertices. |
+| `get_rest_vertex_position()` | `(num_envs, n_vert, 3` | Rest (initial) positions of collision vertices. |
 
 > Note: N is the number of environments/instances, V_col is the number of collision vertices, and V_sim is the number of simulation vertices.
 

--- a/docs/source/tutorial/atomic_actions.rst
+++ b/docs/source/tutorial/atomic_actions.rst
@@ -81,9 +81,8 @@ sends commands returned by an execution session and supplies new observations.
 ``AtomicAction.plan(request, context)`` is different from ``engine.plan()``.
 It is the framework-owned template method called by the engine, not an
 additional application execution entry point. Atomic-action authors implement
-the protected ``_plan()`` hook instead. Similarly,
-``engine.plan_action()`` is reserved for extensions and isolated tests that
-need to plan an unregistered instance.
+the protected ``_plan()`` hook instead. Register custom action instances with
+``engine.register()`` before using the same public planning entry points.
 
 Runnable examples
 -----------------
@@ -393,8 +392,8 @@ only once. The durable state is ``tick.pending_effect`` (an
 Adding an action
 ----------------
 
-Define an action-owned frozen goal dataclass with a stable ``goal_kind``. Then
-define typed runtime options when needed, implement the protected
+Define an action-owned frozen goal dataclass. Then define typed runtime options
+when needed, implement the protected
 ``_plan(request, context)`` hook, and declare the stable skill metadata. Do not
 override the inherited public ``plan()`` method because it binds the latest
 collision scene first.
@@ -412,7 +411,6 @@ A minimal implementation looks like:
 
    @dataclass(frozen=True, slots=True)
    class PushGoal:
-       goal_kind: ClassVar[str] = "push"
        contact_pose: torch.Tensor
 
    @dataclass(frozen=True, slots=True)

--- a/embodichain/lab/gym/envs/managers/actions.py
+++ b/embodichain/lab/gym/envs/managers/actions.py
@@ -284,7 +284,7 @@ class EefPoseTerm(ActionTerm):
             raise ValueError(
                 f"EEF pose action must be 6D or 7D, got {scaled.shape[-1]}D"
             )
-        # Batch IK: robot.compute_ik supports (n_envs, 4, 4) pose and (n_envs, dof) seed
+        # Batch IK: robot.compute_ik supports (num_envs, 4, 4) pose and (num_envs, dof) seed
         ret, qpos_ik = self._env.robot.compute_ik(
             pose=target_pose,
             joint_seed=current_qpos,

--- a/embodichain/lab/sim/atomic_actions/__init__.py
+++ b/embodichain/lab/sim/atomic_actions/__init__.py
@@ -45,12 +45,7 @@ from .control import (
 )
 from .core import AtomicAction, ObjectSemantics, SkillDescriptor
 from .effects import StateDelta
-from .engine import (
-    AtomicActionEngine,
-    get_registered_actions,
-    register_action,
-    unregister_action,
-)
+from .engine import AtomicActionEngine
 from .execution import (
     EffectVerificationRequest,
     ExecutionEvent,
@@ -60,7 +55,7 @@ from .execution import (
     ExecutionTick,
     JointCommand,
 )
-from .goals import ActionGoal, ObjectActionGoal, PoseGoalValue, SceneEntityPose
+from .goals import ObjectActionGoal, PoseGoalValue, SceneEntityPose
 from .invocation import ActionInvocation, ActionOptions, ResolvedActionRequest
 from .plans import (
     ActionPlan,
@@ -125,7 +120,6 @@ from .sim_adapter import (
     SimulationExecutionAdapter,
 )
 from .state import (
-    CoordinatedHeldObjectState,
     EntityState,
     HeldObjectState,
     PlanningContext,
@@ -137,7 +131,6 @@ from .state import (
 __all__ = [
     "ActionBinding",
     "ActionControlOverrides",
-    "ActionGoal",
     "ActionInvocation",
     "ActionOptions",
     "ActionPlan",
@@ -157,7 +150,6 @@ __all__ = [
     "CommandSink",
     "ControlCommand",
     "ControlPartCommandProfile",
-    "CoordinatedHeldObjectState",
     "CoordinatedPickGoal",
     "CoordinatedPickment",
     "CoordinatedPickmentOptions",
@@ -230,7 +222,4 @@ __all__ = [
     "TaskState",
     "TimedTrajectory",
     "TrajectorySegment",
-    "get_registered_actions",
-    "register_action",
-    "unregister_action",
 ]

--- a/embodichain/lab/sim/atomic_actions/affordance.py
+++ b/embodichain/lab/sim/atomic_actions/affordance.py
@@ -262,7 +262,7 @@ class AssembleAffordance(Affordance):
         default_factory=lambda: torch.eye(4, dtype=torch.float32)
     )
     """Pose of the assemble object relative to the base object frame, shape
-    ``(4, 4)`` or ``(n_envs, 4, 4)``."""
+    ``(4, 4)`` or ``(num_envs, 4, 4)``."""
 
     def get_assemble_object_pose(self, base_pose: torch.Tensor) -> torch.Tensor:
         """Return the assemble-object target pose for a given base-object pose.
@@ -270,22 +270,22 @@ class AssembleAffordance(Affordance):
         The assemble object is placed at ``base_pose @ assemble_to_base_pose``.
 
         Args:
-            base_pose: Base-object pose with shape ``(4, 4)`` or ``(n_envs, 4, 4)``.
+            base_pose: Base-object pose with shape ``(4, 4)`` or ``(num_envs, 4, 4)``.
 
         Returns:
-            Assemble-object target pose with shape ``(n_envs, 4, 4)``.
+            Assemble-object target pose with shape ``(num_envs, 4, 4)``.
         """
         base_pose = base_pose.to(dtype=torch.float32)
         if base_pose.dim() == 2:
             base_pose = base_pose.unsqueeze(0)
-        n_envs = base_pose.shape[0]
+        num_envs = base_pose.shape[0]
         rel = self.assemble_to_base_pose.to(
             device=base_pose.device, dtype=torch.float32
         )
         if rel.dim() == 2:
-            rel = rel.unsqueeze(0).repeat(n_envs, 1, 1)
+            rel = rel.unsqueeze(0).repeat(num_envs, 1, 1)
         elif rel.shape[0] == 1:
-            rel = rel.repeat(n_envs, 1, 1)
+            rel = rel.repeat(num_envs, 1, 1)
         return torch.bmm(base_pose, rel)
 
 

--- a/embodichain/lab/sim/atomic_actions/bindings.py
+++ b/embodichain/lab/sim/atomic_actions/bindings.py
@@ -206,7 +206,7 @@ class ResolvedControlPart:
         self,
         name: str,
         *,
-        n_envs: int,
+        num_envs: int,
         device: torch.device | str,
         dtype: torch.dtype | None = None,
     ) -> torch.Tensor:
@@ -224,7 +224,7 @@ class ResolvedControlPart:
                 f"{type(command).__name__}, not JointPositionCommand."
             )
         return command.resolve(
-            n_envs=n_envs,
+            num_envs=num_envs,
             control_dof=self.dof,
             device=device,
             dtype=dtype,

--- a/embodichain/lab/sim/atomic_actions/control.py
+++ b/embodichain/lab/sim/atomic_actions/control.py
@@ -50,7 +50,7 @@ class JointPositionCommand(ControlCommand):
     """A semantic command represented by one or batched joint positions.
 
     ``positions`` has shape ``(control_dof,)`` or
-    ``(n_envs, control_dof)``. A one-dimensional command is broadcast to the
+    ``(num_envs, control_dof)``. A one-dimensional command is broadcast to the
     planning batch when resolved.
     """
 
@@ -62,7 +62,7 @@ class JointPositionCommand(ControlCommand):
         if positions.dim() not in (1, 2) or positions.shape[-1] == 0:
             raise ValueError(
                 "positions must have shape (control_dof,) or "
-                "(n_envs, control_dof), got "
+                "(num_envs, control_dof), got "
                 f"{tuple(positions.shape)}."
             )
         if not torch.isfinite(positions).all().item():
@@ -81,7 +81,7 @@ class JointPositionCommand(ControlCommand):
     def resolve(
         self,
         *,
-        n_envs: int,
+        num_envs: int,
         control_dof: int,
         device: torch.device | str,
         dtype: torch.dtype | None = None,
@@ -89,20 +89,20 @@ class JointPositionCommand(ControlCommand):
         """Validate, move, and broadcast this command for a planning batch.
 
         Args:
-            n_envs: Number of selected environments.
+            num_envs: Number of selected environments.
             control_dof: Joint count of the resolved control part.
             device: Target planning device.
             dtype: Optional target dtype.
 
         Returns:
-            Independently owned tensor with shape ``(n_envs, control_dof)``.
+            Independently owned tensor with shape ``(num_envs, control_dof)``.
 
         Raises:
             ValueError: If the command shape does not match the control part or
                 selected environment batch.
         """
-        if not isinstance(n_envs, int) or n_envs < 1:
-            raise ValueError("n_envs must be a positive integer.")
+        if not isinstance(num_envs, int) or num_envs < 1:
+            raise ValueError("num_envs must be a positive integer.")
         if not isinstance(control_dof, int) or control_dof < 1:
             raise ValueError("control_dof must be a positive integer.")
         if self._positions.shape[-1] != control_dof:
@@ -112,11 +112,11 @@ class JointPositionCommand(ControlCommand):
             )
         resolved = self._positions.to(device=device, dtype=dtype)
         if resolved.dim() == 1:
-            return resolved.unsqueeze(0).expand(n_envs, -1).clone()
-        if resolved.shape[0] != n_envs:
+            return resolved.unsqueeze(0).expand(num_envs, -1).clone()
+        if resolved.shape[0] != num_envs:
             raise ValueError(
                 f"Batched joint-position command has {resolved.shape[0]} "
-                f"environments, expected {n_envs}."
+                f"environments, expected {num_envs}."
             )
         return resolved.clone()
 

--- a/embodichain/lab/sim/atomic_actions/core.py
+++ b/embodichain/lab/sim/atomic_actions/core.py
@@ -22,6 +22,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Mapping
 from copy import deepcopy
 from dataclasses import dataclass, field, replace
+from functools import cached_property
 from typing import Any, ClassVar, Generic, TYPE_CHECKING
 
 import torch
@@ -208,7 +209,7 @@ class AtomicAction(Generic[GoalT, OptionsT], ABC):
         if self._planning_services is None:
             raise RuntimeError(
                 f"Atomic action {self.skill_id!r} is not bound to an "
-                "AtomicActionEngine. Register it or call engine.plan_action()."
+                "AtomicActionEngine. Register it with engine.register()."
             )
         return self._planning_services
 
@@ -227,6 +228,16 @@ class AtomicAction(Generic[GoalT, OptionsT], ABC):
         """Return the concrete runtime device associated with the engine."""
         return self.planning_services.device
 
+    @cached_property
+    def num_envs(self) -> int:
+        """Number of environments owned by the bound robot."""
+        return int(self.robot.get_qpos().shape[0])
+
+    @cached_property
+    def robot_dof(self) -> int:
+        """Number of full-robot degrees of freedom."""
+        return int(self.robot.dof)
+
     def _bind(self, services: ActionPlanningServices) -> None:
         """Bind engine-owned planning services exactly once."""
         if self._planning_services is services:
@@ -237,14 +248,6 @@ class AtomicAction(Generic[GoalT, OptionsT], ABC):
                 "AtomicActionEngine."
             )
         self._planning_services = services
-        try:
-            self._on_bind()
-        except Exception:
-            self._planning_services = None
-            raise
-
-    def _on_bind(self) -> None:
-        """Initialize implementation state that depends on engine resources."""
 
     @classmethod
     def descriptor(cls) -> SkillDescriptor:
@@ -457,10 +460,9 @@ class AtomicAction(Generic[GoalT, OptionsT], ABC):
         Returns:
             Side-effect-free action plan.
         """
-        self.require_goal(request)
         success_mask = normalize_success_mask(
             success,
-            n_envs=context.batch_size,
+            num_envs=context.batch_size,
             device=self.device,
             name="Planning success",
         )

--- a/embodichain/lab/sim/atomic_actions/effects.py
+++ b/embodichain/lab/sim/atomic_actions/effects.py
@@ -24,14 +24,7 @@ from typing import Mapping
 
 import torch
 
-from .state import (
-    CoordinatedHeldObjectState,
-    HeldObjectState,
-    TaskState,
-    _normalize_coordinated_held,
-    _normalize_held,
-    _normalize_mask,
-)
+from .state import HeldObjectState, TaskState, _normalize_held, _normalize_mask
 
 
 def _with_held_mask(
@@ -43,21 +36,6 @@ def _with_held_mask(
         semantics=value.semantics,
         object_to_eef=value.object_to_eef,
         grasp_xpos=value.grasp_xpos,
-        env_mask=env_mask,
-    )
-
-
-def _with_coordinated_mask(
-    value: CoordinatedHeldObjectState,
-    env_mask: torch.Tensor,
-) -> CoordinatedHeldObjectState:
-    """Copy a coordinated held-object relation with a replacement mask."""
-    return CoordinatedHeldObjectState(
-        semantics=value.semantics,
-        left_object_to_eef=value.left_object_to_eef,
-        right_object_to_eef=value.right_object_to_eef,
-        left_grasp_xpos=value.left_grasp_xpos,
-        right_grasp_xpos=value.right_grasp_xpos,
         env_mask=env_mask,
     )
 
@@ -105,57 +83,6 @@ def _merge_held(
     )
 
 
-def _merge_coordinated(
-    previous: CoordinatedHeldObjectState | None,
-    candidate: CoordinatedHeldObjectState | None,
-    update_mask: torch.Tensor,
-) -> CoordinatedHeldObjectState | None:
-    """Apply one optional coordinated relation update per environment."""
-    if previous is None and candidate is None:
-        return None
-    if previous is None:
-        assert candidate is not None and candidate.env_mask is not None
-        env_mask = candidate.env_mask & update_mask
-        return _with_coordinated_mask(candidate, env_mask) if env_mask.any() else None
-    assert previous.env_mask is not None
-    if candidate is None:
-        env_mask = previous.env_mask & ~update_mask
-        return _with_coordinated_mask(previous, env_mask) if env_mask.any() else None
-    assert candidate.env_mask is not None
-
-    previous_retained = bool((previous.env_mask & ~update_mask).any().item())
-    candidate_applied = bool((candidate.env_mask & update_mask).any().item())
-    if (
-        previous_retained
-        and candidate_applied
-        and previous.semantics is not candidate.semantics
-    ):
-        raise ValueError(
-            "Cannot merge different coordinated held-object semantics for one "
-            "resource pair across environments."
-        )
-    env_mask = torch.where(update_mask, candidate.env_mask, previous.env_mask)
-    if not env_mask.any():
-        return None
-    selector = update_mask[:, None, None]
-    return CoordinatedHeldObjectState(
-        semantics=candidate.semantics if candidate_applied else previous.semantics,
-        left_object_to_eef=torch.where(
-            selector, candidate.left_object_to_eef, previous.left_object_to_eef
-        ),
-        right_object_to_eef=torch.where(
-            selector, candidate.right_object_to_eef, previous.right_object_to_eef
-        ),
-        left_grasp_xpos=torch.where(
-            selector, candidate.left_grasp_xpos, previous.left_grasp_xpos
-        ),
-        right_grasp_xpos=torch.where(
-            selector, candidate.right_grasp_xpos, previous.right_grasp_xpos
-        ),
-        env_mask=env_mask,
-    )
-
-
 @dataclass(frozen=True, slots=True, eq=False)
 class StateDelta:
     """Expected task-state changes that require post-execution verification.
@@ -170,14 +97,8 @@ class StateDelta:
     )
     """Per-resource attachment replacements or removals."""
 
-    coordinated_held_object_updates: Mapping[
-        tuple[str, str], CoordinatedHeldObjectState | None
-    ] = field(default_factory=dict)
-    """Per-resource-pair coordinated attachment replacements or removals."""
-
     def __post_init__(self) -> None:
         held = dict(self.held_object_updates)
-        coordinated = dict(self.coordinated_held_object_updates)
         for resource, value in held.items():
             if not isinstance(resource, str) or not resource:
                 raise ValueError(
@@ -187,31 +108,12 @@ class StateDelta:
                 raise TypeError(
                     "held_object_updates values must be HeldObjectState or None."
                 )
-        for resources, value in coordinated.items():
-            if (
-                not isinstance(resources, tuple)
-                or len(resources) != 2
-                or not all(isinstance(item, str) and item for item in resources)
-            ):
-                raise ValueError(
-                    "coordinated_held_object_updates keys must be resource pairs."
-                )
-            if value is not None and not isinstance(value, CoordinatedHeldObjectState):
-                raise TypeError(
-                    "coordinated_held_object_updates values must be "
-                    "CoordinatedHeldObjectState or None."
-                )
         object.__setattr__(self, "held_object_updates", MappingProxyType(held))
-        object.__setattr__(
-            self,
-            "coordinated_held_object_updates",
-            MappingProxyType(coordinated),
-        )
 
     @property
     def is_empty(self) -> bool:
         """Whether this delta declares no symbolic state changes."""
-        return not self.held_object_updates and not self.coordinated_held_object_updates
+        return not self.held_object_updates
 
     def apply(
         self,
@@ -226,7 +128,7 @@ class StateDelta:
 
         Args:
             state: Input task state.
-            update_mask: Successful and verified rows, shape ``(n_envs,)``.
+            update_mask: Successful and verified rows, shape ``(num_envs,)``.
 
         Returns:
             New task state with masked updates.
@@ -256,28 +158,10 @@ class StateDelta:
             else:
                 held[resource] = merged
 
-        coordinated = dict(state.coordinated_held_objects)
-        for resources, candidate in self.coordinated_held_object_updates.items():
-            normalized = (
-                None
-                if candidate is None
-                else _normalize_coordinated_held(
-                    candidate,
-                    batch_size=state.batch_size,
-                    device=state.device,
-                )
-            )
-            merged = _merge_coordinated(coordinated.get(resources), normalized, mask)
-            if merged is None:
-                coordinated.pop(resources, None)
-            else:
-                coordinated[resources] = merged
-
         return TaskState(
             batch_size=state.batch_size,
             device=state.device,
             held_objects=held,
-            coordinated_held_objects=coordinated,
         )
 
 

--- a/embodichain/lab/sim/atomic_actions/engine.py
+++ b/embodichain/lab/sim/atomic_actions/engine.py
@@ -36,49 +36,6 @@ if TYPE_CHECKING:
     from .execution import ExecutionSession
 
 
-_global_extension_registry: dict[str, type[AtomicAction]] = {}
-
-
-def register_action(action_class: type[AtomicAction]) -> None:
-    """Register an extension action type for process-wide discovery.
-
-    This catalog does not bind the type to an engine or automatically load it.
-    Built-in types live in ``BUILTIN_ACTION_TYPES`` and are loaded separately
-    by each :class:`AtomicActionEngine`.
-
-    Args:
-        action_class: Concrete :class:`AtomicAction` subclass.
-
-    Raises:
-        TypeError: If ``action_class`` is not an AtomicAction subclass.
-        ValueError: If another class already owns the same skill identifier.
-    """
-    if not isinstance(action_class, type) or not issubclass(action_class, AtomicAction):
-        raise TypeError("action_class must be an AtomicAction subclass.")
-    descriptor = action_class.descriptor()
-    existing = _global_extension_registry.get(descriptor.skill_id)
-    if existing is not None and existing is not action_class:
-        raise ValueError(
-            f"Skill id {descriptor.skill_id!r} is already registered by "
-            f"{existing.__name__}."
-        )
-    _global_extension_registry[descriptor.skill_id] = action_class
-
-
-def unregister_action(skill_id: str) -> None:
-    """Remove a globally discoverable extension action type if present.
-
-    Args:
-        skill_id: Stable registered skill identifier.
-    """
-    _global_extension_registry.pop(skill_id, None)
-
-
-def get_registered_actions() -> dict[str, type[AtomicAction]]:
-    """Return a copy of the process-wide extension action-type registry."""
-    return dict(_global_extension_registry)
-
-
 class AtomicActionEngine:
     """Own planning resources and coordinate side-effect-free atomic actions."""
 
@@ -169,41 +126,7 @@ class AtomicActionEngine:
         for action_type in BUILTIN_ACTION_TYPES:
             self.register(action_type())
 
-    def plan_action(
-        self,
-        action: AtomicAction,
-        invocation: ActionInvocation,
-        context: PlanningContext,
-    ) -> ActionPlan:
-        """Plan with a configured action using this engine's resources.
-
-        Unlike :meth:`plan`, the supplied action does not need to be in the
-        skill registry. This is an advanced extension and testing escape hatch;
-        built-in parameter variants should use ``ActionInvocation.skill_options``
-        with the engine's registered implementation.
-
-        Args:
-            action: Configured action implementation to invoke.
-            invocation: Grounded request matching the action's skill identifier.
-            context: Latest measured planning state.
-
-        Returns:
-            Validated side-effect-free action plan.
-
-        Raises:
-            TypeError: If ``action`` is not an :class:`AtomicAction`.
-            ValueError: If the action, invocation, context, or plan is invalid.
-        """
-        if not isinstance(action, AtomicAction):
-            raise TypeError("action must be an AtomicAction instance.")
-        self._validate_context(context)
-        action._bind(self._planning_services)
-        request = action.resolve_request(invocation)
-        plan = action.plan(request, context)
-        self._validate_plan(plan, context, request)
-        return plan
-
-    def resolve(
+    def _resolve(
         self,
         invocation: ActionInvocation,
     ) -> ResolvedActionRequest:
@@ -229,7 +152,7 @@ class AtomicActionEngine:
             )
         return action.resolve_request(invocation)
 
-    def plan_request(
+    def _plan_request(
         self,
         request: ResolvedActionRequest,
         context: PlanningContext | None = None,
@@ -241,7 +164,7 @@ class AtomicActionEngine:
         calls this method for every replan.
 
         Args:
-            request: Immutable request previously returned by :meth:`resolve`.
+            request: Immutable request previously returned by :meth:`_resolve`.
             context: Optional latest planning state; captured when omitted.
 
         Returns:
@@ -278,8 +201,8 @@ class AtomicActionEngine:
             KeyError: If the invocation references an unregistered skill.
         """
         current = self.initial_context() if context is None else context
-        request = self.resolve(invocation)
-        return self.plan_request(request, current)
+        request = self._resolve(invocation)
+        return self._plan_request(request, current)
 
     def initial_context(
         self,
@@ -454,9 +377,4 @@ class AtomicActionEngine:
             )
 
 
-__all__ = [
-    "AtomicActionEngine",
-    "get_registered_actions",
-    "register_action",
-    "unregister_action",
-]
+__all__ = ["AtomicActionEngine"]

--- a/embodichain/lab/sim/atomic_actions/execution.py
+++ b/embodichain/lab/sim/atomic_actions/execution.py
@@ -220,7 +220,7 @@ class ExecutionSession:
         engine._validate_context(context)
         self._engine = engine
         self._requests: tuple[ResolvedActionRequest, ...] = tuple(
-            engine.resolve(invocation) for invocation in invocations
+            engine._resolve(invocation) for invocation in invocations
         )
         self._task_state = context.task
         self._context = context
@@ -305,8 +305,8 @@ class ExecutionSession:
                 f"{invocation.revision}."
             )
 
-        replacement = self._engine.resolve(invocation)
-        replacement_plan = self._engine.plan_request(replacement, self._context)
+        replacement = self._engine._resolve(invocation)
+        replacement_plan = self._engine._plan_request(replacement, self._context)
         requests = list(self._requests)
         requests[self._invocation_index] = replacement
         self._requests = tuple(requests)
@@ -470,7 +470,7 @@ class ExecutionSession:
     ) -> None:
         """Plan the current invocation from the latest observation."""
         request = self._requests[self._invocation_index]
-        plan = self._engine.plan_request(request, context)
+        plan = self._engine._plan_request(request, context)
         self._install_plan(plan, context, event_kind)
 
     def _install_plan(

--- a/embodichain/lab/sim/atomic_actions/goals.py
+++ b/embodichain/lab/sim/atomic_actions/goals.py
@@ -20,25 +20,13 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, fields, is_dataclass
-from typing import Any, ClassVar, Protocol, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 
 import torch
 
 if TYPE_CHECKING:
     from .core import ObjectSemantics
     from .state import PlanningContext
-
-
-class ActionGoal(Protocol):
-    """Structural protocol implemented by atomic-action goal value objects.
-
-    Goals are action-owned dataclasses. They do not have to inherit from a
-    marker base class; the owning action declares its concrete ``GoalType``.
-    ``goal_kind`` supplies the stable semantic discriminator needed by skill
-    catalogs and agent-facing schemas.
-    """
-
-    goal_kind: ClassVar[str]
 
 
 @dataclass(frozen=True, slots=True, eq=False)
@@ -97,9 +85,9 @@ def validate_pose_tensor(
         raise TypeError(f"{name} must be a torch.Tensor, got {type(value).__name__}.")
     valid_dims = {2, 3, 4} if allow_waypoints else {2, 3}
     if value.dim() not in valid_dims or value.shape[-2:] != (4, 4):
-        supported = "(4, 4), (n_envs, 4, 4)"
+        supported = "(4, 4), (num_envs, 4, 4)"
         if allow_waypoints:
-            supported += ", or (n_envs, n_waypoint, 4, 4)"
+            supported += ", or (num_envs, n_waypoint, 4, 4)"
         raise ValueError(
             f"{name} must have shape {supported}, got {tuple(value.shape)}."
         )
@@ -191,8 +179,6 @@ def collect_scene_dependencies(value: Any) -> tuple[str, ...]:
 class ObjectActionGoal:
     """Shared semantic-object goal contract for object-centric skills."""
 
-    goal_kind: ClassVar[str] = "semantic_object"
-
     semantics: ObjectSemantics
     """Semantic and geometric description of the object."""
 
@@ -204,7 +190,6 @@ class ObjectActionGoal:
 
 
 __all__ = [
-    "ActionGoal",
     "ObjectActionGoal",
     "PoseGoalValue",
     "SceneEntityPose",

--- a/embodichain/lab/sim/atomic_actions/invocation.py
+++ b/embodichain/lab/sim/atomic_actions/invocation.py
@@ -27,10 +27,9 @@ from embodichain.lab.sim.common import BatchEntity
 
 from .bindings import ActionBinding, ResolvedActionBinding
 from .control import ActionControlOverrides
-from .goals import ActionGoal
 from .policies import MotionPolicy, RecoveryPolicy
 
-GoalT = TypeVar("GoalT", bound=ActionGoal)
+GoalT = TypeVar("GoalT")
 
 
 @dataclass(frozen=True, slots=True, eq=False)
@@ -46,7 +45,7 @@ class ActionOptions:
 OptionsT = TypeVar("OptionsT", bound=ActionOptions)
 
 
-def _goal_snapshot_memo(goal: ActionGoal) -> dict[int, object]:
+def _goal_snapshot_memo(goal: object) -> dict[int, object]:
     """Return deepcopy memo entries for live goal references and runtime caches."""
     memo: dict[int, object] = {}
     visited: set[int] = set()
@@ -121,12 +120,6 @@ class ActionInvocation(Generic[GoalT, OptionsT]):
     def __post_init__(self) -> None:
         if not isinstance(self.skill_id, str) or not self.skill_id.strip():
             raise ValueError("skill_id must be a non-empty string.")
-        goal_kind = getattr(type(self.goal), "goal_kind", None)
-        if not isinstance(goal_kind, str) or not goal_kind:
-            raise TypeError(
-                "goal must implement the ActionGoal protocol with a non-empty "
-                "goal_kind class variable."
-            )
         if not isinstance(self.binding, ActionBinding):
             raise TypeError("binding must be an ActionBinding.")
         if not isinstance(self.motion_policy, MotionPolicy):

--- a/embodichain/lab/sim/atomic_actions/plans.py
+++ b/embodichain/lab/sim/atomic_actions/plans.py
@@ -58,7 +58,6 @@ class TimedTrajectory:
     accelerations: torch.Tensor | None
     dt: torch.Tensor
     """Per-waypoint arrival intervals; the first sample normally has zero dt."""
-    duration: torch.Tensor
     env_ids: torch.Tensor
 
     def __post_init__(self) -> None:
@@ -88,21 +87,6 @@ class TimedTrajectory:
             raise ValueError("dt must share the positions device.")
         if not torch.isfinite(self.dt).all() or (self.dt < 0).any():
             raise ValueError("dt must contain finite non-negative values.")
-        if not isinstance(self.duration, torch.Tensor) or self.duration.shape != (
-            batch_size,
-        ):
-            raise ValueError(f"duration must have shape ({batch_size},).")
-        if self.duration.device != self.positions.device:
-            raise ValueError("duration must share the positions device.")
-        if not torch.isfinite(self.duration).all() or (self.duration < 0).any():
-            raise ValueError("duration must contain finite non-negative values.")
-        if not torch.allclose(
-            self.duration,
-            self.dt.sum(dim=1),
-            rtol=1e-4,
-            atol=1e-6,
-        ):
-            raise ValueError("duration must equal the sum of dt for each environment.")
         if not isinstance(self.env_ids, torch.Tensor):
             raise TypeError("env_ids must be a torch.Tensor.")
         if self.env_ids.dtype != torch.long or self.env_ids.shape != (batch_size,):
@@ -126,6 +110,11 @@ class TimedTrajectory:
         """Number of full-robot command columns."""
         return int(self.positions.shape[2])
 
+    @property
+    def duration(self) -> torch.Tensor:
+        """Per-environment trajectory duration derived from waypoint intervals."""
+        return self.dt.sum(dim=1)
+
     def snapshot(self) -> TimedTrajectory:
         """Return an independently owned copy of this trajectory.
 
@@ -140,7 +129,6 @@ class TimedTrajectory:
                 None if self.accelerations is None else self.accelerations.clone()
             ),
             dt=self.dt.clone(),
-            duration=self.duration.clone(),
             env_ids=self.env_ids.clone(),
         )
 
@@ -213,7 +201,6 @@ class TimedTrajectory:
             velocities=velocities,
             accelerations=accelerations,
             dt=dt,
-            duration=computed_duration,
             env_ids=env_ids,
         )
 
@@ -235,7 +222,6 @@ class TimedTrajectory:
             velocities=None,
             accelerations=None,
             dt=torch.empty((batch_size, 0), dtype=torch.float32, device=resolved),
-            duration=torch.zeros(batch_size, dtype=torch.float32, device=resolved),
             env_ids=env_ids,
         )
 
@@ -280,7 +266,6 @@ class TimedTrajectory:
             velocities=mask_derivative(self.velocities),
             accelerations=mask_derivative(self.accelerations),
             dt=self.dt,
-            duration=self.duration,
             env_ids=self.env_ids,
         )
 
@@ -332,7 +317,6 @@ class TimedTrajectory:
             velocities=concatenate_optional("velocities"),
             accelerations=concatenate_optional("accelerations"),
             dt=dt,
-            duration=dt.sum(dim=1),
             env_ids=first.env_ids,
         )
 

--- a/embodichain/lab/sim/atomic_actions/primitives/_helpers.py
+++ b/embodichain/lab/sim/atomic_actions/primitives/_helpers.py
@@ -18,30 +18,102 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
 import torch
 
-from embodichain.utils import logger
-
 from ..state import PlanningContext
+from ..trajectory_ops import build_pose_plan_states
+
+if TYPE_CHECKING:
+    from embodichain.lab.sim.planners import MotionGenerator
+
+    from ..policies import MotionPolicy
+
+
+def resolve_batched_pose(
+    pose: torch.Tensor,
+    *,
+    num_envs: int,
+    device: torch.device,
+    name: str,
+) -> torch.Tensor:
+    """Copy and broadcast one homogeneous pose to ``(num_envs, 4, 4)``."""
+    pose = pose.to(device=device, dtype=torch.float32).clone()
+    if pose.shape == (4, 4):
+        pose = pose.unsqueeze(0).repeat(num_envs, 1, 1)
+    if pose.shape != (num_envs, 4, 4):
+        raise ValueError(
+            f"{name} must have shape (4, 4) or ({num_envs}, 4, 4), "
+            f"but got {pose.shape}"
+        )
+    return pose
 
 
 def resolve_object_target(
     target: torch.Tensor,
     *,
-    n_envs: int,
+    num_envs: int,
     device: torch.device,
     name: str = "object_target_pose",
 ) -> torch.Tensor:
-    """Broadcast an object target pose to ``(n_envs, 4, 4)`` or validate it."""
-    target = target.to(device=device, dtype=torch.float32).clone()
-    if target.shape == (4, 4):
-        target = target.unsqueeze(0).repeat(n_envs, 1, 1)
-    if target.shape != (n_envs, 4, 4):
-        logger.log_error(
-            f"{name} must be (4, 4) or ({n_envs}, 4, 4), but got {target.shape}",
-            ValueError,
-        )
-    return target
+    """Broadcast an object target pose to ``(num_envs, 4, 4)`` or validate it."""
+    return resolve_batched_pose(
+        target,
+        num_envs=num_envs,
+        device=device,
+        name=name,
+    )
+
+
+def repeat_qpos(qpos: torch.Tensor, n_waypoints: int) -> torch.Tensor:
+    """Repeat batched joint positions along a waypoint dimension."""
+    return qpos.unsqueeze(1).repeat(1, n_waypoints, 1)
+
+
+def assemble_full_robot_trajectory(
+    base_qpos: torch.Tensor,
+    part_trajectories: Sequence[tuple[Sequence[int], torch.Tensor]],
+) -> torch.Tensor:
+    """Overlay control-part trajectories on repeated full-robot positions."""
+    if not part_trajectories:
+        raise ValueError("part_trajectories must not be empty.")
+    n_waypoints = part_trajectories[0][1].shape[1]
+    full = repeat_qpos(
+        base_qpos.to(
+            device=part_trajectories[0][1].device,
+            dtype=torch.float32,
+        ),
+        n_waypoints,
+    ).clone()
+    for joint_ids, trajectory in part_trajectories:
+        full[:, :, list(joint_ids)] = trajectory
+    return full
+
+
+def plan_named_arm_trajectory(
+    motion_generator: MotionGenerator,
+    control_part: str,
+    start_qpos: torch.Tensor,
+    target_poses: torch.Tensor,
+    n_waypoints: int,
+    motion_policy: MotionPolicy,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Plan a fixed-size pose trajectory for one named manipulator."""
+    result = motion_generator.generate(
+        build_pose_plan_states(target_poses),
+        options=motion_policy.to_motion_gen_options(
+            start_qpos=start_qpos,
+            control_part=control_part,
+            sample_count=n_waypoints,
+        ),
+    )
+    if not isinstance(result.success, torch.Tensor):
+        raise TypeError("Motion planning success must be a torch.Tensor.")
+    if result.positions is None:
+        raise ValueError("Motion planning result must contain joint positions.")
+    return result.success, result.positions
 
 
 def arm_qpos_from_state(
@@ -52,4 +124,11 @@ def arm_qpos_from_state(
     return context.robot.qpos[:, arm_joint_ids]
 
 
-__all__ = ["arm_qpos_from_state", "resolve_object_target"]
+__all__ = [
+    "arm_qpos_from_state",
+    "assemble_full_robot_trajectory",
+    "plan_named_arm_trajectory",
+    "repeat_qpos",
+    "resolve_batched_pose",
+    "resolve_object_target",
+]

--- a/embodichain/lab/sim/atomic_actions/primitives/coordinated_pickment.py
+++ b/embodichain/lab/sim/atomic_actions/primitives/coordinated_pickment.py
@@ -39,8 +39,13 @@ from ..goals import (
 )
 from ..invocation import ActionOptions, ResolvedActionRequest
 from ..plans import ActionPlan, normalize_success_mask
-from ..state import CoordinatedHeldObjectState, PlanningContext
+from ..state import HeldObjectState, PlanningContext
 from ..trajectory_ops import interpolate_joint_trajectory, translate_pose_world
+from ._helpers import (
+    assemble_full_robot_trajectory,
+    repeat_qpos,
+    resolve_batched_pose,
+)
 
 
 @dataclass(frozen=True, slots=True, eq=False)
@@ -53,10 +58,8 @@ class CoordinatedPickGoal(ObjectActionGoal):
     :class:`CoordinatedPickmentOptions`.
     """
 
-    goal_kind: ClassVar[str] = "coordinated_pick"
-
     object_target_pose: PoseGoalValue
-    """Target pose for the shared object, shape ``(4, 4)`` or ``(n_envs, 4, 4)``."""
+    """Target pose for the shared object, shape ``(4, 4)`` or ``(num_envs, 4, 4)``."""
 
     object_initial_pose: PoseGoalValue | None = None
     """Optional initial object pose. Defaults to ``semantics.entity`` pose."""
@@ -160,27 +163,21 @@ class _DualArmHelpers:
     def _expand_qpos(self, qpos: torch.Tensor, dof: int, name: str) -> torch.Tensor:
         qpos = qpos.to(device=self.device, dtype=torch.float32)
         if qpos.shape == (dof,):
-            return qpos.unsqueeze(0).repeat(self.n_envs, 1)
-        if qpos.shape == (self.n_envs, dof):
+            return qpos.unsqueeze(0).repeat(self.num_envs, 1)
+        if qpos.shape == (self.num_envs, dof):
             return qpos
-        logger.log_error(
+        raise ValueError(
             f"{name} must have shape ({dof},) or "
-            f"({self.n_envs}, {dof}), but got {qpos.shape}",
-            ValueError,
+            f"({self.num_envs}, {dof}), but got {qpos.shape}"
         )
-        raise AssertionError("unreachable")
 
     def _resolve_pose(self, pose: torch.Tensor, name: str) -> torch.Tensor:
-        pose = pose.to(device=self.device, dtype=torch.float32)
-        if pose.shape == (4, 4):
-            pose = pose.unsqueeze(0).repeat(self.n_envs, 1, 1)
-        if pose.shape != (self.n_envs, 4, 4):
-            logger.log_error(
-                f"{name} must have shape (4, 4) or "
-                f"({self.n_envs}, 4, 4), but got {pose.shape}",
-                ValueError,
-            )
-        return pose
+        return resolve_batched_pose(
+            pose,
+            num_envs=self.num_envs,
+            device=self.device,
+            name=name,
+        )
 
     def _resolve_dual_arm_start(
         self,
@@ -203,22 +200,15 @@ class _DualArmHelpers:
         *,
         resources: _CoordinatedPickResources,
     ) -> torch.Tensor:
-        n_waypoints = first_arm_traj.shape[1]
-        full = torch.empty(
-            (self.n_envs, n_waypoints, self.robot_dof),
-            dtype=torch.float32,
-            device=self.device,
+        return assemble_full_robot_trajectory(
+            state.last_qpos,
+            (
+                (resources.left_arm.joint_ids, first_arm_traj),
+                (resources.right_arm.joint_ids, second_arm_traj),
+                (resources.left_hand.joint_ids, first_hand_traj),
+                (resources.right_hand.joint_ids, second_hand_traj),
+            ),
         )
-        full[:, :, :] = state.last_qpos.to(self.device).unsqueeze(1)
-        full[:, :, list(resources.left_arm.joint_ids)] = first_arm_traj
-        full[:, :, list(resources.right_arm.joint_ids)] = second_arm_traj
-        full[:, :, list(resources.left_hand.joint_ids)] = first_hand_traj
-        full[:, :, list(resources.right_hand.joint_ids)] = second_hand_traj
-        return full
-
-    @staticmethod
-    def _repeat_qpos(qpos: torch.Tensor, n_waypoints: int) -> torch.Tensor:
-        return qpos.unsqueeze(1).repeat(1, n_waypoints, 1)
 
     def _interpolate_qpos(
         self,
@@ -264,7 +254,7 @@ class _DualArmHelpers:
         n_waypoints: int,
     ) -> torch.Tensor:
         trajectory = torch.zeros(
-            (self.n_envs, n_waypoints, keyframe_qpos.shape[-1]),
+            (self.num_envs, n_waypoints, keyframe_qpos.shape[-1]),
             dtype=torch.float32,
             device=self.device,
         )
@@ -322,7 +312,7 @@ class _DualArmHelpers:
         )
         quat = quat / torch.linalg.norm(quat, dim=-1, keepdim=True).clamp_min(1e-8)
         poses[:, :, :3, :3] = matrix_from_quat(quat.reshape(-1, 4)).reshape(
-            self.n_envs, n_waypoints, 3, 3
+            self.num_envs, n_waypoints, 3, 3
         )
         return poses
 
@@ -344,20 +334,9 @@ class CoordinatedPickment(
     _interpolate_object_pose = _DualArmHelpers._interpolate_object_pose
     _interpolate_qpos = _DualArmHelpers._interpolate_qpos
     _interpolate_qpos_keyframes = _DualArmHelpers._interpolate_qpos_keyframes
-    _repeat_qpos = staticmethod(_DualArmHelpers._repeat_qpos)
+    _repeat_qpos = staticmethod(repeat_qpos)
     _resolve_dual_arm_start = _DualArmHelpers._resolve_dual_arm_start
     _resolve_pose = _DualArmHelpers._resolve_pose
-
-    def __init__(
-        self,
-        default_options: CoordinatedPickmentOptions | None = None,
-    ) -> None:
-        super().__init__(default_options)
-
-    def _on_bind(self) -> None:
-        """Resolve engine-wide resources from the owning engine."""
-        self.n_envs = self.robot.get_qpos().shape[0]
-        self.robot_dof = self.robot.dof
 
     def _resolve_resources(
         self,
@@ -386,25 +365,25 @@ class CoordinatedPickment(
             right_hand=right_hand,
             left_hand_open_qpos=left_hand.joint_positions(
                 OPEN_COMMAND,
-                n_envs=self.n_envs,
+                num_envs=self.num_envs,
                 device=self.device,
                 dtype=torch.float32,
             ),
             left_hand_close_qpos=left_hand.joint_positions(
                 GRASP_COMMAND,
-                n_envs=self.n_envs,
+                num_envs=self.num_envs,
                 device=self.device,
                 dtype=torch.float32,
             ),
             right_hand_open_qpos=right_hand.joint_positions(
                 OPEN_COMMAND,
-                n_envs=self.n_envs,
+                num_envs=self.num_envs,
                 device=self.device,
                 dtype=torch.float32,
             ),
             right_hand_close_qpos=right_hand.joint_positions(
                 GRASP_COMMAND,
-                n_envs=self.n_envs,
+                num_envs=self.num_envs,
                 device=self.device,
                 dtype=torch.float32,
             ),
@@ -425,10 +404,9 @@ class CoordinatedPickment(
                 "object_initial_pose",
             )
         if target.semantics.entity is None:
-            logger.log_error(
+            raise ValueError(
                 "CoordinatedPickGoal requires object_initial_pose when "
-                "semantics.entity is not provided.",
-                ValueError,
+                "semantics.entity is not provided."
             )
         return self._resolve_pose(
             target.semantics.entity.get_local_pose(to_matrix=True),
@@ -447,7 +425,7 @@ class CoordinatedPickment(
         torch.Tensor,
         torch.Tensor,
         torch.Tensor,
-        CoordinatedHeldObjectState,
+        tuple[HeldObjectState, HeldObjectState],
         torch.Tensor,
     ]:
         object_initial_pose = self._resolve_object_initial_pose(target, context)
@@ -468,12 +446,17 @@ class CoordinatedPickment(
         right_object_to_eef = torch.bmm(pose_inv(object_initial_pose), right_grasp_xpos)
         left_target_xpos = torch.bmm(object_target_pose, left_object_to_eef)
         right_target_xpos = torch.bmm(object_target_pose, right_object_to_eef)
-        held_state = CoordinatedHeldObjectState(
-            semantics=target.semantics,
-            left_object_to_eef=left_object_to_eef,
-            right_object_to_eef=right_object_to_eef,
-            left_grasp_xpos=left_grasp_xpos,
-            right_grasp_xpos=right_grasp_xpos,
+        held_states = (
+            HeldObjectState(
+                semantics=target.semantics,
+                object_to_eef=left_object_to_eef,
+                grasp_xpos=left_grasp_xpos,
+            ),
+            HeldObjectState(
+                semantics=target.semantics,
+                object_to_eef=right_object_to_eef,
+                grasp_xpos=right_grasp_xpos,
+            ),
         )
         return (
             object_initial_pose,
@@ -482,7 +465,7 @@ class CoordinatedPickment(
             right_grasp_xpos,
             left_target_xpos,
             right_target_xpos,
-            held_state,
+            held_states,
             grasp_success,
         )
 
@@ -496,27 +479,26 @@ class CoordinatedPickment(
 
         Args:
             semantics: Object semantics carrying an :class:`AntipodalAffordance`.
-            object_poses: Object poses with shape ``(n_envs, 4, 4)``.
+            object_poses: Object poses with shape ``(num_envs, 4, 4)``.
             options: Coordinated pickment options carrying the dual-arm and
                 approach directions used by the affordance sampler.
 
         Returns:
             ``(left_grasp_xpos, right_grasp_xpos, success_mask)``. The grasp poses
-            have shape ``(n_envs, 4, 4)`` and the success mask has shape
-            ``(n_envs,)``. Environments without a valid left or right grasp hold
+            have shape ``(num_envs, 4, 4)`` and the success mask has shape
+            ``(num_envs,)``. Environments without a valid left or right grasp hold
             the identity pose and are marked ``False``.
         """
         if not isinstance(semantics.affordance, AntipodalAffordance):
-            logger.log_error(
+            raise ValueError(
                 "CoordinatedPickment requires an AntipodalAffordance to sample "
-                "dual-arm grasps.",
-                ValueError,
+                "dual-arm grasps."
             )
-        n_envs = object_poses.shape[0]
+        num_envs = object_poses.shape[0]
         identity = torch.eye(4, dtype=torch.float32, device=self.device)
-        left_grasp_xpos = identity.unsqueeze(0).repeat(n_envs, 1, 1)
-        right_grasp_xpos = identity.unsqueeze(0).repeat(n_envs, 1, 1)
-        success_mask = torch.zeros(n_envs, dtype=torch.bool, device=self.device)
+        left_grasp_xpos = identity.unsqueeze(0).repeat(num_envs, 1, 1)
+        right_grasp_xpos = identity.unsqueeze(0).repeat(num_envs, 1, 1)
+        success_mask = torch.zeros(num_envs, dtype=torch.bool, device=self.device)
         approach_direction = options.approach_direction.to(
             device=self.device, dtype=torch.float32
         )
@@ -593,10 +575,9 @@ class CoordinatedPickment(
         n_lift = n_motion // 3
         n_move = n_motion - n_approach - n_lift
         if min(n_approach, n_lift, n_move) < 2:
-            logger.log_error(
+            raise ValueError(
                 "Not enough waypoints for coordinated pickment. Please increase "
-                "sample_count or decrease hand_interp_steps/hold_steps.",
-                ValueError,
+                "sample_count or decrease hand_interp_steps/hold_steps."
             )
         return {
             "approach": n_approach,
@@ -650,7 +631,7 @@ class CoordinatedPickment(
     ) -> tuple[torch.Tensor, torch.Tensor]:
         n_state = target_poses.shape[1]
         keyframe_qpos = torch.zeros(
-            (self.n_envs, n_state, start_qpos.shape[-1]),
+            (self.num_envs, n_state, start_qpos.shape[-1]),
             dtype=torch.float32,
             device=self.device,
         )
@@ -664,7 +645,7 @@ class CoordinatedPickment(
             )
             ik_success = normalize_success_mask(
                 ik_success,
-                n_envs=self.n_envs,
+                num_envs=self.num_envs,
                 device=self.device,
                 name=f"IK success for {control_part} target state {target_idx}",
             )
@@ -701,12 +682,12 @@ class CoordinatedPickment(
         n_waypoints = object_pose_traj.shape[1]
         keyframe_indices = self._select_motion_keyframe_indices(n_waypoints, options)
         left_traj = torch.zeros(
-            (self.n_envs, len(keyframe_indices), left_start_qpos.shape[-1]),
+            (self.num_envs, len(keyframe_indices), left_start_qpos.shape[-1]),
             dtype=torch.float32,
             device=self.device,
         )
         right_traj = torch.zeros(
-            (self.n_envs, len(keyframe_indices), right_start_qpos.shape[-1]),
+            (self.num_envs, len(keyframe_indices), right_start_qpos.shape[-1]),
             dtype=torch.float32,
             device=self.device,
         )
@@ -730,7 +711,7 @@ class CoordinatedPickment(
             )
             left_success = normalize_success_mask(
                 left_success,
-                n_envs=self.n_envs,
+                num_envs=self.num_envs,
                 device=self.device,
                 name=(
                     f"IK success for {resources.left_arm.name} object waypoint "
@@ -739,7 +720,7 @@ class CoordinatedPickment(
             )
             right_success = normalize_success_mask(
                 right_success,
-                n_envs=self.n_envs,
+                num_envs=self.num_envs,
                 device=self.device,
                 name=(
                     f"IK success for {resources.right_arm.name} object waypoint "
@@ -784,7 +765,7 @@ class CoordinatedPickment(
         context: PlanningContext,
     ) -> ActionPlan:
         """Plan a coordinated pick without committing the dual attachment."""
-        target = self.require_goal(request)
+        target = request.goal
         options = request.skill_options
         resources = self._resolve_resources(request)
         if (
@@ -802,9 +783,10 @@ class CoordinatedPickment(
             right_grasp_xpos,
             left_target_xpos,
             right_target_xpos,
-            held_state,
+            held_states,
             grasp_success,
         ) = self._resolve_target(target, context, options)
+        left_held_state, right_held_state = held_states
         if not grasp_success.any():
             logger.log_warning("CoordinatedPickment failed to resolve dual-arm grasps.")
             return self.failed_plan(
@@ -885,8 +867,8 @@ class CoordinatedPickment(
                 left_grasp_qpos,
                 right_grasp_qpos,
                 lift_object_traj,
-                held_state.left_object_to_eef,
-                held_state.right_object_to_eef,
+                left_held_state.object_to_eef,
+                right_held_state.object_to_eef,
                 success_mask,
                 resources,
                 options,
@@ -915,8 +897,8 @@ class CoordinatedPickment(
                 left_lift_qpos,
                 right_lift_qpos,
                 move_object_traj,
-                held_state.left_object_to_eef,
-                held_state.right_object_to_eef,
+                left_held_state.object_to_eef,
+                right_held_state.object_to_eef,
                 success_mask,
                 resources,
                 options,
@@ -935,7 +917,9 @@ class CoordinatedPickment(
         )
 
         hold_trajectory = torch.empty(
-            (self.n_envs, 0, self.robot_dof), dtype=torch.float32, device=self.device
+            (self.num_envs, 0, self.robot_dof),
+            dtype=torch.float32,
+            device=self.device,
         )
         if segments["hold"] > 0:
             hold_trajectory = self._assemble_segment(
@@ -957,12 +941,15 @@ class CoordinatedPickment(
             ],
             dim=1,
         )
-        coordinated_held_object = CoordinatedHeldObjectState(
-            semantics=held_state.semantics,
-            left_object_to_eef=held_state.left_object_to_eef,
-            right_object_to_eef=held_state.right_object_to_eef,
-            left_grasp_xpos=left_target_xpos,
-            right_grasp_xpos=right_target_xpos,
+        left_held_object = HeldObjectState(
+            semantics=left_held_state.semantics,
+            object_to_eef=left_held_state.object_to_eef,
+            grasp_xpos=left_target_xpos,
+        )
+        right_held_object = HeldObjectState(
+            semantics=right_held_state.semantics,
+            object_to_eef=right_held_state.object_to_eef,
+            grasp_xpos=right_target_xpos,
         )
         return self.build_plan(
             request,
@@ -971,14 +958,8 @@ class CoordinatedPickment(
             trajectory=full,
             expected_effects=StateDelta(
                 held_object_updates={
-                    resources.left_arm.name: None,
-                    resources.right_arm.name: None,
-                },
-                coordinated_held_object_updates={
-                    (
-                        resources.left_arm.name,
-                        resources.right_arm.name,
-                    ): coordinated_held_object,
+                    resources.left_arm.name: left_held_object,
+                    resources.right_arm.name: right_held_object,
                 },
             ),
             segment_lengths={

--- a/embodichain/lab/sim/atomic_actions/primitives/coordinated_placement.py
+++ b/embodichain/lab/sim/atomic_actions/primitives/coordinated_placement.py
@@ -209,6 +209,18 @@ class CoordinatedPlacement(
             placing_held_object,
             support_held_object,
         ) = self._resolve_target(target, state, resources, options)
+        eligible = context.task.exclusive_held_object_mask(
+            resources.placing_arm.name
+        ) & context.task.exclusive_held_object_mask(resources.support_arm.name)
+        if not eligible.any():
+            logger.log_warning(
+                "CoordinatedPlacement requires two exclusively held objects."
+            )
+            return self.failed_plan(
+                request,
+                context,
+                message="Placing and support objects must be held exclusively.",
+            )
         placing_start_qpos, support_start_qpos = self._resolve_start_qpos(
             state, resources
         )
@@ -225,11 +237,7 @@ class CoordinatedPlacement(
             ),
         )
 
-        success_mask = torch.ones(
-            self.num_envs,
-            dtype=torch.bool,
-            device=self.device,
-        )
+        success_mask = eligible.clone()
         segment_success, placing_approach_traj = plan_named_arm_trajectory(
             self.motion_generator,
             resources.placing_arm.name,

--- a/embodichain/lab/sim/atomic_actions/primitives/coordinated_placement.py
+++ b/embodichain/lab/sim/atomic_actions/primitives/coordinated_placement.py
@@ -25,7 +25,6 @@ import torch
 
 from embodichain.utils import logger
 
-from ._helpers import resolve_object_target
 from ..bindings import ResolvedControlPart
 from ..control import GRASP_COMMAND, OPEN_COMMAND
 from ..core import AtomicAction
@@ -33,20 +32,23 @@ from ..effects import StateDelta
 from ..goals import PoseGoalValue, resolve_pose_goal, validate_pose_goal
 from ..invocation import ActionOptions, ResolvedActionRequest
 from ..plans import ActionPlan, normalize_success_mask
-from ..policies import MotionPolicy
 from ..state import HeldObjectState, PlanningContext
 from ..trajectory_ops import (
-    build_pose_plan_states,
     interpolate_hand_qpos,
     translate_pose_world,
+)
+from ._helpers import (
+    assemble_full_robot_trajectory,
+    plan_named_arm_trajectory,
+    repeat_qpos,
+    resolve_batched_pose,
+    resolve_object_target,
 )
 
 
 @dataclass(frozen=True, slots=True, eq=False)
 class CoordinatedPlacementGoal:
     """Object-centric target for dual-arm coordinated placement."""
-
-    goal_kind: ClassVar[str] = "coordinated_placement"
 
     placing_object_target_pose: PoseGoalValue
     """Target pose for the object released by the placing arm."""
@@ -132,17 +134,7 @@ class CoordinatedPlacement(
     OptionsType: ClassVar[type] = CoordinatedPlacementOptions
     manipulator_roles: ClassVar[tuple[str, ...]] = ("placing", "support")
     end_effector_roles: ClassVar[tuple[str, ...]] = ("placing", "support")
-
-    def __init__(
-        self,
-        default_options: CoordinatedPlacementOptions | None = None,
-    ) -> None:
-        super().__init__(default_options)
-
-    def _on_bind(self) -> None:
-        """Resolve engine-wide resources from the owning engine."""
-        self.n_envs = self.robot.get_qpos().shape[0]
-        self.robot_dof = self.robot.dof
+    _repeat_qpos = staticmethod(repeat_qpos)
 
     def _resolve_resources(
         self,
@@ -173,19 +165,19 @@ class CoordinatedPlacement(
             support_hand=support_hand,
             placing_hand_open_qpos=placing_hand.joint_positions(
                 OPEN_COMMAND,
-                n_envs=self.n_envs,
+                num_envs=self.num_envs,
                 device=self.device,
                 dtype=torch.float32,
             ),
             placing_hand_close_qpos=placing_hand.joint_positions(
                 GRASP_COMMAND,
-                n_envs=self.n_envs,
+                num_envs=self.num_envs,
                 device=self.device,
                 dtype=torch.float32,
             ),
             support_hand_close_qpos=support_hand.joint_positions(
                 GRASP_COMMAND,
-                n_envs=self.n_envs,
+                num_envs=self.num_envs,
                 device=self.device,
                 dtype=torch.float32,
             ),
@@ -199,7 +191,7 @@ class CoordinatedPlacement(
         context: PlanningContext,
     ) -> ActionPlan:
         """Plan coordinated placement without committing attachment changes."""
-        target = self.require_goal(request)
+        target = request.goal
         options = request.skill_options
         resources = self._resolve_resources(request)
         if (
@@ -234,11 +226,12 @@ class CoordinatedPlacement(
         )
 
         success_mask = torch.ones(
-            self.n_envs,
+            self.num_envs,
             dtype=torch.bool,
             device=self.device,
         )
-        segment_success, placing_approach_traj = self._plan_named_arm_trajectory(
+        segment_success, placing_approach_traj = plan_named_arm_trajectory(
+            self.motion_generator,
             resources.placing_arm.name,
             placing_start_qpos,
             torch.stack([placing_lift_xpos, placing_xpos], dim=1),
@@ -247,7 +240,7 @@ class CoordinatedPlacement(
         )
         success_mask &= normalize_success_mask(
             segment_success,
-            n_envs=self.n_envs,
+            num_envs=self.num_envs,
             device=self.device,
             name="Placing-approach success",
         )
@@ -257,7 +250,8 @@ class CoordinatedPlacement(
                 request, context, message="Placing approach failed."
             )
 
-        segment_success, support_approach_traj = self._plan_named_arm_trajectory(
+        segment_success, support_approach_traj = plan_named_arm_trajectory(
+            self.motion_generator,
             resources.support_arm.name,
             support_start_qpos,
             support_xpos.unsqueeze(1),
@@ -266,7 +260,7 @@ class CoordinatedPlacement(
         )
         success_mask &= normalize_success_mask(
             segment_success,
-            n_envs=self.n_envs,
+            num_envs=self.num_envs,
             device=self.device,
             name="Support-approach success",
         )
@@ -315,7 +309,8 @@ class CoordinatedPlacement(
                 resources=resources,
             )
 
-        segment_success, placing_retreat_traj = self._plan_named_arm_trajectory(
+        segment_success, placing_retreat_traj = plan_named_arm_trajectory(
+            self.motion_generator,
             resources.placing_arm.name,
             placing_place_qpos,
             placing_lift_xpos.unsqueeze(1),
@@ -324,7 +319,7 @@ class CoordinatedPlacement(
         )
         success_mask &= normalize_success_mask(
             segment_success,
-            n_envs=self.n_envs,
+            num_envs=self.num_envs,
             device=self.device,
             name="Placing-retreat success",
         )
@@ -355,15 +350,6 @@ class CoordinatedPlacement(
             ],
             dim=1,
         )
-        involved_control_parts = {
-            resources.placing_arm.name,
-            resources.support_arm.name,
-        }
-        coordinated_removals = {
-            key: None
-            for key in state.coordinated_held_objects
-            if not involved_control_parts.isdisjoint(key)
-        }
         return self.build_plan(
             request,
             context,
@@ -376,7 +362,6 @@ class CoordinatedPlacement(
                     ),
                     resources.support_arm.name: support_held_object,
                 },
-                coordinated_held_object_updates=coordinated_removals,
             ),
             segment_lengths={
                 "approach": approach_trajectory.shape[1],
@@ -395,7 +380,7 @@ class CoordinatedPlacement(
     ) -> torch.Tensor:
         object_pose = resolve_object_target(
             resolve_pose_goal(pose, context, name=name),
-            n_envs=self.n_envs,
+            num_envs=self.num_envs,
             device=self.device,
             name=name,
         )
@@ -419,16 +404,12 @@ class CoordinatedPlacement(
         )
 
     def _resolve_held_matrix(self, matrix: torch.Tensor, name: str) -> torch.Tensor:
-        matrix = matrix.to(device=self.device, dtype=torch.float32)
-        if matrix.shape == (4, 4):
-            matrix = matrix.unsqueeze(0).repeat(self.n_envs, 1, 1)
-        if matrix.shape != (self.n_envs, 4, 4):
-            logger.log_error(
-                f"{name} must have shape (4, 4) or ({self.n_envs}, 4, 4), "
-                f"but got {matrix.shape}",
-                ValueError,
-            )
-        return matrix
+        return resolve_batched_pose(
+            matrix,
+            num_envs=self.num_envs,
+            device=self.device,
+            name=name,
+        )
 
     def _resolve_held_state(
         self,
@@ -462,17 +443,15 @@ class CoordinatedPlacement(
         support_control_part = resources.support_arm.name
         placing_held_object = state.get_held_object(placing_control_part)
         if placing_held_object is None:
-            logger.log_error(
+            raise ValueError(
                 "CoordinatedPlacement requires an object held by placing control "
-                f"part {placing_control_part!r}.",
-                ValueError,
+                f"part {placing_control_part!r}."
             )
         support_held_object = state.get_held_object(support_control_part)
         if support_held_object is None:
-            logger.log_error(
+            raise ValueError(
                 "CoordinatedPlacement requires an object held by support control "
-                f"part {support_control_part!r}.",
-                ValueError,
+                f"part {support_control_part!r}."
             )
         placing_height_offset = (
             options.placing_height_offset
@@ -528,12 +507,11 @@ class CoordinatedPlacement(
         state: PlanningContext,
         resources: _CoordinatedPlacementResources,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        if state.last_qpos.shape != (self.n_envs, self.robot_dof):
-            logger.log_error(
+        if state.last_qpos.shape != (self.num_envs, self.robot_dof):
+            raise ValueError(
                 "PlanningContext.last_qpos must have shape "
-                f"({self.n_envs}, {self.robot_dof}), "
-                f"but got {state.last_qpos.shape}",
-                ValueError,
+                f"({self.num_envs}, {self.robot_dof}), "
+                f"but got {state.last_qpos.shape}"
             )
         start_qpos = state.last_qpos.to(device=self.device, dtype=torch.float32)
         return (
@@ -553,10 +531,9 @@ class CoordinatedPlacement(
         n_retreat = max(2, options.retreat_steps)
         n_approach = sample_count - n_hold - n_release - n_retreat
         if n_approach < 2:
-            logger.log_error(
+            raise ValueError(
                 "Not enough waypoints for coordinated placement. Increase "
-                "sample_count or decrease hold/release/retreat steps.",
-                ValueError,
+                "sample_count or decrease hold/release/retreat steps."
             )
         return {
             "approach": n_approach,
@@ -565,33 +542,9 @@ class CoordinatedPlacement(
             "retreat": n_retreat,
         }
 
-    def _plan_named_arm_trajectory(
-        self,
-        control_part: str,
-        start_qpos: torch.Tensor,
-        target_poses: torch.Tensor,
-        n_waypoints: int,
-        motion_policy: MotionPolicy,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        result = self.motion_generator.generate(
-            build_pose_plan_states(target_poses),
-            options=motion_policy.to_motion_gen_options(
-                start_qpos=start_qpos,
-                control_part=control_part,
-                sample_count=n_waypoints,
-            ),
-        )
-        assert isinstance(result.success, torch.Tensor)
-        assert result.positions is not None
-        return result.success, result.positions
-
-    @staticmethod
-    def _repeat_qpos(qpos: torch.Tensor, n_waypoints: int) -> torch.Tensor:
-        return qpos.unsqueeze(1).repeat(1, n_waypoints, 1)
-
     def _empty_segment(self) -> torch.Tensor:
         return torch.empty(
-            (self.n_envs, 0, self.robot_dof),
+            (self.num_envs, 0, self.robot_dof),
             dtype=torch.float32,
             device=self.device,
         )
@@ -606,14 +559,15 @@ class CoordinatedPlacement(
         *,
         resources: _CoordinatedPlacementResources,
     ) -> torch.Tensor:
-        n_waypoints = placing_arm_traj.shape[1]
-        full = base_full_qpos.to(device=self.device, dtype=torch.float32)
-        full = full.unsqueeze(1).repeat(1, n_waypoints, 1).clone()
-        full[:, :, list(resources.placing_arm.joint_ids)] = placing_arm_traj
-        full[:, :, list(resources.support_arm.joint_ids)] = support_arm_traj
-        full[:, :, list(resources.placing_hand.joint_ids)] = placing_hand_traj
-        full[:, :, list(resources.support_hand.joint_ids)] = support_hand_traj
-        return full
+        return assemble_full_robot_trajectory(
+            base_full_qpos,
+            (
+                (resources.placing_arm.joint_ids, placing_arm_traj),
+                (resources.support_arm.joint_ids, support_arm_traj),
+                (resources.placing_hand.joint_ids, placing_hand_traj),
+                (resources.support_hand.joint_ids, support_hand_traj),
+            ),
+        )
 
 
 __all__ = [

--- a/embodichain/lab/sim/atomic_actions/primitives/hand_over.py
+++ b/embodichain/lab/sim/atomic_actions/primitives/hand_over.py
@@ -32,12 +32,16 @@ from ..core import AtomicAction, ObjectSemantics
 from ..effects import StateDelta
 from ..invocation import ActionOptions, ResolvedActionRequest
 from ..plans import ActionPlan, normalize_success_mask
-from ..policies import MotionPolicy
 from ..state import HeldObjectState, PlanningContext
 from ..trajectory_ops import (
-    build_pose_plan_states,
     interpolate_hand_qpos,
     translate_pose_world,
+)
+from ._helpers import (
+    assemble_full_robot_trajectory,
+    plan_named_arm_trajectory,
+    repeat_qpos,
+    resolve_batched_pose,
 )
 from .pick_up import GraspGoal
 
@@ -52,11 +56,11 @@ class HandOverOptions(ActionOptions):
 
     middle_object_pose: torch.Tensor | None = None
     """Object pose at the handover point where the receiving arm grasps it,
-    shape ``(4, 4)`` or ``(n_envs, 4, 4)``. Must be set by the caller."""
+    shape ``(4, 4)`` or ``(num_envs, 4, 4)``. Must be set by the caller."""
 
     final_object_pose: torch.Tensor | None = None
     """Object pose the receiving arm delivers the object to, shape ``(4, 4)``
-    or ``(n_envs, 4, 4)``. Must be set by the caller."""
+    or ``(num_envs, 4, 4)``. Must be set by the caller."""
 
     receive_approach_direction: torch.Tensor = torch.tensor(
         [0.0, 0.0, -1.0], dtype=torch.float32
@@ -137,17 +141,7 @@ class HandOver(AtomicAction[GraspGoal, HandOverOptions]):
     OptionsType: ClassVar[type] = HandOverOptions
     manipulator_roles: ClassVar[tuple[str, ...]] = ("source", "destination")
     end_effector_roles: ClassVar[tuple[str, ...]] = ("source", "destination")
-
-    def __init__(
-        self,
-        default_options: HandOverOptions | None = None,
-    ) -> None:
-        super().__init__(default_options)
-
-    def _on_bind(self) -> None:
-        """Resolve engine-wide resources from the owning engine."""
-        self.n_envs = self.robot.get_qpos().shape[0]
-        self.robot_dof = self.robot.dof
+    _repeat_qpos = staticmethod(repeat_qpos)
 
     def _resolve_resources(
         self,
@@ -176,25 +170,25 @@ class HandOver(AtomicAction[GraspGoal, HandOverOptions]):
             receive_hand=receive_hand,
             transfer_hand_open_qpos=transfer_hand.joint_positions(
                 OPEN_COMMAND,
-                n_envs=self.n_envs,
+                num_envs=self.num_envs,
                 device=self.device,
                 dtype=torch.float32,
             ),
             transfer_hand_close_qpos=transfer_hand.joint_positions(
                 GRASP_COMMAND,
-                n_envs=self.n_envs,
+                num_envs=self.num_envs,
                 device=self.device,
                 dtype=torch.float32,
             ),
             receive_hand_open_qpos=receive_hand.joint_positions(
                 OPEN_COMMAND,
-                n_envs=self.n_envs,
+                num_envs=self.num_envs,
                 device=self.device,
                 dtype=torch.float32,
             ),
             receive_hand_close_qpos=receive_hand.joint_positions(
                 GRASP_COMMAND,
-                n_envs=self.n_envs,
+                num_envs=self.num_envs,
                 device=self.device,
                 dtype=torch.float32,
             ),
@@ -210,7 +204,7 @@ class HandOver(AtomicAction[GraspGoal, HandOverOptions]):
         context: PlanningContext,
     ) -> ActionPlan:
         """Plan a handover without committing the attachment transfer."""
-        target = self.require_goal(request)
+        target = request.goal
         options = request.skill_options
         self._validate_pose_options(options)
         resources = self._resolve_resources(request)
@@ -258,7 +252,7 @@ class HandOver(AtomicAction[GraspGoal, HandOverOptions]):
         )
         success_mask = normalize_success_mask(
             grasp_success,
-            n_envs=self.n_envs,
+            num_envs=self.num_envs,
             device=self.device,
             name="Receiving-grasp success",
         )
@@ -292,7 +286,8 @@ class HandOver(AtomicAction[GraspGoal, HandOverOptions]):
             request.motion_policy.sample_count, options
         )
 
-        segment_success, transfer_move_traj = self._plan_named_arm_trajectory(
+        segment_success, transfer_move_traj = plan_named_arm_trajectory(
+            self.motion_generator,
             resources.transfer_arm.name,
             transfer_start_qpos,
             transfer_middle_eef.unsqueeze(1),
@@ -301,7 +296,7 @@ class HandOver(AtomicAction[GraspGoal, HandOverOptions]):
         )
         success_mask &= normalize_success_mask(
             segment_success,
-            n_envs=self.n_envs,
+            num_envs=self.num_envs,
             device=self.device,
             name="Transfer-move success",
         )
@@ -309,7 +304,8 @@ class HandOver(AtomicAction[GraspGoal, HandOverOptions]):
             logger.log_warning("HandOver failed to plan the transfer move.")
             return self.failed_plan(request, context, message="Transfer move failed.")
 
-        segment_success, receive_approach_traj = self._plan_named_arm_trajectory(
+        segment_success, receive_approach_traj = plan_named_arm_trajectory(
+            self.motion_generator,
             resources.receive_arm.name,
             receive_start_qpos,
             torch.stack([receive_pre_grasp_eef, receive_grasp_xpos], dim=1),
@@ -318,7 +314,7 @@ class HandOver(AtomicAction[GraspGoal, HandOverOptions]):
         )
         success_mask &= normalize_success_mask(
             segment_success,
-            n_envs=self.n_envs,
+            num_envs=self.num_envs,
             device=self.device,
             name="Receiving-approach success",
         )
@@ -331,7 +327,8 @@ class HandOver(AtomicAction[GraspGoal, HandOverOptions]):
         transfer_hold_qpos = transfer_move_traj[:, -1]
         receive_grasp_qpos = receive_approach_traj[:, -1]
 
-        segment_success, transfer_retreat_traj = self._plan_named_arm_trajectory(
+        segment_success, transfer_retreat_traj = plan_named_arm_trajectory(
+            self.motion_generator,
             resources.transfer_arm.name,
             transfer_hold_qpos,
             transfer_retreat_eef.unsqueeze(1),
@@ -340,7 +337,7 @@ class HandOver(AtomicAction[GraspGoal, HandOverOptions]):
         )
         success_mask &= normalize_success_mask(
             segment_success,
-            n_envs=self.n_envs,
+            num_envs=self.num_envs,
             device=self.device,
             name="Transfer-retreat success",
         )
@@ -350,7 +347,8 @@ class HandOver(AtomicAction[GraspGoal, HandOverOptions]):
                 request, context, message="Transfer retreat failed."
             )
 
-        segment_success, receive_deliver_traj = self._plan_named_arm_trajectory(
+        segment_success, receive_deliver_traj = plan_named_arm_trajectory(
+            self.motion_generator,
             resources.receive_arm.name,
             receive_grasp_qpos,
             receive_final_eef.unsqueeze(1),
@@ -359,7 +357,7 @@ class HandOver(AtomicAction[GraspGoal, HandOverOptions]):
         )
         success_mask &= normalize_success_mask(
             segment_success,
-            n_envs=self.n_envs,
+            num_envs=self.num_envs,
             device=self.device,
             name="Receiving-delivery success",
         )
@@ -502,21 +500,15 @@ class HandOver(AtomicAction[GraspGoal, HandOverOptions]):
     def _validate_pose_options(options: HandOverOptions) -> None:
         for name in ("middle_object_pose", "final_object_pose"):
             if getattr(options, name) is None:
-                logger.log_error(
-                    f"{name} must be specified in HandOverOptions", ValueError
-                )
+                raise ValueError(f"{name} must be specified in HandOverOptions")
 
     def _resolve_matrix(self, matrix: torch.Tensor, name: str) -> torch.Tensor:
-        matrix = matrix.to(device=self.device, dtype=torch.float32)
-        if matrix.shape == (4, 4):
-            matrix = matrix.unsqueeze(0).repeat(self.n_envs, 1, 1)
-        if matrix.shape != (self.n_envs, 4, 4):
-            logger.log_error(
-                f"{name} must have shape (4, 4) or ({self.n_envs}, 4, 4), "
-                f"but got {matrix.shape}",
-                ValueError,
-            )
-        return matrix
+        return resolve_batched_pose(
+            matrix,
+            num_envs=self.num_envs,
+            device=self.device,
+            name=name,
+        )
 
     def _resolve_transfer_object_to_eef(
         self,
@@ -525,10 +517,9 @@ class HandOver(AtomicAction[GraspGoal, HandOverOptions]):
     ) -> torch.Tensor:
         held = state.get_held_object(transfer_control_part)
         if held is None:
-            logger.log_error(
+            raise ValueError(
                 "HandOver requires an object held by transfer control part "
-                f"{transfer_control_part!r} (run PickUp first).",
-                ValueError,
+                f"{transfer_control_part!r} (run PickUp first)."
             )
         return self._resolve_matrix(held.object_to_eef, "held_object.object_to_eef")
 
@@ -545,14 +536,14 @@ class HandOver(AtomicAction[GraspGoal, HandOverOptions]):
             approach_direction=approach_direction,
             object_part=object_part,
         )
-        n_envs = object_pose.shape[0]
+        num_envs = object_pose.shape[0]
         grasp_xpos = (
             torch.eye(4, device=self.device, dtype=torch.float32)
             .unsqueeze(0)
-            .repeat(n_envs, 1, 1)
+            .repeat(num_envs, 1, 1)
         )
-        is_success = torch.ones(n_envs, dtype=torch.bool, device=self.device)
-        for i in range(n_envs):
+        is_success = torch.ones(num_envs, dtype=torch.bool, device=self.device)
+        for i in range(num_envs):
             poses, costs = grasp_poses_result[i]
             poses = poses.to(device=self.device, dtype=torch.float32)
             costs = costs.to(device=self.device, dtype=torch.float32)
@@ -570,11 +561,11 @@ class HandOver(AtomicAction[GraspGoal, HandOverOptions]):
         state: PlanningContext,
         resources: _HandOverResources,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        if state.last_qpos.shape != (self.n_envs, self.robot_dof):
-            logger.log_error(
+        if state.last_qpos.shape != (self.num_envs, self.robot_dof):
+            raise ValueError(
                 f"PlanningContext.last_qpos must have shape "
-                f"({self.n_envs}, {self.robot_dof}), but got {state.last_qpos.shape}",
-                ValueError,
+                f"({self.num_envs}, {self.robot_dof}), but got "
+                f"{state.last_qpos.shape}"
             )
         start_qpos = state.last_qpos.to(device=self.device, dtype=torch.float32)
         return (
@@ -594,10 +585,9 @@ class HandOver(AtomicAction[GraspGoal, HandOverOptions]):
         n_transfer = max(2, (sample_count - reserved) // 2)
         n_approach = sample_count - reserved - n_transfer
         if n_approach < 2:
-            logger.log_error(
+            raise ValueError(
                 "Not enough waypoints for handover. Increase sample_count or "
-                "decrease hand_interp_steps/hold_steps/retreat_steps.",
-                ValueError,
+                "decrease hand_interp_steps/hold_steps/retreat_steps."
             )
         return {
             "transfer": n_transfer,
@@ -612,30 +602,6 @@ class HandOver(AtomicAction[GraspGoal, HandOverOptions]):
     # Planning / assembly helpers
     # ------------------------------------------------------------------
 
-    def _plan_named_arm_trajectory(
-        self,
-        control_part: str,
-        start_qpos: torch.Tensor,
-        target_poses: torch.Tensor,
-        n_waypoints: int,
-        motion_policy: MotionPolicy,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        result = self.motion_generator.generate(
-            build_pose_plan_states(target_poses),
-            options=motion_policy.to_motion_gen_options(
-                start_qpos=start_qpos,
-                control_part=control_part,
-                sample_count=n_waypoints,
-            ),
-        )
-        assert isinstance(result.success, torch.Tensor)
-        assert result.positions is not None
-        return result.success, result.positions
-
-    @staticmethod
-    def _repeat_qpos(qpos: torch.Tensor, n_waypoints: int) -> torch.Tensor:
-        return qpos.unsqueeze(1).repeat(1, n_waypoints, 1)
-
     def _assemble_segment(
         self,
         state: PlanningContext,
@@ -646,18 +612,15 @@ class HandOver(AtomicAction[GraspGoal, HandOverOptions]):
         *,
         resources: _HandOverResources,
     ) -> torch.Tensor:
-        n_waypoints = transfer_arm_traj.shape[1]
-        base = (
-            state.last_qpos.to(device=self.device, dtype=torch.float32)
-            .unsqueeze(1)
-            .repeat(1, n_waypoints, 1)
-            .clone()
+        return assemble_full_robot_trajectory(
+            state.last_qpos,
+            (
+                (resources.transfer_arm.joint_ids, transfer_arm_traj),
+                (resources.receive_arm.joint_ids, receive_arm_traj),
+                (resources.transfer_hand.joint_ids, transfer_hand_traj),
+                (resources.receive_hand.joint_ids, receive_hand_traj),
+            ),
         )
-        base[:, :, list(resources.transfer_arm.joint_ids)] = transfer_arm_traj
-        base[:, :, list(resources.receive_arm.joint_ids)] = receive_arm_traj
-        base[:, :, list(resources.transfer_hand.joint_ids)] = transfer_hand_traj
-        base[:, :, list(resources.receive_hand.joint_ids)] = receive_hand_traj
-        return base
 
 
 __all__ = ["HandOver", "HandOverOptions"]

--- a/embodichain/lab/sim/atomic_actions/primitives/hand_over.py
+++ b/embodichain/lab/sim/atomic_actions/primitives/hand_over.py
@@ -216,9 +216,24 @@ class HandOver(AtomicAction[GraspGoal, HandOverOptions]):
                 "Coordinated dual-arm planning is not supported by the cuRobo backend."
             )
         state = context
-        semantics = target.semantics
-        transfer_object_to_eef = self._resolve_transfer_object_to_eef(
+        transfer_held_object = self._resolve_transfer_held_object(
             state, resources.transfer_arm.name
+        )
+        self._validate_requested_object(
+            target.semantics, transfer_held_object.semantics
+        )
+        semantics = transfer_held_object.semantics
+        eligible = context.task.exclusive_held_object_mask(resources.transfer_arm.name)
+        if not eligible.any():
+            logger.log_warning("HandOver requires an exclusively held source object.")
+            return self.failed_plan(
+                request,
+                context,
+                message="Source object must be held exclusively.",
+            )
+        transfer_object_to_eef = self._resolve_matrix(
+            transfer_held_object.object_to_eef,
+            "held_object.object_to_eef",
         )
         assert options.middle_object_pose is not None
         assert options.final_object_pose is not None
@@ -236,7 +251,9 @@ class HandOver(AtomicAction[GraspGoal, HandOverOptions]):
             / torch.linalg.vector_norm(receive_approach_direction)
         )
         # force object pose to have the same rotation as the current object pose, so that the handover is feasible.
-        current_object_pose = target.semantics.entity.get_local_pose(to_matrix=True)
+        if semantics.entity is None:
+            raise ValueError("HandOver requires the held object to have an entity.")
+        current_object_pose = semantics.entity.get_local_pose(to_matrix=True)
         middle_object_pose[:, :3, :3] = current_object_pose[:, :3, :3]
         final_object_pose[:, :3, :3] = current_object_pose[:, :3, :3]
 
@@ -256,6 +273,7 @@ class HandOver(AtomicAction[GraspGoal, HandOverOptions]):
             device=self.device,
             name="Receiving-grasp success",
         )
+        success_mask &= eligible
         if not success_mask.any():
             logger.log_warning("HandOver failed to resolve a receiving grasp pose.")
             return self.failed_plan(request, context, message="No receiving grasp.")
@@ -510,18 +528,34 @@ class HandOver(AtomicAction[GraspGoal, HandOverOptions]):
             name=name,
         )
 
-    def _resolve_transfer_object_to_eef(
+    def _resolve_transfer_held_object(
         self,
         state: PlanningContext,
         transfer_control_part: str,
-    ) -> torch.Tensor:
+    ) -> HeldObjectState:
         held = state.get_held_object(transfer_control_part)
         if held is None:
             raise ValueError(
                 "HandOver requires an object held by transfer control part "
                 f"{transfer_control_part!r} (run PickUp first)."
             )
-        return self._resolve_matrix(held.object_to_eef, "held_object.object_to_eef")
+        return held
+
+    @staticmethod
+    def _validate_requested_object(
+        requested: ObjectSemantics,
+        held: ObjectSemantics,
+    ) -> None:
+        """Reject a request that names a different grounded object."""
+        if (
+            requested.entity is not None
+            and held.entity is not None
+            and requested.entity is not held.entity
+        ):
+            raise ValueError(
+                "HandOver goal semantics must identify the object held by the "
+                "source control part."
+            )
 
     def _resolve_receive_grasp(
         self,

--- a/embodichain/lab/sim/atomic_actions/primitives/move_end_effector.py
+++ b/embodichain/lab/sim/atomic_actions/primitives/move_end_effector.py
@@ -39,8 +39,6 @@ from ..trajectory_ops import (
 class EndEffectorPoseGoal:
     """End-effector pose goal with optional batched intermediate waypoints."""
 
-    goal_kind: ClassVar[str] = "end_effector_pose"
-
     xpos: PoseGoalValue
     """Homogeneous pose with shape ``(4,4)``, ``(B,4,4)`` or ``(B,N,4,4)``."""
 
@@ -61,25 +59,19 @@ class MoveEndEffector(AtomicAction[EndEffectorPoseGoal, MoveEndEffectorOptions])
     OptionsType: ClassVar[type] = MoveEndEffectorOptions
     manipulator_roles: ClassVar[tuple[str, ...]] = ("primary",)
 
-    def __init__(
-        self,
-        default_options: MoveEndEffectorOptions | None = None,
-    ) -> None:
-        super().__init__(default_options)
-
     def _plan(
         self,
         request: ResolvedActionRequest[EndEffectorPoseGoal, MoveEndEffectorOptions],
         context: PlanningContext,
     ) -> ActionPlan:
         """Plan an end-effector pose goal from the observed joint state."""
-        goal = self.require_goal(request)
+        goal = request.goal
         manipulator = request.binding.manipulator("primary")
         control_part = manipulator.name
         joint_ids = list(manipulator.joint_ids)
         move_xpos = resolve_pose_target(
             resolve_pose_goal(goal.xpos, context, name="xpos"),
-            n_envs=context.batch_size,
+            num_envs=context.batch_size,
             device=self.device,
         )
         start_qpos = context.robot.qpos[:, joint_ids]

--- a/embodichain/lab/sim/atomic_actions/primitives/move_held_object.py
+++ b/embodichain/lab/sim/atomic_actions/primitives/move_held_object.py
@@ -23,7 +23,6 @@ from typing import ClassVar
 
 import torch
 
-from embodichain.utils import logger
 from embodichain.utils.math import axis_angle_to_rotation_matrix, get_relative_rotation
 
 from ._helpers import arm_qpos_from_state, resolve_object_target
@@ -40,10 +39,8 @@ from ..trajectory_ops import build_pose_plan_states
 class HeldObjectPoseGoal:
     """Desired pose for the object held by this action's control part."""
 
-    goal_kind: ClassVar[str] = "held_object_pose"
-
     object_target_pose: PoseGoalValue
-    """Target object pose, shape ``(4, 4)`` or ``(n_envs, 4, 4)``."""
+    """Target object pose, shape ``(4, 4)`` or ``(num_envs, 4, 4)``."""
 
     def __post_init__(self) -> None:
         validate_pose_goal(
@@ -86,24 +83,13 @@ class MoveHeldObject(AtomicAction[HeldObjectPoseGoal, MoveHeldObjectOptions]):
     manipulator_roles: ClassVar[tuple[str, ...]] = ("primary",)
     end_effector_roles: ClassVar[tuple[str, ...]] = ("primary",)
 
-    def __init__(
-        self,
-        default_options: MoveHeldObjectOptions | None = None,
-    ) -> None:
-        super().__init__(default_options)
-
-    def _on_bind(self) -> None:
-        """Resolve engine-wide resources from the owning engine."""
-        self.n_envs = self.robot.get_qpos().shape[0]
-        self.robot_dof = self.robot.dof
-
     def _plan(
         self,
         request: ResolvedActionRequest[HeldObjectPoseGoal, MoveHeldObjectOptions],
         context: PlanningContext,
     ) -> ActionPlan:
         """Plan held-object transport without changing the attachment relation."""
-        target = self.require_goal(request)
+        target = request.goal
         options = request.skill_options
         binding = request.binding
         manipulator = binding.manipulator()
@@ -113,17 +99,16 @@ class MoveHeldObject(AtomicAction[HeldObjectPoseGoal, MoveHeldObjectOptions]):
         hand_joint_ids = list(end_effector.joint_ids)
         hand_grasp_qpos = end_effector.joint_positions(
             GRASP_COMMAND,
-            n_envs=context.batch_size,
+            num_envs=context.batch_size,
             device=self.device,
             dtype=context.robot.qpos.dtype,
         )
         state = context
         held_object = state.get_held_object(control_part)
         if held_object is None:
-            logger.log_error(
+            raise ValueError(
                 "MoveHeldObject requires an object held by control part "
-                f"{control_part!r} - run PickUp first.",
-                ValueError,
+                f"{control_part!r} - run PickUp first."
             )
         object_target_pose = resolve_object_target(
             resolve_pose_goal(
@@ -131,7 +116,7 @@ class MoveHeldObject(AtomicAction[HeldObjectPoseGoal, MoveHeldObjectOptions]):
                 context,
                 name="object_target_pose",
             ),
-            n_envs=self.n_envs,
+            num_envs=self.num_envs,
             device=self.device,
         )
         start_arm_qpos = arm_qpos_from_state(state, arm_joint_ids)
@@ -149,7 +134,7 @@ class MoveHeldObject(AtomicAction[HeldObjectPoseGoal, MoveHeldObjectOptions]):
             device=self.device, dtype=torch.float32
         )
         if object_to_eef.shape == (4, 4):
-            object_to_eef = object_to_eef.unsqueeze(0).repeat(self.n_envs, 1, 1)
+            object_to_eef = object_to_eef.unsqueeze(0).repeat(self.num_envs, 1, 1)
         move_eef_xpos = torch.bmm(object_target_pose, object_to_eef)
 
         if options.pick_rotate_upright is None:
@@ -168,7 +153,7 @@ class MoveHeldObject(AtomicAction[HeldObjectPoseGoal, MoveHeldObjectOptions]):
         arm_traj = result.positions
 
         full = torch.empty(
-            (self.n_envs, arm_traj.shape[1], self.robot_dof),
+            (self.num_envs, arm_traj.shape[1], self.robot_dof),
             dtype=torch.float32,
             device=self.device,
         )
@@ -228,7 +213,7 @@ class MoveHeldObject(AtomicAction[HeldObjectPoseGoal, MoveHeldObjectOptions]):
         revert_flag = torch.where(end_arm_xpos[:, 2, 1] > 0, 1.0, -1.0)
         rotation_axis = torch.tensor(
             [1.0, 0.0, 0.0], device=self.device, dtype=torch.float32
-        ).repeat(self.n_envs, 1)
+        ).repeat(self.num_envs, 1)
         axis_angle = (
             (torch.pi * 0.5 - arm_dot_angle).unsqueeze(-1)
             * rotation_axis
@@ -239,12 +224,12 @@ class MoveHeldObject(AtomicAction[HeldObjectPoseGoal, MoveHeldObjectOptions]):
             [[1.0, 0.0, 0.0], [0.0, -1.0, 0.0], [0.0, 0.0, -1.0]],
             device=self.device,
             dtype=torch.float32,
-        ).repeat(self.n_envs, 1, 1)
+        ).repeat(self.num_envs, 1, 1)
         template_rotation_b = torch.tensor(
             [[-1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, -1.0]],
             device=self.device,
             dtype=torch.float32,
-        ).repeat(self.n_envs, 1, 1)
+        ).repeat(self.num_envs, 1, 1)
         target_rotation_a = torch.bmm(template_rotation_a, rotation_offset)
         target_rotation_b = torch.bmm(template_rotation_b, rotation_offset)
         relative_rotation_a = get_relative_rotation(

--- a/embodichain/lab/sim/atomic_actions/primitives/move_held_object.py
+++ b/embodichain/lab/sim/atomic_actions/primitives/move_held_object.py
@@ -110,6 +110,13 @@ class MoveHeldObject(AtomicAction[HeldObjectPoseGoal, MoveHeldObjectOptions]):
                 "MoveHeldObject requires an object held by control part "
                 f"{control_part!r} - run PickUp first."
             )
+        eligible = context.task.exclusive_held_object_mask(control_part)
+        if not eligible.any():
+            return self.failed_plan(
+                request,
+                context,
+                message="Held object is not exclusive to the control part.",
+            )
         object_target_pose = resolve_object_target(
             resolve_pose_goal(
                 target.object_target_pose,
@@ -149,7 +156,7 @@ class MoveHeldObject(AtomicAction[HeldObjectPoseGoal, MoveHeldObjectOptions]):
         )
         assert isinstance(result.success, torch.Tensor)
         assert result.positions is not None
-        success = result.success
+        success = result.success & eligible
         arm_traj = result.positions
 
         full = torch.empty(

--- a/embodichain/lab/sim/atomic_actions/primitives/move_joints.py
+++ b/embodichain/lab/sim/atomic_actions/primitives/move_joints.py
@@ -38,8 +38,6 @@ from ..trajectory_ops import (
 class JointPositionGoal:
     """Explicit or named joint-space goal for a bound robot resource."""
 
-    goal_kind: ClassVar[str] = "joint_position"
-
     target: torch.Tensor | str
     """Joint qpos/waypoints or a named control-part profile command."""
 
@@ -56,8 +54,8 @@ class JointPositionGoal:
         if self.target.dim() not in (1, 2, 3) or self.target.shape[-1] == 0:
             raise ValueError(
                 "Tensor target must have shape (control_dof,), "
-                "(n_envs, control_dof), "
-                "or (n_envs, n_waypoint, control_dof), "
+                "(num_envs, control_dof), "
+                "or (num_envs, n_waypoint, control_dof), "
                 f"got {tuple(self.target.shape)}."
             )
 
@@ -76,19 +74,13 @@ class MoveJoints(AtomicAction[JointPositionGoal, MoveJointsOptions]):
     manipulator_roles: ClassVar[tuple[str, ...]] = ("primary",)
     agent_visible: ClassVar[bool] = False
 
-    def __init__(
-        self,
-        default_options: MoveJointsOptions | None = None,
-    ) -> None:
-        super().__init__(default_options)
-
     def _plan(
         self,
         request: ResolvedActionRequest[JointPositionGoal, MoveJointsOptions],
         context: PlanningContext,
     ) -> ActionPlan:
         """Plan a joint-space goal without mutating the robot or task state."""
-        goal = self.require_goal(request)
+        goal = request.goal
         manipulator = request.binding.manipulator("primary")
         control_part = manipulator.name
         joint_ids = list(manipulator.joint_ids)
@@ -99,7 +91,7 @@ class MoveJoints(AtomicAction[JointPositionGoal, MoveJointsOptions]):
                 request=request,
                 context=context,
             ),
-            n_envs=context.batch_size,
+            num_envs=context.batch_size,
             joint_dof=joint_dof,
             control_part=control_part,
             device=self.device,
@@ -138,7 +130,7 @@ class MoveJoints(AtomicAction[JointPositionGoal, MoveJointsOptions]):
             return goal.target
         return request.binding.manipulator("primary").joint_positions(
             goal.target,
-            n_envs=context.batch_size,
+            num_envs=context.batch_size,
             device=self.device,
             dtype=context.robot.qpos.dtype,
         )

--- a/embodichain/lab/sim/atomic_actions/primitives/pick_up.py
+++ b/embodichain/lab/sim/atomic_actions/primitives/pick_up.py
@@ -61,8 +61,6 @@ from ..trajectory_ops import (
 class GraspGoal(ObjectActionGoal):
     """Pickup target with an affordance-selected or supplied grasp pose."""
 
-    goal_kind: ClassVar[str] = "grasp"
-
     grasp_xpos: PoseGoalValue | None = None
     """Optional end-effector grasp pose.
 
@@ -155,17 +153,6 @@ class PickUp(AtomicAction[GraspGoal, PickUpOptions]):
     manipulator_roles: ClassVar[tuple[str, ...]] = ("primary",)
     end_effector_roles: ClassVar[tuple[str, ...]] = ("primary",)
 
-    def __init__(
-        self,
-        default_options: PickUpOptions | None = None,
-    ) -> None:
-        super().__init__(default_options)
-
-    def _on_bind(self) -> None:
-        """Resolve engine-wide resources from the owning engine."""
-        self.n_envs = self.robot.get_qpos().shape[0]
-        self.robot_dof = self.robot.dof
-
     def _get_full_pickup_trajectory(
         self,
         grasp_xpos: torch.Tensor,
@@ -228,7 +215,11 @@ class PickUp(AtomicAction[GraspGoal, PickUpOptions]):
         n_approach_actual = approach_arm.shape[1]
         n_lift_actual = lift_arm.shape[1]
         full = torch.empty(
-            (self.n_envs, n_approach_actual + n_close + n_lift_actual, self.robot_dof),
+            (
+                self.num_envs,
+                n_approach_actual + n_close + n_lift_actual,
+                self.robot_dof,
+            ),
             dtype=torch.float32,
             device=self.device,
         )
@@ -263,7 +254,7 @@ class PickUp(AtomicAction[GraspGoal, PickUpOptions]):
         context: PlanningContext,
     ) -> ActionPlan:
         """Plan approach, close, and lift segments without committing attachment."""
-        target = self.require_goal(request)
+        target = request.goal
         options = request.skill_options
         approach_direction = options.approach_direction.to(
             device=self.device, dtype=torch.float32
@@ -276,13 +267,13 @@ class PickUp(AtomicAction[GraspGoal, PickUpOptions]):
         end_effector = binding.end_effector()
         hand_open_qpos = end_effector.joint_positions(
             OPEN_COMMAND,
-            n_envs=context.batch_size,
+            num_envs=context.batch_size,
             device=self.device,
             dtype=context.robot.qpos.dtype,
         )
         hand_grasp_qpos = end_effector.joint_positions(
             GRASP_COMMAND,
-            n_envs=context.batch_size,
+            num_envs=context.batch_size,
             device=self.device,
             dtype=context.robot.qpos.dtype,
         )
@@ -292,14 +283,11 @@ class PickUp(AtomicAction[GraspGoal, PickUpOptions]):
         if target.grasp_xpos is None and not isinstance(
             sem.affordance, AntipodalAffordance
         ):
-            logger.log_error(
-                "PickUp requires an AntipodalAffordance when grasp_xpos is not set.",
-                ValueError,
+            raise ValueError(
+                "PickUp requires an AntipodalAffordance when grasp_xpos is not set."
             )
         if sem.entity is None:
-            logger.log_error(
-                "PickUp requires an entity on the target semantics.", ValueError
-            )
+            raise ValueError("PickUp requires an entity on the target semantics.")
         start_arm_qpos = arm_qpos_from_state(
             state,
             list(manipulator.joint_ids),
@@ -311,17 +299,17 @@ class PickUp(AtomicAction[GraspGoal, PickUpOptions]):
         else:
             grasp_xpos = resolve_pose_target(
                 resolve_pose_goal(target.grasp_xpos, context, name="grasp_xpos"),
-                n_envs=self.n_envs,
+                num_envs=self.num_envs,
                 device=self.device,
             )
             if options.rotate_upright is not None:
                 grasp_xpos = self._upright_adjusted_grasp_poses(
                     sem, grasp_xpos, options
                 )
-            is_success = torch.ones(self.n_envs, dtype=torch.bool, device=self.device)
+            is_success = torch.ones(self.num_envs, dtype=torch.bool, device=self.device)
         grasp_success = normalize_success_mask(
             is_success,
-            n_envs=self.n_envs,
+            num_envs=self.num_envs,
             device=self.device,
             name="Grasp-pose success",
         )
@@ -345,7 +333,7 @@ class PickUp(AtomicAction[GraspGoal, PickUpOptions]):
         )
         success_mask = grasp_success & normalize_success_mask(
             trajectory_success,
-            n_envs=self.n_envs,
+            num_envs=self.num_envs,
             device=self.device,
             name="Pick-up trajectory success",
         )
@@ -355,18 +343,12 @@ class PickUp(AtomicAction[GraspGoal, PickUpOptions]):
         held = HeldObjectState(
             semantics=sem, object_to_eef=object_to_eef, grasp_xpos=grasp_xpos
         )
-        coordinated_updates = {
-            key: None for key in state.coordinated_held_objects if control_part in key
-        }
         return self.build_plan(
             request,
             context,
             success=success_mask,
             trajectory=full,
-            expected_effects=StateDelta(
-                held_object_updates={control_part: held},
-                coordinated_held_object_updates=coordinated_updates,
-            ),
+            expected_effects=StateDelta(held_object_updates={control_part: held}),
             segment_lengths=segment_lengths,
         )
 
@@ -384,18 +366,18 @@ class PickUp(AtomicAction[GraspGoal, PickUpOptions]):
             approach_direction=approach_direction,
             object_part=options.pick_object_part,
         )
-        n_envs = obj_poses.shape[0]
+        num_envs = obj_poses.shape[0]
         n_max_pose = max(r[0].shape[0] for r in grasp_poses_result)
         grasp_xpos_padding = torch.zeros(
-            (n_envs, n_max_pose, 4, 4), dtype=torch.float32, device=self.device
+            (num_envs, n_max_pose, 4, 4), dtype=torch.float32, device=self.device
         )
         grasp_cost_padding = torch.full(
-            (n_envs, n_max_pose),
+            (num_envs, n_max_pose),
             float("inf"),
             dtype=torch.float32,
             device=self.device,
         )
-        for i in range(n_envs):
+        for i in range(num_envs):
             n_pose = grasp_poses_result[i][0].shape[0]
             grasp_poses = grasp_poses_result[i][0].to(
                 device=self.device, dtype=torch.float32
@@ -420,7 +402,7 @@ class PickUp(AtomicAction[GraspGoal, PickUpOptions]):
         best_cost, best_idx = grasp_cost_masked.min(dim=1)
         is_success = best_cost < 9999.0
         best_grasp_xpos = grasp_xpos_padding[
-            torch.arange(n_envs, device=self.device), best_idx
+            torch.arange(num_envs, device=self.device), best_idx
         ]
         return is_success, best_grasp_xpos
 
@@ -435,7 +417,7 @@ class PickUp(AtomicAction[GraspGoal, PickUpOptions]):
         approach_direction: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Choose a TCP-roll variant with a feasible pickup and transport path."""
-        n_envs, n_pose = grasp_xpos.shape[:2]
+        num_envs, n_pose = grasp_xpos.shape[:2]
         mirrored_grasp_xpos = grasp_xpos.clone()
         mirrored_grasp_xpos[..., :3, 0] = -mirrored_grasp_xpos[..., :3, 0]
         mirrored_grasp_xpos[..., :3, 1] = -mirrored_grasp_xpos[..., :3, 1]
@@ -482,14 +464,13 @@ class PickUp(AtomicAction[GraspGoal, PickUpOptions]):
             )
             if object_target_pose.shape == (4, 4):
                 object_target_pose = object_target_pose.unsqueeze(0).repeat(
-                    n_envs, 1, 1
+                    num_envs, 1, 1
                 )
-            if object_target_pose.shape != (n_envs, 4, 4):
-                logger.log_error(
+            if object_target_pose.shape != (num_envs, 4, 4):
+                raise ValueError(
                     "downstream_object_target_poses entries must have shape "
-                    f"(4, 4) or ({n_envs}, 4, 4), but got "
-                    f"{object_target_pose.shape}.",
-                    ValueError,
+                    f"(4, 4) or ({num_envs}, 4, 4), but got "
+                    f"{object_target_pose.shape}."
                 )
             downstream_eef_variants = torch.matmul(
                 object_target_pose[:, None, None], object_to_eef_variants
@@ -522,7 +503,7 @@ class PickUp(AtomicAction[GraspGoal, PickUpOptions]):
         rotation_error = quat_error_magnitude(
             variant_quat.reshape(-1, 4),
             start_quat.reshape(-1, 4),
-        ).reshape(n_envs, n_pose, 2)
+        ).reshape(num_envs, n_pose, 2)
         feasible_rotation_error = torch.where(
             pickup_success,
             rotation_error,
@@ -530,7 +511,7 @@ class PickUp(AtomicAction[GraspGoal, PickUpOptions]):
         )
         best_variant_idx = feasible_rotation_error.argmin(dim=2)
 
-        env_idx = torch.arange(n_envs, device=self.device)[:, None]
+        env_idx = torch.arange(num_envs, device=self.device)[:, None]
         pose_idx = torch.arange(n_pose, device=self.device)[None, :]
         selected_grasp_xpos = grasp_variants[env_idx, pose_idx, best_variant_idx]
         ik_success = pickup_success[env_idx, pose_idx, best_variant_idx]
@@ -559,19 +540,19 @@ class PickUp(AtomicAction[GraspGoal, PickUpOptions]):
         manipulator: ResolvedControlPart,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Solve candidate IK poses while preserving the candidate dimensions."""
-        n_envs, n_pose, n_variant = poses.shape[:3]
-        flat_poses = poses.reshape(n_envs, n_pose * n_variant, 4, 4)
+        num_envs, n_pose, n_variant = poses.shape[:3]
+        flat_poses = poses.reshape(num_envs, n_pose * n_variant, 4, 4)
         if joint_seed.dim() == 2:
             joint_seed = joint_seed[:, None, None, :].expand(-1, n_pose, n_variant, -1)
-        flat_seed = joint_seed.reshape(n_envs, n_pose * n_variant, manipulator.dof)
+        flat_seed = joint_seed.reshape(num_envs, n_pose * n_variant, manipulator.dof)
         is_success, qpos = self.robot.compute_batch_ik(
             pose=flat_poses,
             name=manipulator.name,
             joint_seed=flat_seed,
         )
         return (
-            is_success.reshape(n_envs, n_pose, n_variant),
-            qpos.reshape(n_envs, n_pose, n_variant, manipulator.dof),
+            is_success.reshape(num_envs, n_pose, n_variant),
+            qpos.reshape(num_envs, n_pose, n_variant, manipulator.dof),
         )
 
     def _upright_adjusted_grasp_poses(

--- a/embodichain/lab/sim/atomic_actions/primitives/place.py
+++ b/embodichain/lab/sim/atomic_actions/primitives/place.py
@@ -23,7 +23,6 @@ from typing import ClassVar, Literal
 
 import torch
 
-from embodichain.utils import logger
 from embodichain.utils.math import quat_error_magnitude, quat_from_matrix
 
 from ._helpers import arm_qpos_from_state, resolve_object_target
@@ -49,13 +48,11 @@ TcpSymmetry = Literal["none", "z_roll_180"]
 class PlaceGoal:
     """End-effector release-pose target used by :class:`Place`."""
 
-    goal_kind: ClassVar[str] = "place_pose"
-
     xpos: PoseGoalValue
     """Target end-effector release pose.
 
-    Accepts ``(4, 4)``, ``(n_envs, 4, 4)``, or
-    ``(n_envs, n_waypoint, 4, 4)``.
+    Accepts ``(4, 4)``, ``(num_envs, 4, 4)``, or
+    ``(num_envs, n_waypoint, 4, 4)``.
     """
 
     tcp_symmetry: TcpSymmetry = "none"
@@ -85,8 +82,6 @@ class AssembleGoal:
     transform (``object_to_eef``) is read from :class:`PlanningContext`
     for the place control part, which a prior :class:`PickUp` populates.
     """
-
-    goal_kind: ClassVar[str] = "assemble"
 
     affordance: AssembleAffordance
     """Assembly affordance anchoring the assemble object to the base object."""
@@ -121,8 +116,8 @@ class Place(AtomicAction[PlaceGoal | AssembleGoal, PlaceOptions]):
     """Lower the held object to a place pose, open the gripper, retract.
 
     The :class:`PlaceGoal` may carry either a single waypoint
-    ``(n_envs, 4, 4)`` (or a broadcastable ``(4, 4)``) or a multi-waypoint
-    trajectory ``(n_envs, n_waypoint, 4, 4)``. In the multi-waypoint case the
+    ``(num_envs, 4, 4)`` (or a broadcastable ``(4, 4)``) or a multi-waypoint
+    trajectory ``(num_envs, n_waypoint, 4, 4)``. In the multi-waypoint case the
     approach segment visits every waypoint in order; approaching from above the
     first waypoint, descending through each waypoint, then opening the gripper
     at the final waypoint and retracting to above the last waypoint. Starting
@@ -143,24 +138,13 @@ class Place(AtomicAction[PlaceGoal | AssembleGoal, PlaceOptions]):
     manipulator_roles: ClassVar[tuple[str, ...]] = ("primary",)
     end_effector_roles: ClassVar[tuple[str, ...]] = ("primary",)
 
-    def __init__(
-        self,
-        default_options: PlaceOptions | None = None,
-    ) -> None:
-        super().__init__(default_options)
-
-    def _on_bind(self) -> None:
-        """Resolve engine-wide resources from the owning engine."""
-        self.n_envs = self.robot.get_qpos().shape[0]
-        self.robot_dof = self.robot.dof
-
     def _plan(
         self,
         request: ResolvedActionRequest[PlaceGoal | AssembleGoal, PlaceOptions],
         context: PlanningContext,
     ) -> ActionPlan:
         """Plan approach, release, and retract without committing detachment."""
-        target = self.require_goal(request)
+        target = request.goal
         options = request.skill_options
         binding = request.binding
         manipulator = binding.manipulator()
@@ -170,13 +154,13 @@ class Place(AtomicAction[PlaceGoal | AssembleGoal, PlaceOptions]):
         hand_joint_ids = list(end_effector.joint_ids)
         hand_open_qpos = end_effector.joint_positions(
             OPEN_COMMAND,
-            n_envs=context.batch_size,
+            num_envs=context.batch_size,
             device=self.device,
             dtype=context.robot.qpos.dtype,
         )
         hand_grasp_qpos = end_effector.joint_positions(
             GRASP_COMMAND,
-            n_envs=context.batch_size,
+            num_envs=context.batch_size,
             device=self.device,
             dtype=context.robot.qpos.dtype,
         )
@@ -248,7 +232,7 @@ class Place(AtomicAction[PlaceGoal | AssembleGoal, PlaceOptions]):
         n_down_actual = down_arm.shape[1]
         n_back_actual = back_arm.shape[1]
         full = torch.empty(
-            (self.n_envs, n_down_actual + n_open + n_back_actual, self.robot_dof),
+            (self.num_envs, n_down_actual + n_open + n_back_actual, self.robot_dof),
             dtype=torch.float32,
             device=self.device,
         )
@@ -262,18 +246,12 @@ class Place(AtomicAction[PlaceGoal | AssembleGoal, PlaceOptions]):
         full[:, n_down_actual + n_open :, arm_joint_ids] = back_arm
         full[:, n_down_actual + n_open :, hand_joint_ids] = hand_open_qpos.unsqueeze(1)
 
-        coordinated_updates = {
-            key: None for key in state.coordinated_held_objects if control_part in key
-        }
         return self.build_plan(
             request,
             context,
             success=success,
             trajectory=full,
-            expected_effects=StateDelta(
-                held_object_updates={control_part: None},
-                coordinated_held_object_updates=coordinated_updates,
-            ),
+            expected_effects=StateDelta(held_object_updates={control_part: None}),
             segment_lengths={
                 "approach": n_down_actual,
                 "release": n_open,
@@ -294,13 +272,13 @@ class Place(AtomicAction[PlaceGoal | AssembleGoal, PlaceOptions]):
             state: World state carrying the held-object transform.
 
         Returns:
-            Place EEF poses with shape ``(n_envs, 4, 4)`` or
-            ``(n_envs, n_waypoint, 4, 4)``.
+            Place EEF poses with shape ``(num_envs, 4, 4)`` or
+            ``(num_envs, n_waypoint, 4, 4)``.
         """
         if isinstance(target, PlaceGoal):
             return resolve_pose_target(
                 resolve_pose_goal(target.xpos, state, name="xpos"),
-                n_envs=self.n_envs,
+                num_envs=self.num_envs,
                 device=self.device,
             )
         return self._resolve_assemble_place_xpos(target, state, control_part)
@@ -322,24 +300,22 @@ class Place(AtomicAction[PlaceGoal | AssembleGoal, PlaceOptions]):
             state: World state carrying the held-object transform.
 
         Returns:
-            Place EEF poses with shape ``(n_envs, 4, 4)``.
+            Place EEF poses with shape ``(num_envs, 4, 4)``.
 
         Raises:
             ValueError: If no held object or no base object entity is available.
         """
         held = state.get_held_object(control_part)
         if held is None:
-            logger.log_error(
+            raise ValueError(
                 "Place with AssembleGoal requires an object held by control "
-                f"part {control_part!r} (run PickUp first).",
-                ValueError,
+                f"part {control_part!r} (run PickUp first)."
             )
         affordance = target.affordance
         if affordance.base_object_entity is None:
-            logger.log_error(
+            raise ValueError(
                 "AssembleAffordance.base_object_entity must be set to assemble "
-                "onto a base object.",
-                ValueError,
+                "onto a base object."
             )
         base_pose = affordance.base_object_entity.get_local_pose(to_matrix=True).to(
             device=self.device, dtype=torch.float32
@@ -347,7 +323,7 @@ class Place(AtomicAction[PlaceGoal | AssembleGoal, PlaceOptions]):
         assemble_object_pose = affordance.get_assemble_object_pose(base_pose)
         object_to_eef = resolve_object_target(
             held.object_to_eef,
-            n_envs=self.n_envs,
+            num_envs=self.num_envs,
             device=self.device,
             name="object_to_eef",
         )
@@ -424,10 +400,10 @@ class Place(AtomicAction[PlaceGoal | AssembleGoal, PlaceOptions]):
         rotation_error = quat_error_magnitude(
             first_waypoint_quat.reshape(-1, 4),
             start_quat.reshape(-1, 4),
-        ).reshape(self.n_envs, 2)
+        ).reshape(self.num_envs, 2)
         best_variant_idx = rotation_error.argmin(dim=1)
 
-        env_idx = torch.arange(self.n_envs, device=self.device)[:, None]
+        env_idx = torch.arange(self.num_envs, device=self.device)[:, None]
         waypoint_idx = torch.arange(place_xpos.shape[1], device=self.device)[None, :]
         return place_variants[
             env_idx,

--- a/embodichain/lab/sim/atomic_actions/primitives/place.py
+++ b/embodichain/lab/sim/atomic_actions/primitives/place.py
@@ -165,7 +165,20 @@ class Place(AtomicAction[PlaceGoal | AssembleGoal, PlaceOptions]):
             dtype=context.robot.qpos.dtype,
         )
         state = context
+        held_mask = context.task.held_object_mask(control_part)
+        exclusive_mask = context.task.exclusive_held_object_mask(control_part)
+        eligible = (
+            exclusive_mask
+            if isinstance(target, AssembleGoal)
+            else ~held_mask | exclusive_mask
+        )
         place_xpos = self._resolve_place_xpos(target, state, control_part)
+        if not eligible.any():
+            return self.failed_plan(
+                request,
+                context,
+                message="Held object is shared with another control part.",
+            )
         if place_xpos.dim() == 3:
             place_xpos = place_xpos.unsqueeze(1)
 
@@ -221,7 +234,7 @@ class Place(AtomicAction[PlaceGoal | AssembleGoal, PlaceOptions]):
         assert back_result.positions is not None
         back_success = back_result.success
         back_arm = back_result.positions
-        success = down_success & back_success
+        success = down_success & back_success & eligible
 
         hand_open_path = interpolate_hand_qpos(
             hand_grasp_qpos, hand_open_qpos, n_waypoints=n_open

--- a/embodichain/lab/sim/atomic_actions/primitives/press.py
+++ b/embodichain/lab/sim/atomic_actions/primitives/press.py
@@ -23,8 +23,6 @@ from typing import ClassVar
 
 import torch
 
-from embodichain.utils import logger
-
 from ._helpers import arm_qpos_from_state
 from ..control import GRASP_COMMAND
 from ..core import AtomicAction
@@ -44,10 +42,8 @@ from ..trajectory_ops import (
 class PressGoal:
     """Single end-effector contact pose used by :class:`Press`."""
 
-    goal_kind: ClassVar[str] = "press_pose"
-
     xpos: PoseGoalValue
-    """Contact pose, shape ``(4, 4)`` or ``(n_envs, 4, 4)``."""
+    """Contact pose, shape ``(4, 4)`` or ``(num_envs, 4, 4)``."""
 
     def __post_init__(self) -> None:
         validate_pose_goal(self.xpos, "xpos", allow_waypoints=False)
@@ -74,24 +70,13 @@ class Press(AtomicAction[PressGoal, PressOptions]):
     manipulator_roles: ClassVar[tuple[str, ...]] = ("primary",)
     end_effector_roles: ClassVar[tuple[str, ...]] = ("primary",)
 
-    def __init__(
-        self,
-        default_options: PressOptions | None = None,
-    ) -> None:
-        super().__init__(default_options)
-
-    def _on_bind(self) -> None:
-        """Resolve engine-wide resources from the owning engine."""
-        self.n_envs = self.robot.get_qpos().shape[0]
-        self.robot_dof = self.robot.dof
-
     def _plan(
         self,
         request: ResolvedActionRequest[PressGoal, PressOptions],
         context: PlanningContext,
     ) -> ActionPlan:
         """Plan a close, press, and retract sequence."""
-        target = self.require_goal(request)
+        target = request.goal
         options = request.skill_options
         binding = request.binding
         manipulator = binding.manipulator()
@@ -101,14 +86,14 @@ class Press(AtomicAction[PressGoal, PressOptions]):
         hand_joint_ids = list(end_effector.joint_ids)
         hand_close_qpos = end_effector.joint_positions(
             GRASP_COMMAND,
-            n_envs=self.n_envs,
+            num_envs=self.num_envs,
             device=self.device,
             dtype=context.robot.qpos.dtype,
         )
         state = context
         press_xpos = resolve_pose_target(
             resolve_pose_goal(target.xpos, context, name="xpos"),
-            n_envs=self.n_envs,
+            num_envs=self.num_envs,
             device=self.device,
         )
         start_arm_qpos = arm_qpos_from_state(state, arm_joint_ids)
@@ -157,7 +142,7 @@ class Press(AtomicAction[PressGoal, PressOptions]):
         n_down_actual = down_arm.shape[1]
         n_back_actual = back_arm.shape[1]
         full = torch.empty(
-            (self.n_envs, n_close + n_down_actual + n_back_actual, self.robot_dof),
+            (self.num_envs, n_close + n_down_actual + n_back_actual, self.robot_dof),
             dtype=torch.float32,
             device=self.device,
         )
@@ -195,10 +180,9 @@ class Press(AtomicAction[PressGoal, PressOptions]):
         n_down = motion_waypoints // 2
         n_back = motion_waypoints - n_down
         if n_down < 2 or n_back < 2:
-            logger.log_error(
+            raise ValueError(
                 "Not enough waypoints for press trajectory. Increase "
-                "MotionPolicy.sample_count or decrease hand_interp_steps.",
-                ValueError,
+                "MotionPolicy.sample_count or decrease hand_interp_steps."
             )
         return n_close, n_down, n_back
 

--- a/embodichain/lab/sim/atomic_actions/sim_adapter.py
+++ b/embodichain/lab/sim/atomic_actions/sim_adapter.py
@@ -411,24 +411,7 @@ class SimulationExecutionAdapter:
         Returns:
             Accepted acknowledgement or a rejected diagnostic.
         """
-        self._validate_timeout(timeout)
-        try:
-            self._validate_command(command)
-            self.robot.set_qpos(
-                command.positions,
-                env_ids=self._robot_env_indices,
-            )
-            if command.velocities is not None:
-                self.robot.set_qvel(
-                    command.velocities,
-                    env_ids=self._robot_env_indices,
-                )
-            return CommandAcknowledgement.accepted_ack()
-        except Exception as exc:
-            return CommandAcknowledgement(
-                CommandAckStatus.REJECTED,
-                f"{type(exc).__name__}: {exc}",
-            )
+        return self._write_command(command, timeout=timeout)
 
     def hold(
         self,
@@ -446,6 +429,15 @@ class SimulationExecutionAdapter:
         Returns:
             Accepted acknowledgement or a rejected diagnostic.
         """
+        return self._write_command(command, timeout=timeout)
+
+    def _write_command(
+        self,
+        command: JointCommand,
+        *,
+        timeout: float,
+    ) -> CommandAcknowledgement:
+        """Validate and synchronously write a full-robot joint command."""
         self._validate_timeout(timeout)
         try:
             self._validate_command(command)

--- a/embodichain/lab/sim/atomic_actions/state.py
+++ b/embodichain/lab/sim/atomic_actions/state.py
@@ -28,6 +28,16 @@ if TYPE_CHECKING:
     from .core import ObjectSemantics
 
 
+def _same_physical_object(
+    first: ObjectSemantics,
+    second: ObjectSemantics,
+) -> bool:
+    """Return whether two semantic records identify one physical object."""
+    if first is second:
+        return True
+    return first.entity is not None and first.entity is second.entity
+
+
 def _resolve_runtime_device(device: torch.device | str) -> torch.device:
     """Resolve an indexless CUDA device to the active concrete GPU index."""
     resolved = torch.device(device)
@@ -216,6 +226,53 @@ class TaskState:
     def get_held_object(self, resource: str) -> HeldObjectState | None:
         """Return the object held by ``resource``, if any."""
         return self.held_objects.get(resource)
+
+    def held_object_mask(self, resource: str) -> torch.Tensor:
+        """Return environments where ``resource`` holds an object.
+
+        Args:
+            resource: Manipulator control-resource name.
+
+        Returns:
+            Owned boolean mask with shape ``(batch_size,)``. Missing resources
+            produce an all-false mask.
+        """
+        held = self.get_held_object(resource)
+        if held is None:
+            return torch.zeros(
+                self.batch_size,
+                dtype=torch.bool,
+                device=self.device,
+            )
+        assert held.env_mask is not None
+        return held.env_mask.clone()
+
+    def exclusive_held_object_mask(self, resource: str) -> torch.Tensor:
+        """Return environments where only ``resource`` holds its object.
+
+        Object identity is established by the exact semantic record or by a
+        shared non-null simulation entity. Labels and structural equality are
+        deliberately ignored because distinct physical objects may look alike.
+
+        Args:
+            resource: Manipulator control-resource name.
+
+        Returns:
+            Owned boolean mask with shape ``(batch_size,)``.
+        """
+        held = self.get_held_object(resource)
+        if held is None:
+            return self.held_object_mask(resource)
+
+        exclusive = self.held_object_mask(resource)
+        for other_resource, other in self.held_objects.items():
+            if other_resource == resource:
+                continue
+            if not _same_physical_object(held.semantics, other.semantics):
+                continue
+            assert other.env_mask is not None
+            exclusive &= ~other.env_mask
+        return exclusive
 
 
 @dataclass(frozen=True, slots=True, eq=False)

--- a/embodichain/lab/sim/atomic_actions/state.py
+++ b/embodichain/lab/sim/atomic_actions/state.py
@@ -44,7 +44,7 @@ def _validate_pose(value: torch.Tensor, name: str) -> int | None:
         return None
     if value.dim() != 3 or value.shape[-2:] != (4, 4) or value.shape[0] == 0:
         raise ValueError(
-            f"{name} must have shape (4, 4) or (n_envs, 4, 4), "
+            f"{name} must have shape (4, 4) or (num_envs, 4, 4), "
             f"got {tuple(value.shape)}."
         )
     return int(value.shape[0])
@@ -136,49 +136,6 @@ class HeldObjectState:
             )
 
 
-@dataclass(frozen=True, slots=True, eq=False)
-class CoordinatedHeldObjectState:
-    """Observed or projected relation for an object held by two manipulators."""
-
-    semantics: ObjectSemantics
-    left_object_to_eef: torch.Tensor
-    right_object_to_eef: torch.Tensor
-    left_grasp_xpos: torch.Tensor
-    right_grasp_xpos: torch.Tensor
-    env_mask: torch.Tensor | None = None
-
-    def __post_init__(self) -> None:
-        from .core import ObjectSemantics
-
-        if not isinstance(self.semantics, ObjectSemantics):
-            raise TypeError("semantics must be an ObjectSemantics instance.")
-        poses = {
-            "left_object_to_eef": self.left_object_to_eef,
-            "right_object_to_eef": self.right_object_to_eef,
-            "left_grasp_xpos": self.left_grasp_xpos,
-            "right_grasp_xpos": self.right_grasp_xpos,
-        }
-        batches = {_validate_pose(value, name) for name, value in poses.items()}
-        batches.discard(None)
-        if len(batches) > 1:
-            raise ValueError("Coordinated held-object poses must share a batch size.")
-        if len({value.device for value in poses.values()}) != 1:
-            raise ValueError("Coordinated held-object poses must share a device.")
-        if self.env_mask is not None:
-            mask_batch = int(self.env_mask.shape[0]) if self.env_mask.dim() == 1 else -1
-            batch_size = next(iter(batches), mask_batch)
-            object.__setattr__(
-                self,
-                "env_mask",
-                _normalize_mask(
-                    self.env_mask,
-                    batch_size=batch_size,
-                    device=self.left_object_to_eef.device,
-                    name="env_mask",
-                ),
-            )
-
-
 def _normalize_held(
     value: HeldObjectState,
     *,
@@ -209,48 +166,6 @@ def _normalize_held(
     )
 
 
-def _normalize_coordinated_held(
-    value: CoordinatedHeldObjectState,
-    *,
-    batch_size: int,
-    device: torch.device,
-) -> CoordinatedHeldObjectState:
-    """Normalize a coordinated relation to one task-state batch."""
-    return CoordinatedHeldObjectState(
-        semantics=value.semantics,
-        left_object_to_eef=_broadcast_pose(
-            value.left_object_to_eef,
-            batch_size=batch_size,
-            device=device,
-            name="CoordinatedHeldObjectState.left_object_to_eef",
-        ),
-        right_object_to_eef=_broadcast_pose(
-            value.right_object_to_eef,
-            batch_size=batch_size,
-            device=device,
-            name="CoordinatedHeldObjectState.right_object_to_eef",
-        ),
-        left_grasp_xpos=_broadcast_pose(
-            value.left_grasp_xpos,
-            batch_size=batch_size,
-            device=device,
-            name="CoordinatedHeldObjectState.left_grasp_xpos",
-        ),
-        right_grasp_xpos=_broadcast_pose(
-            value.right_grasp_xpos,
-            batch_size=batch_size,
-            device=device,
-            name="CoordinatedHeldObjectState.right_grasp_xpos",
-        ),
-        env_mask=_normalize_mask(
-            value.env_mask,
-            batch_size=batch_size,
-            device=device,
-            name="CoordinatedHeldObjectState.env_mask",
-        ),
-    )
-
-
 @dataclass(frozen=True, slots=True, eq=False)
 class TaskState:
     """Symbolic task state, separate from measured robot state."""
@@ -263,11 +178,6 @@ class TaskState:
 
     held_objects: Mapping[str, HeldObjectState] = field(default_factory=dict)
     """Single-manipulator held-object relations keyed by control resource."""
-
-    coordinated_held_objects: Mapping[tuple[str, str], CoordinatedHeldObjectState] = (
-        field(default_factory=dict)
-    )
-    """Two-manipulator held-object relations keyed by ordered resource pairs."""
 
     def __post_init__(self) -> None:
         if self.batch_size <= 0:
@@ -283,32 +193,8 @@ class TaskState:
                 value, batch_size=self.batch_size, device=device
             )
 
-        normalized_coordinated: dict[tuple[str, str], CoordinatedHeldObjectState] = {}
-        for resources, value in self.coordinated_held_objects.items():
-            if (
-                not isinstance(resources, tuple)
-                or len(resources) != 2
-                or not all(isinstance(item, str) and item for item in resources)
-            ):
-                raise TypeError(
-                    "coordinated_held_objects keys must be pairs of non-empty strings."
-                )
-            if not isinstance(value, CoordinatedHeldObjectState):
-                raise TypeError(
-                    "coordinated_held_objects values must be "
-                    "CoordinatedHeldObjectState objects."
-                )
-            normalized_coordinated[resources] = _normalize_coordinated_held(
-                value, batch_size=self.batch_size, device=device
-            )
-
         object.__setattr__(self, "device", device)
         object.__setattr__(self, "held_objects", MappingProxyType(normalized_held))
-        object.__setattr__(
-            self,
-            "coordinated_held_objects",
-            MappingProxyType(normalized_coordinated),
-        )
 
     @classmethod
     def empty(
@@ -331,14 +217,6 @@ class TaskState:
         """Return the object held by ``resource``, if any."""
         return self.held_objects.get(resource)
 
-    def get_coordinated_held_object(
-        self,
-        first_resource: str,
-        second_resource: str,
-    ) -> CoordinatedHeldObjectState | None:
-        """Return the relation for an ordered resource pair, if any."""
-        return self.coordinated_held_objects.get((first_resource, second_resource))
-
 
 @dataclass(frozen=True, slots=True, eq=False)
 class RobotObservation:
@@ -356,7 +234,7 @@ class RobotObservation:
             raise ValueError("RobotObservation.timestamp must be non-negative.")
         if not isinstance(self.qpos, torch.Tensor) or self.qpos.dim() != 2:
             raise ValueError(
-                "RobotObservation.qpos must have shape (n_envs, robot_dof)."
+                "RobotObservation.qpos must have shape (num_envs, robot_dof)."
             )
         if self.qpos.shape[0] == 0 or self.qpos.shape[1] == 0:
             raise ValueError("RobotObservation.qpos dimensions must be non-zero.")
@@ -609,24 +487,9 @@ class PlanningContext:
         """Single-resource held-object relations."""
         return self.task.held_objects
 
-    @property
-    def coordinated_held_objects(
-        self,
-    ) -> Mapping[tuple[str, str], CoordinatedHeldObjectState]:
-        """Coordinated held-object relations."""
-        return self.task.coordinated_held_objects
-
     def get_held_object(self, resource: str) -> HeldObjectState | None:
         """Return the object held by ``resource``, if any."""
         return self.task.get_held_object(resource)
-
-    def get_coordinated_held_object(
-        self,
-        first_resource: str,
-        second_resource: str,
-    ) -> CoordinatedHeldObjectState | None:
-        """Return a coordinated held-object relation, if any."""
-        return self.task.get_coordinated_held_object(first_resource, second_resource)
 
     def project(
         self,
@@ -652,7 +515,6 @@ class PlanningContext:
 
 
 __all__ = [
-    "CoordinatedHeldObjectState",
     "EntityState",
     "HeldObjectState",
     "PlanningContext",

--- a/embodichain/lab/sim/atomic_actions/trajectory_ops.py
+++ b/embodichain/lab/sim/atomic_actions/trajectory_ops.py
@@ -18,7 +18,6 @@
 
 from __future__ import annotations
 
-import numpy as np
 import torch
 
 from embodichain.lab.sim.planners import MoveType, PlanResult, PlanState
@@ -30,29 +29,29 @@ from .plans import TimedTrajectory, normalize_success_mask
 def resolve_pose_target(
     target: torch.Tensor,
     *,
-    n_envs: int,
+    num_envs: int,
     device: torch.device | str,
 ) -> torch.Tensor:
     """Validate and copy an end-effector target onto the planning device."""
     if not isinstance(target, torch.Tensor):
         raise TypeError(
-            f"target must be torch.Tensor of shape (4, 4), ({n_envs}, 4, 4), "
-            f"or ({n_envs}, n_waypoint, 4, 4)"
+            f"target must be torch.Tensor of shape (4, 4), ({num_envs}, 4, 4), "
+            f"or ({num_envs}, n_waypoint, 4, 4)"
         )
     target = target.to(device=device, dtype=torch.float32).clone()
     if target.shape == (4, 4):
-        target = target.unsqueeze(0).repeat(n_envs, 1, 1)
+        target = target.unsqueeze(0).repeat(num_envs, 1, 1)
     if target.dim() == 3:
-        if target.shape != (n_envs, 4, 4):
+        if target.shape != (num_envs, 4, 4):
             raise ValueError(
-                f"target tensor must have shape (4, 4) or ({n_envs}, 4, 4), "
+                f"target tensor must have shape (4, 4) or ({num_envs}, 4, 4), "
                 f"but got {target.shape}"
             )
     elif target.dim() == 4:
-        if target.shape[0] != n_envs or target.shape[2:] != (4, 4):
+        if target.shape[0] != num_envs or target.shape[2:] != (4, 4):
             raise ValueError(
                 "multi-waypoint target tensor must have shape "
-                f"({n_envs}, n_waypoint, 4, 4), but got {target.shape}"
+                f"({num_envs}, n_waypoint, 4, 4), but got {target.shape}"
             )
         if target.shape[1] == 0:
             raise ValueError(
@@ -61,8 +60,8 @@ def resolve_pose_target(
             )
     else:
         raise ValueError(
-            f"target tensor must be (4, 4), ({n_envs}, 4, 4), or "
-            f"({n_envs}, n_waypoint, 4, 4), but got {target.shape}"
+            f"target tensor must be (4, 4), ({num_envs}, 4, 4), or "
+            f"({num_envs}, n_waypoint, 4, 4), but got {target.shape}"
         )
     return target
 
@@ -70,7 +69,7 @@ def resolve_pose_target(
 def resolve_joint_target(
     target_qpos: torch.Tensor,
     *,
-    n_envs: int,
+    num_envs: int,
     joint_dof: int,
     control_part: str,
     device: torch.device | str,
@@ -79,23 +78,23 @@ def resolve_joint_target(
     if not isinstance(target_qpos, torch.Tensor):
         raise TypeError(
             f"target qpos for '{control_part}' must be a torch.Tensor with shape "
-            f"({joint_dof},), ({n_envs}, {joint_dof}), or "
-            f"({n_envs}, n_waypoint, {joint_dof})"
+            f"({joint_dof},), ({num_envs}, {joint_dof}), or "
+            f"({num_envs}, n_waypoint, {joint_dof})"
         )
     target_qpos = target_qpos.to(device=device, dtype=torch.float32).clone()
     if target_qpos.shape == (joint_dof,):
-        target_qpos = target_qpos.unsqueeze(0).repeat(n_envs, 1)
+        target_qpos = target_qpos.unsqueeze(0).repeat(num_envs, 1)
     if target_qpos.dim() == 2:
-        if target_qpos.shape != (n_envs, joint_dof):
+        if target_qpos.shape != (num_envs, joint_dof):
             raise ValueError(
                 f"target qpos for '{control_part}' must have shape ({joint_dof},) "
-                f"or ({n_envs}, {joint_dof}), but got {target_qpos.shape}"
+                f"or ({num_envs}, {joint_dof}), but got {target_qpos.shape}"
             )
     elif target_qpos.dim() == 3:
-        if target_qpos.shape[0] != n_envs or target_qpos.shape[2] != joint_dof:
+        if target_qpos.shape[0] != num_envs or target_qpos.shape[2] != joint_dof:
             raise ValueError(
                 f"multi-waypoint target qpos for '{control_part}' must have shape "
-                f"({n_envs}, n_waypoint, {joint_dof}), but got {target_qpos.shape}"
+                f"({num_envs}, n_waypoint, {joint_dof}), but got {target_qpos.shape}"
             )
         if target_qpos.shape[1] == 0:
             raise ValueError(
@@ -182,7 +181,7 @@ def split_three_segments(
     third_segment_name: str = "third",
 ) -> tuple[int, int, int]:
     """Split a sample budget into motion, hand, and motion segments."""
-    first = int(np.round(sample_count - hand_interp_steps) * first_segment_ratio)
+    first = int((sample_count - hand_interp_steps) * first_segment_ratio)
     if first < 2:
         raise ValueError(
             f"Not enough waypoints for {first_segment_name} trajectory. "
@@ -291,7 +290,7 @@ def to_full_robot_trajectory(
     )
     success = normalize_success_mask(
         result.success,
-        n_envs=base_qpos.shape[0],
+        num_envs=base_qpos.shape[0],
         device=base_qpos.device,
         name="PlanResult.success",
     )

--- a/embodichain/lab/sim/objects/robot.py
+++ b/embodichain/lab/sim/objects/robot.py
@@ -775,7 +775,7 @@ class Robot(Articulation):
         The output pose will be in the local arena frame.
 
         Args:
-            qpos (torch.Tensor | np.ndarray | None): Joint positions of the robot, (n_envs, num_joints).
+            qpos (torch.Tensor | np.ndarray | None): Joint positions of the robot, (num_envs, num_joints).
             name (str | None): The name of the control part to compute the FK for. If None, the default part is used.
             link_names (List[str] | None): The names of the links to compute the FK for. If None, all links are used.
             end_link_name (str | None): The name of the end link to compute the FK for. If None, the default end link is used.
@@ -784,7 +784,7 @@ class Robot(Articulation):
             to_matrix (bool): If True, returns the transformation in the form of a 4x4 matrix.
 
         Returns:
-            torch.Tensor: The forward kinematics result with shape (n_envs, 7) or (n_envs, 4, 4) if `to_matrix` is True.
+            torch.Tensor: The forward kinematics result with shape (num_envs, 7) or (num_envs, 4, 4) if `to_matrix` is True.
         """
         local_env_ids = self._all_indices if env_ids is None else env_ids
 
@@ -848,15 +848,15 @@ class Robot(Articulation):
         The input pose should be in the local arena frame.
 
         Args:
-            pose (torch.Tensor): The end effector pose of the robot, (n_envs, 7) or (n_envs, 4, 4).
-            joint_seed (torch.Tensor | None): The joint positions to use as a seed for the IK computation, (n_envs, dof).
+            pose (torch.Tensor): The end effector pose of the robot, (num_envs, 7) or (num_envs, 4, 4).
+            joint_seed (torch.Tensor | None): The joint positions to use as a seed for the IK computation, (num_envs, dof).
                 If None, the zero joint positions will be used as the seed.
             name (str | None): The name of the control part to compute the IK for. If None, the default part is used.
             env_ids (Sequence[int] | None): Environment indices to apply the positions. Defaults to all environments.
             return_all_solutions (bool): Whether to return all IK solutions or just the best one. Defaults to False.
 
         Returns:
-            Tuple[torch.Tensor, torch.Tensor] | None: The success Tensor with shape (n_envs, ) and qpos Tensor with shape (n_envs, max_results, dof), or None if solver not found.
+            Tuple[torch.Tensor, torch.Tensor] | None: The success Tensor with shape (num_envs, ) and qpos Tensor with shape (num_envs, max_results, dof), or None if solver not found.
         """
         local_env_ids = self._all_indices if env_ids is None else env_ids
 
@@ -926,13 +926,13 @@ class Robot(Articulation):
         The output pose will be in the local arena frame.
 
         Args:
-            qpos (torch.Tensor | np.ndarray | None): Joint positions of the robot, (n_envs, n_batch, num_joints).
+            qpos (torch.Tensor | np.ndarray | None): Joint positions of the robot, (num_envs, n_batch, num_joints).
             name (str | None): The name of the control part to compute the FK for. If None, the default part is used.
             env_ids (Sequence[int] | None): The environment ids to compute the FK for. If None, all environments are used.
             to_matrix (bool): If True, returns the transformation in the form of a 4x4 matrix.
 
         Returns:
-            torch.Tensor: The forward kinematics result with shape (n_envs, batch, 7) or (n_envs, batch, 4, 4) if `to_matrix` is True.
+            torch.Tensor: The forward kinematics result with shape (num_envs, batch, 7) or (num_envs, batch, 4, 4) if `to_matrix` is True.
         """
         local_env_ids = self._all_indices if env_ids is None else env_ids
         if not self._solvers:
@@ -992,15 +992,15 @@ class Robot(Articulation):
         The input pose should be in the local arena frame.
 
         Args:
-            pose (torch.Tensor): The end effector pose of the robot, (n_envs, n_batch, 7) or (n_envs, n_batch, 4, 4).
-            joint_seed (torch.Tensor | None): The joint positions to use as a seed for the IK computation, (n_envs, n_batch, dof). If None, the zero joint positions will be used as the seed.
+            pose (torch.Tensor): The end effector pose of the robot, (num_envs, n_batch, 7) or (num_envs, n_batch, 4, 4).
+            joint_seed (torch.Tensor | None): The joint positions to use as a seed for the IK computation, (num_envs, n_batch, dof). If None, the zero joint positions will be used as the seed.
             name (str | None): The name of the control part to compute the IK for. If None, the default part is used.
             env_ids (Sequence[int] | None): Environment indices to apply the positions. Defaults to all environments.
 
         Returns:
             Tuple[torch.Tensor, torch.Tensor]:
-                Success Tensor with shape (n_envs, n_batch)
-                Qpos Tensor with shape (n_envs, n_batch, dof).
+                Success Tensor with shape (num_envs, n_batch)
+                Qpos Tensor with shape (num_envs, n_batch, dof).
         """
         local_env_ids = self._all_indices if env_ids is None else env_ids
 
@@ -1042,7 +1042,7 @@ class Robot(Articulation):
             )
 
         if pose.shape[-1] == 7 and pose.dim() == 3:
-            # Convert pose from (n_envs, n_batch, 7) to (n_envs * n_batch, 4, 4)
+            # Convert pose from (num_envs, n_batch, 7) to (num_envs * n_batch, 4, 4)
             pose_batch = pose.reshape(-1, 7)
             pos = pose_batch[:, :3]
             quat = pose_batch[:, 3:]
@@ -1055,7 +1055,7 @@ class Robot(Articulation):
             pose_batch[:, :3, :3] = rot
             pose_batch[:, :3, 3] = pos
         else:
-            # Convert pose from (n_envs, n_batch, 4, 4) to (n_envs * n_batch, 4, 4)
+            # Convert pose from (num_envs, n_batch, 4, 4) to (num_envs * n_batch, 4, 4)
             pose_batch = pose.reshape(-1, 4, 4)
 
         # get xpos from link root

--- a/embodichain/lab/sim/planners/motion_generator.py
+++ b/embodichain/lab/sim/planners/motion_generator.py
@@ -486,7 +486,7 @@ class MotionGenerator:
             )
             step_success = normalize_success_mask(
                 step_success,
-                n_envs=batch_size,
+                num_envs=batch_size,
                 device=device,
                 name=f"IK success for target state {index}",
             )
@@ -550,7 +550,7 @@ class MotionGenerator:
 
         success = normalize_success_mask(
             result.success,
-            n_envs=batch_size,
+            num_envs=batch_size,
             device=device,
             name="MotionGenerator PlanResult.success",
         )

--- a/embodichain/lab/sim/planners/utils.py
+++ b/embodichain/lab/sim/planners/utils.py
@@ -41,15 +41,15 @@ __all__ = [
 def normalize_success_mask(
     success: bool | torch.Tensor,
     *,
-    n_envs: int,
+    num_envs: int,
     device: torch.device | str,
     name: str,
 ) -> torch.Tensor:
-    """Normalize a scalar or batched success value to ``(n_envs,)``.
+    """Normalize a scalar or batched success value to ``(num_envs,)``.
 
     Args:
         success: Scalar success or a boolean/binary-integer tensor.
-        n_envs: Required batch size.
+        num_envs: Required batch size.
         device: Device of the resulting tensor.
         name: Human-readable value name used in validation errors.
 
@@ -64,7 +64,9 @@ def normalize_success_mask(
     if resolved_device.type == "cuda" and resolved_device.index is None:
         resolved_device = torch.device(f"cuda:{torch.cuda.current_device()}")
     if isinstance(success, bool):
-        return torch.full((n_envs,), success, dtype=torch.bool, device=resolved_device)
+        return torch.full(
+            (num_envs,), success, dtype=torch.bool, device=resolved_device
+        )
     if not isinstance(success, torch.Tensor):
         raise TypeError(
             f"{name} must be a bool or torch.Tensor, got {type(success).__name__}."
@@ -87,10 +89,10 @@ def normalize_success_mask(
             )
         success = success.to(dtype=torch.bool)
     if success.dim() == 0 or success.shape == (1,):
-        success = success.reshape(1).expand(n_envs)
-    if success.shape != (n_envs,):
+        success = success.reshape(1).expand(num_envs)
+    if success.shape != (num_envs,):
         raise ValueError(
-            f"{name} must have shape ({n_envs},), got {tuple(success.shape)}."
+            f"{name} must have shape ({num_envs},), got {tuple(success.shape)}."
         )
     return success.clone()
 

--- a/embodichain/lab/sim/workspace/analyzer.py
+++ b/embodichain/lab/sim/workspace/analyzer.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
+from __future__ import annotations
+
 import time
 import torch
 import numpy as np
@@ -962,7 +964,7 @@ class WorkspaceAnalyzer:
         for batch_start in pbar:
             batch_end = min(batch_start + batch_size, num_samples)
 
-            # Reshape to (n_envs=1, batch_size, num_joints) for compute_batch_fk
+            # Reshape to (num_envs=1, batch_size, num_joints) for compute_batch_fk
             qpos_batch = joint_configs[batch_start:batch_end].unsqueeze(0)
 
             try:

--- a/embodichain/learning/rl/algo/grpo.py
+++ b/embodichain/learning/rl/algo/grpo.py
@@ -68,21 +68,21 @@ class GRPO(BaseAlgorithm[TensorDict]):
         self, rewards: torch.Tensor, dones: torch.Tensor
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Compute discounted returns and valid-step mask over `[N, T]` rollout."""
-        n_envs, t_steps = rewards.shape
+        num_envs, t_steps = rewards.shape
         seq_mask = torch.ones(
-            (n_envs, t_steps), dtype=torch.float32, device=self.device
+            (num_envs, t_steps), dtype=torch.float32, device=self.device
         )
         step_returns = torch.zeros(
-            (n_envs, t_steps), dtype=torch.float32, device=self.device
+            (num_envs, t_steps), dtype=torch.float32, device=self.device
         )
 
-        alive = torch.ones(n_envs, dtype=torch.float32, device=self.device)
+        alive = torch.ones(num_envs, dtype=torch.float32, device=self.device)
         for t in range(t_steps):
             seq_mask[:, t] = alive
             if self.cfg.truncate_at_first_done:
                 alive = alive * (~dones[:, t]).float()
 
-        running_return = torch.zeros(n_envs, dtype=torch.float32, device=self.device)
+        running_return = torch.zeros(num_envs, dtype=torch.float32, device=self.device)
         for t in reversed(range(t_steps)):
             running_return = (
                 rewards[:, t] + self.cfg.gamma * running_return * (~dones[:, t]).float()
@@ -95,11 +95,11 @@ class GRPO(BaseAlgorithm[TensorDict]):
         self, step_returns: torch.Tensor, seq_mask: torch.Tensor
     ) -> torch.Tensor:
         """Normalize per-step returns within each environment group."""
-        n_envs, t_steps = step_returns.shape
+        num_envs, t_steps = step_returns.shape
         group_size = self.cfg.group_size
 
-        returns_grouped = step_returns.view(n_envs // group_size, group_size, t_steps)
-        mask_grouped = seq_mask.view(n_envs // group_size, group_size, t_steps)
+        returns_grouped = step_returns.view(num_envs // group_size, group_size, t_steps)
+        mask_grouped = seq_mask.view(num_envs // group_size, group_size, t_steps)
 
         valid_count = mask_grouped.sum(dim=1, keepdim=True)
         valid_count_safe = torch.clamp(valid_count, min=1.0)
@@ -112,7 +112,7 @@ class GRPO(BaseAlgorithm[TensorDict]):
         group_std = torch.sqrt(group_var)
 
         advantages = (returns_grouped - group_mean) / (group_std + self.cfg.eps)
-        return advantages.view(n_envs, t_steps) * seq_mask
+        return advantages.view(num_envs, t_steps) * seq_mask
 
     def update(self, rollout: TensorDict) -> Dict[str, float]:
         rollout = rollout.clone()

--- a/examples/sim/demo/grasp_cup_to_caffe.py
+++ b/examples/sim/demo/grasp_cup_to_caffe.py
@@ -257,7 +257,7 @@ def create_trajectory(
         caffe (Robot): The caffe object.
 
     Returns:
-        torch.Tensor: Interpolated trajectory of shape [n_envs, n_waypoint, dof].
+        torch.Tensor: Interpolated trajectory of shape [num_envs, n_waypoint, dof].
     """
     right_arm_ids = robot.get_joint_ids("right_arm")
     hand_open_qpos = torch.tensor(
@@ -274,7 +274,7 @@ def create_trajectory(
     cup_position = cup.get_local_pose(to_matrix=True)[:, :3, 3]
 
     # grasp cup waypoint generation
-    rest_right_qpos = robot.get_qpos()[:, right_arm_ids]  # [n_envs, dof]
+    rest_right_qpos = robot.get_qpos()[:, right_arm_ids]  # [num_envs, dof]
     right_arm_xpos = robot.compute_fk(
         qpos=rest_right_qpos, name="right_arm", to_matrix=True
     )
@@ -324,7 +324,7 @@ def create_trajectory(
         pose=place_down_pose, joint_seed=place_up_qpos, name="right_arm"
     )
 
-    n_envs = sim.num_envs
+    num_envs = sim.num_envs
 
     # combine hand and arm trajectory
     arm_trajectory = torch.cat(
@@ -344,21 +344,21 @@ def create_trajectory(
     )
     hand_trajectory = torch.cat(
         [
-            hand_open_qpos[None, None, :].repeat(n_envs, 1, 1),
-            hand_open_qpos[None, None, :].repeat(n_envs, 1, 1),
-            hand_open_qpos[None, None, :].repeat(n_envs, 1, 1),
-            hand_close_qpos[None, None, :].repeat(n_envs, 1, 1),
-            hand_close_qpos[None, None, :].repeat(n_envs, 1, 1),
-            hand_close_qpos[None, None, :].repeat(n_envs, 1, 1),
-            hand_close_qpos[None, None, :].repeat(n_envs, 1, 1),
-            hand_open_qpos[None, None, :].repeat(n_envs, 1, 1),
-            hand_open_qpos[None, None, :].repeat(n_envs, 1, 1),
-            hand_open_qpos[None, None, :].repeat(n_envs, 1, 1),
+            hand_open_qpos[None, None, :].repeat(num_envs, 1, 1),
+            hand_open_qpos[None, None, :].repeat(num_envs, 1, 1),
+            hand_open_qpos[None, None, :].repeat(num_envs, 1, 1),
+            hand_close_qpos[None, None, :].repeat(num_envs, 1, 1),
+            hand_close_qpos[None, None, :].repeat(num_envs, 1, 1),
+            hand_close_qpos[None, None, :].repeat(num_envs, 1, 1),
+            hand_close_qpos[None, None, :].repeat(num_envs, 1, 1),
+            hand_open_qpos[None, None, :].repeat(num_envs, 1, 1),
+            hand_open_qpos[None, None, :].repeat(num_envs, 1, 1),
+            hand_open_qpos[None, None, :].repeat(num_envs, 1, 1),
         ],
         dim=1,
     )
     all_trajectory = torch.cat([arm_trajectory, hand_trajectory], dim=-1)
-    # trajetory with shape [n_envs, n_waypoint, dof]
+    # trajetory with shape [num_envs, n_waypoint, dof]
     interp_trajectory = interpolate_with_distance(
         trajectory=all_trajectory, interp_num=150, device=sim.device
     )
@@ -377,7 +377,7 @@ def run_simulation(
         cup (RigidObject): The cup object.
         caffe (Robot): The caffe object.
     """
-    # [n_envs, n_waypoint, dof]
+    # [num_envs, n_waypoint, dof]
     interp_trajectory = create_trajectory(sim, robot, cup, caffe)
 
     right_arm_ids = robot.get_joint_ids("right_arm")

--- a/examples/sim/demo/pick_up_cloth.py
+++ b/examples/sim/demo/pick_up_cloth.py
@@ -193,7 +193,7 @@ def create_cloth(sim: SimulationManager):
 
 
 def get_grasp_traj(sim: SimulationManager, robot: Robot, grasp_xpos: torch.Tensor):
-    n_envs = sim.num_envs
+    num_envs = sim.num_envs
     rest_arm_qpos = robot.get_qpos("arm")
 
     approach_xpos = grasp_xpos.clone()
@@ -222,12 +222,12 @@ def get_grasp_traj(sim: SimulationManager, robot: Robot, grasp_xpos: torch.Tenso
     )
     hand_trajectory = torch.cat(
         [
-            hand_open_qpos[None, None, :].repeat(n_envs, 1, 1),
-            hand_open_qpos[None, None, :].repeat(n_envs, 1, 1),
-            hand_open_qpos[None, None, :].repeat(n_envs, 1, 1),
-            hand_close_qpos[None, None, :].repeat(n_envs, 1, 1),
-            hand_close_qpos[None, None, :].repeat(n_envs, 1, 1),
-            hand_close_qpos[None, None, :].repeat(n_envs, 1, 1),
+            hand_open_qpos[None, None, :].repeat(num_envs, 1, 1),
+            hand_open_qpos[None, None, :].repeat(num_envs, 1, 1),
+            hand_open_qpos[None, None, :].repeat(num_envs, 1, 1),
+            hand_close_qpos[None, None, :].repeat(num_envs, 1, 1),
+            hand_close_qpos[None, None, :].repeat(num_envs, 1, 1),
+            hand_close_qpos[None, None, :].repeat(num_envs, 1, 1),
         ],
         dim=1,
     )

--- a/scripts/tutorials/atomic_action/assemble.py
+++ b/scripts/tutorials/atomic_action/assemble.py
@@ -269,12 +269,12 @@ def run_assemble_demo(
     cube_pose = cube.get_local_pose(to_matrix=True)
     assemble_object_target_pose = cube_pose[0] @ assemble_to_base
 
-    n_envs = robot.get_qpos().shape[0]
+    num_envs = robot.get_qpos().shape[0]
     if not args.no_vis_eef_axis:
         draw_axis_marker(
             sim,
             "assemble_target_axis",
-            broadcast_pose_batch(assemble_object_target_pose, n_envs),
+            broadcast_pose_batch(assemble_object_target_pose, num_envs),
         )
 
     # Step 1 - the left arm picks the soda can up by its top part.

--- a/scripts/tutorials/atomic_action/coordinated_pickment.py
+++ b/scripts/tutorials/atomic_action/coordinated_pickment.py
@@ -372,7 +372,7 @@ def run_coordinated_pickment_demo(
     object_pose_batch = clone_local_pose_from_first_env(obj)
     obj.clear_dynamics()
     object_pose = object_pose_batch[0].to(device=sim.device, dtype=torch.float32)
-    n_envs = object_pose_batch.shape[0]
+    num_envs = object_pose_batch.shape[0]
     object_vertices = get_local_vertices(obj)
     object_semantics = create_antipodal_semantics(
         obj,
@@ -424,12 +424,12 @@ def run_coordinated_pickment_demo(
     )
     log_scene_targets(preset.label, object_pose, target_pose)
     if not args.no_vis_eef_axis:
-        draw_pickment_target_axes(sim, target_pose, num_envs=n_envs)
+        draw_pickment_target_axes(sim, target_pose, num_envs=num_envs)
 
     pickment_target = CoordinatedPickGoal(
         semantics=object_semantics,
-        object_target_pose=broadcast_pose_batch(target_pose, num_envs=n_envs),
-        object_initial_pose=broadcast_pose_batch(object_pose, num_envs=n_envs),
+        object_target_pose=broadcast_pose_batch(target_pose, num_envs=num_envs),
+        object_initial_pose=broadcast_pose_batch(object_pose, num_envs=num_envs),
     )
 
     wait_for_user = prepare_tutorial_scene(

--- a/scripts/tutorials/atomic_action/coordinated_placement.py
+++ b/scripts/tutorials/atomic_action/coordinated_placement.py
@@ -548,7 +548,7 @@ def run_coordinated_placement_demo(
     pan.clear_dynamics()
     bread_pose = bread_pose_batch[0].to(device=sim.device, dtype=torch.float32)
     pan_pose = pan_pose_batch[0].to(device=sim.device, dtype=torch.float32)
-    n_envs = bread_pose_batch.shape[0]
+    num_envs = bread_pose_batch.shape[0]
     bread_vertices = get_local_vertices(bread)
     pan_vertices = get_local_vertices(pan)
     bread_local_min, bread_local_max = compute_local_bounds(bread_vertices)
@@ -625,7 +625,7 @@ def run_coordinated_placement_demo(
             skill_id="pick_up",
             goal=GraspGoal(
                 semantics=bread_semantics,
-                grasp_xpos=broadcast_pose_batch(bread_grasp_pose, num_envs=n_envs),
+                grasp_xpos=broadcast_pose_batch(bread_grasp_pose, num_envs=num_envs),
             ),
             binding=ActionBinding(
                 manipulators={"primary": "left_arm"},
@@ -638,7 +638,7 @@ def run_coordinated_placement_demo(
             skill_id="pick_up",
             goal=GraspGoal(
                 semantics=pan_semantics,
-                grasp_xpos=broadcast_pose_batch(pan_grasp_pose, num_envs=n_envs),
+                grasp_xpos=broadcast_pose_batch(pan_grasp_pose, num_envs=num_envs),
             ),
             binding=ActionBinding(
                 manipulators={"primary": "right_arm"},
@@ -748,7 +748,6 @@ def run_coordinated_placement_demo(
                 batch_size=state.batch_size,
                 device=state.robot.qpos.device,
                 held_objects=held_objects,
-                coordinated_held_objects=state.task.coordinated_held_objects,
             ),
         )
 
@@ -771,14 +770,14 @@ def run_coordinated_placement_demo(
             sim,
             support_target_pose,
             placing_target_pose,
-            num_envs=n_envs,
+            num_envs=num_envs,
         )
     coordinated_target = CoordinatedPlacementGoal(
         placing_object_target_pose=broadcast_pose_batch(
-            placing_target_pose, num_envs=n_envs
+            placing_target_pose, num_envs=num_envs
         ),
         support_object_target_pose=broadcast_pose_batch(
-            support_target_pose, num_envs=n_envs
+            support_target_pose, num_envs=num_envs
         ),
         placing_height_offset=BREAD_TARGET_HEIGHT_OFFSET,
         support_height_offset=SUPPORT_TARGET_HEIGHT_OFFSET,
@@ -835,7 +834,7 @@ def run_coordinated_placement_demo(
             sim,
             support_target_pose,
             placing_target_pose,
-            num_envs=n_envs,
+            num_envs=num_envs,
         )
     if wait_for_user:
         input("Press Enter to execute coordinated placement...")

--- a/scripts/tutorials/atomic_action/move_end_effector.py
+++ b/scripts/tutorials/atomic_action/move_end_effector.py
@@ -80,13 +80,13 @@ def main() -> None:
             make_top_down_eef_pose(torch.tensor([0.45, 0.10, 0.30], device=sim.device)),
         ]
     )
-    n_envs = robot.get_qpos().shape[0]
+    num_envs = robot.get_qpos().shape[0]
     if not args.no_vis_eef_axis:
         for name, pose in zip(("target", "side"), poses, strict=True):
             draw_axis_marker(
                 sim,
                 f"move_end_effector_{name}_axis",
-                broadcast_pose_batch(pose, num_envs=n_envs),
+                broadcast_pose_batch(pose, num_envs=num_envs),
             )
     wait_for_user = prepare_tutorial_scene(
         sim, args, "Inspect the robot, then press Enter to plan MoveEndEffector..."
@@ -96,7 +96,9 @@ def main() -> None:
         (
             ActionInvocation(
                 skill_id="move_end_effector",
-                goal=EndEffectorPoseGoal(broadcast_waypoint_pose_batch(poses, n_envs)),
+                goal=EndEffectorPoseGoal(
+                    broadcast_waypoint_pose_batch(poses, num_envs)
+                ),
                 binding=ActionBinding(manipulators={"primary": "arm"}),
                 motion_policy=MotionPolicy(sample_count=MOVE_SAMPLE_INTERVAL),
             ),

--- a/scripts/tutorials/atomic_action/move_held_object.py
+++ b/scripts/tutorials/atomic_action/move_held_object.py
@@ -139,9 +139,9 @@ def main() -> None:
     )
     move_position = obj.get_local_pose(to_matrix=True)[0, :3, 3].clone()
     move_position[2] = 0.36
-    n_envs = robot.get_qpos().shape[0]
-    move_target = broadcast_pose_batch(make_eef_pose_at(robot, move_position), n_envs)
-    object_target = broadcast_pose_batch(make_object_target_pose(sim.device), n_envs)
+    num_envs = robot.get_qpos().shape[0]
+    move_target = broadcast_pose_batch(make_eef_pose_at(robot, move_position), num_envs)
+    object_target = broadcast_pose_batch(make_object_target_pose(sim.device), num_envs)
     if not args.no_vis_eef_axis:
         draw_axis_marker(sim, "move_held_object_target_axis", object_target)
     wait_for_user = prepare_tutorial_scene(

--- a/scripts/tutorials/atomic_action/press.py
+++ b/scripts/tutorials/atomic_action/press.py
@@ -174,9 +174,11 @@ def main() -> None:
     press_position[2] += 0.5 * BLOCK_SIZE[2] + PRESS_SURFACE_OFFSET
     move_position = press_position.clone()
     move_position[2] += PRESS_CLEARANCE - PRESS_SURFACE_OFFSET
-    n_envs = robot.get_qpos().shape[0]
-    move_target = broadcast_pose_batch(make_top_down_eef_pose(move_position), n_envs)
-    press_target = broadcast_pose_batch(make_top_down_eef_pose(press_position), n_envs)
+    num_envs = robot.get_qpos().shape[0]
+    move_target = broadcast_pose_batch(make_top_down_eef_pose(move_position), num_envs)
+    press_target = broadcast_pose_batch(
+        make_top_down_eef_pose(press_position), num_envs
+    )
     if not args.no_vis_eef_axis:
         draw_axis_marker(sim, "press_target_axis", press_target)
     wait_for_user = prepare_tutorial_scene(

--- a/scripts/tutorials/atomic_action/tutorial_utils.py
+++ b/scripts/tutorials/atomic_action/tutorial_utils.py
@@ -368,7 +368,7 @@ def make_eef_pose_at(robot: Robot, position: torch.Tensor) -> torch.Tensor:
 
     Args:
         robot: Robot whose current arm pose supplies the orientation.
-        position: Position tensor with shape ``(3,)`` or ``(n_envs, 3)``.
+        position: Position tensor with shape ``(3,)`` or ``(num_envs, 3)``.
 
     Returns:
         A single or batched homogeneous pose matching ``position``.
@@ -509,7 +509,7 @@ def replay_trajectory(
         sim: Simulation manager to step and record.
         robot: Robot receiving full-DOF trajectory positions.
         trajectory: Timed full-robot trajectory, or a legacy position tensor
-            with shape ``(n_envs, n_steps, dof)``.
+            with shape ``(num_envs, n_steps, dof)``.
         args: Parsed tutorial arguments controlling auto-play recording.
         video_prefix: Output video filename prefix.
         hold_steps: Number of final-pose simulation updates after the trajectory.
@@ -682,14 +682,14 @@ def draw_axis_marker(
 ) -> None:
     """Draw a named coordinate-frame marker for a semantic tutorial target."""
     arena_offsets = sim.arena_offsets
-    n_envs = arena_offsets.shape[0]
+    num_envs = arena_offsets.shape[0]
 
     # Normalize a single (4, 4) pose to (1, 4, 4) so it is not mistaken for a
     # per-environment batch when num_envs happens to equal 4.
     if xpos.dim() == 2:
         xpos = xpos.unsqueeze(0)
 
-    if n_envs == xpos.shape[0]:
+    if num_envs == xpos.shape[0]:
         # add arena offsets to xpos
         draw_xpos = xpos.clone()
         draw_xpos[:, :3, 3] += arena_offsets

--- a/scripts/tutorials/grasp/grasp_generator.py
+++ b/scripts/tutorials/grasp/grasp_generator.py
@@ -171,7 +171,7 @@ def create_obj(sim: SimulationManager):
 
 
 def get_grasp_traj(sim: SimulationManager, robot: Robot, grasp_xpos: torch.Tensor):
-    n_envs = sim.num_envs
+    num_envs = sim.num_envs
     rest_arm_qpos = robot.get_qpos("arm")
 
     approach_xpos = grasp_xpos.clone()
@@ -201,12 +201,12 @@ def get_grasp_traj(sim: SimulationManager, robot: Robot, grasp_xpos: torch.Tenso
     )
     hand_trajectory = torch.cat(
         [
-            hand_open_qpos[None, None, :].repeat(n_envs, 1, 1),
-            hand_open_qpos[None, None, :].repeat(n_envs, 1, 1),
-            hand_open_qpos[None, None, :].repeat(n_envs, 1, 1),
-            hand_close_qpos[None, None, :].repeat(n_envs, 1, 1),
-            hand_close_qpos[None, None, :].repeat(n_envs, 1, 1),
-            hand_close_qpos[None, None, :].repeat(n_envs, 1, 1),
+            hand_open_qpos[None, None, :].repeat(num_envs, 1, 1),
+            hand_open_qpos[None, None, :].repeat(num_envs, 1, 1),
+            hand_open_qpos[None, None, :].repeat(num_envs, 1, 1),
+            hand_close_qpos[None, None, :].repeat(num_envs, 1, 1),
+            hand_close_qpos[None, None, :].repeat(num_envs, 1, 1),
+            hand_close_qpos[None, None, :].repeat(num_envs, 1, 1),
         ],
         dim=1,
     )

--- a/tests/sim/atomic_actions/test_actions.py
+++ b/tests/sim/atomic_actions/test_actions.py
@@ -70,6 +70,7 @@ from embodichain.lab.sim.atomic_actions import (
     SceneSnapshot,
     TaskState,
 )
+from embodichain.lab.sim.common import BatchEntity
 from embodichain.lab.sim.planners import (
     MotionGenerator,
     MoveType,
@@ -269,7 +270,7 @@ def _invocation(
 
 
 def _semantics() -> ObjectSemantics:
-    entity = Mock()
+    entity = Mock(spec=BatchEntity)
     entity.get_local_pose.return_value = torch.eye(4).repeat(NUM_ENVS, 1, 1)
     return ObjectSemantics(
         affordance=Affordance(),
@@ -279,12 +280,17 @@ def _semantics() -> ObjectSemantics:
     )
 
 
-def _held(semantics: ObjectSemantics | None = None) -> HeldObjectState:
+def _held(
+    semantics: ObjectSemantics | None = None,
+    *,
+    env_mask: torch.Tensor | None = None,
+) -> HeldObjectState:
     poses = torch.eye(4).repeat(NUM_ENVS, 1, 1)
     return HeldObjectState(
         semantics=semantics or _semantics(),
         object_to_eef=poses,
         grasp_xpos=poses,
+        env_mask=env_mask,
     )
 
 
@@ -546,6 +552,51 @@ def test_pick_and_place_declare_effects_without_mutating_context() -> None:
     assert placed_task.get_held_object("arm") is None
 
 
+def test_place_releases_only_exclusively_held_rows() -> None:
+    generator = _motion_generator()
+
+    def move_ik(
+        pose: torch.Tensor,
+        name: str,
+        joint_seed: torch.Tensor,
+        **_: object,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return torch.ones(NUM_ENVS, dtype=torch.bool), joint_seed + 0.1
+
+    generator.robot.compute_ik.side_effect = move_ik
+    action = _bind_action(generator, Place())
+    semantics = _semantics()
+    task = TaskState(
+        batch_size=NUM_ENVS,
+        device="cpu",
+        held_objects={
+            "arm": _held(semantics),
+            "alternate_arm": _held(
+                semantics,
+                env_mask=torch.tensor([True, False]),
+            ),
+        },
+    )
+    context = _context(task)
+
+    plan = _plan_action(
+        action,
+        _invocation("place", PlaceGoal(torch.eye(4))),
+        context,
+    )
+    projected = plan.expected_effects.apply(task, plan.plan_success)
+
+    assert plan.plan_success.tolist() == [False, True]
+    assert torch.allclose(
+        plan.trajectory.positions[0],
+        context.robot.qpos[0].unsqueeze(0).expand(plan.trajectory.waypoint_count, -1),
+    )
+    primary = projected.get_held_object("arm")
+    alternate = projected.get_held_object("alternate_arm")
+    assert primary is not None and primary.env_mask.tolist() == [True, False]
+    assert alternate is not None and alternate.env_mask.tolist() == [True, False]
+
+
 def test_move_held_object_requires_projected_attachment() -> None:
     generator = _motion_generator()
     action = _bind_action(generator, MoveHeldObject())
@@ -567,6 +618,47 @@ def test_move_held_object_requires_projected_attachment() -> None:
     plan = _plan_action(action, invocation, _context(task))
     assert plan.plan_success.all()
     assert plan.expected_effects.is_empty
+
+
+def test_move_held_object_moves_only_exclusively_held_rows() -> None:
+    generator = _motion_generator()
+
+    def move_ik(
+        pose: torch.Tensor,
+        name: str,
+        joint_seed: torch.Tensor,
+        **_: object,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return torch.ones(NUM_ENVS, dtype=torch.bool), joint_seed + 0.1
+
+    generator.robot.compute_ik.side_effect = move_ik
+    action = _bind_action(generator, MoveHeldObject())
+    semantics = _semantics()
+    task = TaskState(
+        batch_size=NUM_ENVS,
+        device="cpu",
+        held_objects={
+            "arm": _held(semantics),
+            "alternate_arm": _held(
+                semantics,
+                env_mask=torch.tensor([True, False]),
+            ),
+        },
+    )
+    context = _context(task)
+
+    plan = _plan_action(
+        action,
+        _invocation("move_held_object", HeldObjectPoseGoal(torch.eye(4))),
+        context,
+    )
+
+    assert plan.plan_success.tolist() == [False, True]
+    assert torch.allclose(
+        plan.trajectory.positions[0],
+        context.robot.qpos[0].unsqueeze(0).expand(plan.trajectory.waypoint_count, -1),
+    )
+    assert not torch.allclose(plan.trajectory.positions[1], context.robot.qpos[1])
 
 
 def test_press_uses_invocation_sample_budget() -> None:
@@ -1089,6 +1181,61 @@ def test_handover_holds_only_environment_with_ik_failure() -> None:
     assert received.env_mask.tolist() == [True, False]
 
 
+def test_handover_transfers_only_exclusively_held_rows() -> None:
+    generator = _dual_motion_generator()
+    semantics = _semantics()
+    task = TaskState(
+        batch_size=NUM_ENVS,
+        device="cpu",
+        held_objects={
+            "left_arm": _held(semantics),
+            "right_arm": _held(
+                semantics,
+                env_mask=torch.tensor([True, False]),
+            ),
+        },
+    )
+    action = _bind_action(
+        generator,
+        HandOver(
+            default_options=HandOverOptions(
+                middle_object_pose=torch.eye(4),
+                final_object_pose=torch.eye(4),
+                hand_interp_steps=4,
+                hold_steps=2,
+                retreat_steps=5,
+            )
+        ),
+    )
+    action._resolve_receive_grasp = Mock(
+        return_value=(
+            torch.eye(4).repeat(NUM_ENVS, 1, 1),
+            torch.ones(NUM_ENVS, dtype=torch.bool),
+        )
+    )
+    context = _dual_context(task)
+    invocation = ActionInvocation(
+        skill_id="hand_over",
+        goal=GraspGoal(semantics=semantics),
+        binding=_dual_binding("source", "destination"),
+        motion_policy=MotionPolicy(sample_count=30),
+    )
+
+    plan = _plan_action(action, invocation, context)
+    projected = plan.expected_effects.apply(context.task, plan.plan_success)
+
+    assert plan.plan_success.tolist() == [False, True]
+    assert torch.allclose(
+        plan.trajectory.positions[0],
+        context.robot.qpos[0].unsqueeze(0).expand(30, -1),
+    )
+    transferred = projected.get_held_object("left_arm")
+    received = projected.get_held_object("right_arm")
+    assert transferred is not None and transferred.env_mask.tolist() == [True, False]
+    assert received is not None and received.env_mask.tolist() == [True, True]
+    assert received.semantics is semantics
+
+
 def test_coordinated_pick_returns_full_dof_plan_and_projected_relation() -> None:
     generator = _dual_motion_generator()
     action = _bind_action(
@@ -1301,6 +1448,35 @@ def test_coordinated_placement_projects_release_and_support_attachment() -> None
         "release",
         "retreat",
     ]
+
+
+def test_coordinated_placement_rejects_one_object_held_by_both_arms() -> None:
+    generator = _dual_motion_generator()
+    action = _bind_action(generator, CoordinatedPlacement())
+    semantics = _semantics()
+    task = TaskState(
+        batch_size=NUM_ENVS,
+        device="cpu",
+        held_objects={
+            "left_arm": _held(semantics),
+            "right_arm": _held(semantics),
+        },
+    )
+    invocation = ActionInvocation(
+        skill_id="coordinated_placement",
+        goal=CoordinatedPlacementGoal(
+            placing_object_target_pose=torch.eye(4),
+            support_object_target_pose=torch.eye(4),
+        ),
+        binding=_dual_binding("placing", "support"),
+        motion_policy=MotionPolicy(sample_count=30),
+    )
+
+    plan = _plan_action(action, invocation, _dual_context(task))
+
+    assert plan.plan_success.tolist() == [False, False]
+    assert plan.trajectory.waypoint_count == 0
+    generator.robot.compute_ik.assert_not_called()
 
 
 def test_coordinated_placement_holds_only_environment_with_ik_failure() -> None:

--- a/tests/sim/atomic_actions/test_actions.py
+++ b/tests/sim/atomic_actions/test_actions.py
@@ -33,7 +33,6 @@ from embodichain.lab.sim.atomic_actions import (
     AtomicAction,
     AtomicActionEngine,
     ControlPartCommandProfile,
-    CoordinatedHeldObjectState,
     CoordinatedPickGoal,
     CoordinatedPickment,
     CoordinatedPickmentOptions,
@@ -604,6 +603,36 @@ def test_move_joints_rejects_binding_with_wrong_goal_skill() -> None:
         action.resolve_request(invocation)
 
 
+def test_move_joints_rejects_incompatible_goal_at_action_boundary() -> None:
+    action = _bind_action(_motion_generator(), MoveJoints())
+    invocation = ActionInvocation(
+        skill_id="move_joints",
+        goal=object(),  # type: ignore[arg-type]
+        binding=ActionBinding(manipulators={"primary": "arm"}),
+    )
+
+    with pytest.raises(TypeError, match="expects goal JointPositionGoal"):
+        action.resolve_request(invocation)
+
+
+def test_builtin_action_validates_resolved_request_once() -> None:
+    generator = _motion_generator()
+    action = _bind_action(generator, MoveEndEffector())
+    validator = Mock(wraps=action.require_goal)
+    action.require_goal = validator  # type: ignore[method-assign]
+
+    _plan_action(
+        action,
+        _invocation(
+            "move_end_effector",
+            EndEffectorPoseGoal(torch.eye(4)),
+        ),
+        _context(),
+    )
+
+    validator.assert_called_once()
+
+
 def test_planner_timing_is_preserved_in_simple_action() -> None:
     generator = _motion_generator()
     generator.planner.cfg.planner_type = "toppra"
@@ -925,7 +954,9 @@ def test_press_closes_hand_without_changing_projected_attachment() -> None:
     assert torch.equal(projected_held.object_to_eef, held.object_to_eef)
 
 
-def test_handover_does_not_mutate_cached_final_pose() -> None:
+def test_handover_does_not_mutate_cached_final_pose(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     generator = _dual_motion_generator()
     handover_options = HandOverOptions(
         middle_object_pose=torch.eye(4),
@@ -955,6 +986,7 @@ def test_handover_does_not_mutate_cached_final_pose() -> None:
     )
 
     def plan_from_start(
+        motion_generator: MotionGenerator,
         control_part: str,
         start_qpos: torch.Tensor,
         target_poses: torch.Tensor,
@@ -963,7 +995,11 @@ def test_handover_does_not_mutate_cached_final_pose() -> None:
     ) -> tuple[bool, torch.Tensor]:
         return True, start_qpos.unsqueeze(1).repeat(1, n_waypoints, 1)
 
-    action._plan_named_arm_trajectory = Mock(side_effect=plan_from_start)
+    monkeypatch.setattr(
+        "embodichain.lab.sim.atomic_actions.primitives.hand_over."
+        "plan_named_arm_trajectory",
+        plan_from_start,
+    )
     invocation = ActionInvocation(
         skill_id="hand_over",
         goal=GraspGoal(semantics=semantics),
@@ -1087,12 +1123,12 @@ def test_coordinated_pick_returns_full_dof_plan_and_projected_relation() -> None
 
     assert plan.plan_success.tolist() == [True, True]
     assert plan.trajectory.positions.shape == (NUM_ENVS, 30, DUAL_ROBOT_DOF)
-    assert projected.get_held_object("left_arm") is None
-    assert projected.get_held_object("right_arm") is None
-    assert isinstance(
-        projected.get_coordinated_held_object("left_arm", "right_arm"),
-        CoordinatedHeldObjectState,
-    )
+    left_held = projected.get_held_object("left_arm")
+    right_held = projected.get_held_object("right_arm")
+    assert isinstance(left_held, HeldObjectState)
+    assert isinstance(right_held, HeldObjectState)
+    assert left_held.semantics is right_held.semantics
+    assert left_held.semantics is not semantics
     assert [segment.name for segment in plan.segments] == [
         "approach",
         "close",
@@ -1159,9 +1195,12 @@ def test_coordinated_pick_holds_only_environment_with_ik_failure() -> None:
         plan.trajectory.positions[1],
         context.robot.qpos[1].unsqueeze(0).repeat(30, 1),
     )
-    held = projected.get_coordinated_held_object("left_arm", "right_arm")
-    assert held is not None
-    assert held.env_mask.tolist() == [True, False]
+    left_held = projected.get_held_object("left_arm")
+    right_held = projected.get_held_object("right_arm")
+    assert left_held is not None and right_held is not None
+    assert left_held.semantics is right_held.semantics
+    assert left_held.env_mask.tolist() == [True, False]
+    assert right_held.env_mask.tolist() == [True, False]
 
 
 def test_coordinated_pick_fails_when_affordance_has_no_grasp() -> None:

--- a/tests/sim/atomic_actions/test_affordance.py
+++ b/tests/sim/atomic_actions/test_affordance.py
@@ -173,23 +173,23 @@ class TestAssembleAffordance:
         assert torch.allclose(result[0], base_pose @ self._rel_pose())
 
     def test_get_assemble_object_pose_broadcasts_across_envs(self):
-        n_envs = 3
+        num_envs = 3
         aff = AssembleAffordance(assemble_to_base_pose=self._rel_pose())
-        base_pose = torch.eye(4).unsqueeze(0).repeat(n_envs, 1, 1)
-        base_pose[:, 0, 3] = torch.arange(n_envs, dtype=torch.float32)
+        base_pose = torch.eye(4).unsqueeze(0).repeat(num_envs, 1, 1)
+        base_pose[:, 0, 3] = torch.arange(num_envs, dtype=torch.float32)
         result = aff.get_assemble_object_pose(base_pose)
-        assert result.shape == (n_envs, 4, 4)
+        assert result.shape == (num_envs, 4, 4)
         expected = torch.bmm(
-            base_pose, self._rel_pose().unsqueeze(0).repeat(n_envs, 1, 1)
+            base_pose, self._rel_pose().unsqueeze(0).repeat(num_envs, 1, 1)
         )
         assert torch.allclose(result, expected)
 
     def test_get_assemble_object_pose_broadcasts_batched_relative_pose(self):
-        n_envs = 2
-        rel = self._rel_pose().unsqueeze(0).repeat(n_envs, 1, 1)
+        num_envs = 2
+        rel = self._rel_pose().unsqueeze(0).repeat(num_envs, 1, 1)
         aff = AssembleAffordance(assemble_to_base_pose=rel)
-        base_pose = torch.eye(4).unsqueeze(0).repeat(n_envs, 1, 1)
+        base_pose = torch.eye(4).unsqueeze(0).repeat(num_envs, 1, 1)
         base_pose[:, 2, 3] = 0.5
         result = aff.get_assemble_object_pose(base_pose)
-        assert result.shape == (n_envs, 4, 4)
+        assert result.shape == (num_envs, 4, 4)
         assert torch.allclose(result, torch.bmm(base_pose, rel))

--- a/tests/sim/atomic_actions/test_control.py
+++ b/tests/sim/atomic_actions/test_control.py
@@ -59,7 +59,7 @@ def test_joint_position_command_broadcasts_owned_batch() -> None:
     command = JointPositionCommand(source)
     source.fill_(9.0)
 
-    resolved = command.resolve(n_envs=3, control_dof=2, device="cpu")
+    resolved = command.resolve(num_envs=3, control_dof=2, device="cpu")
     resolved[0].fill_(7.0)
 
     assert torch.allclose(resolved[1:], torch.tensor([[0.1, 0.2], [0.1, 0.2]]))
@@ -70,7 +70,7 @@ def test_joint_position_command_rejects_incompatible_control_part() -> None:
     command = JointPositionCommand(torch.zeros(2))
 
     with pytest.raises(ValueError, match="resolved control part has 3"):
-        command.resolve(n_envs=1, control_dof=3, device="cpu")
+        command.resolve(num_envs=1, control_dof=3, device="cpu")
 
 
 def test_control_profile_is_resolved_from_robot_control_part() -> None:
@@ -83,7 +83,7 @@ def test_control_profile_is_resolved_from_robot_control_part() -> None:
 
     grasp = resolved.end_effector().joint_positions(
         "grasp",
-        n_envs=2,
+        num_envs=2,
         device="cpu",
     )
 
@@ -91,7 +91,7 @@ def test_control_profile_is_resolved_from_robot_control_part() -> None:
     with pytest.raises(KeyError, match="Available commands"):
         resolved.end_effector().joint_positions(
             "pinch",
-            n_envs=2,
+            num_envs=2,
             device="cpu",
         )
 
@@ -115,11 +115,11 @@ def test_invocation_override_replaces_only_resolved_role_snapshot() -> None:
     overrides.end_effectors["primary"]["grasp"].positions.fill_(6.0)  # type: ignore[attr-defined]
 
     assert torch.allclose(
-        overridden.end_effector().joint_positions("grasp", n_envs=1, device="cpu"),
+        overridden.end_effector().joint_positions("grasp", num_envs=1, device="cpu"),
         torch.full((1, 2), 0.4),
     )
     assert torch.equal(
-        base.end_effector().joint_positions("grasp", n_envs=1, device="cpu"),
+        base.end_effector().joint_positions("grasp", num_envs=1, device="cpu"),
         torch.ones(1, 2),
     )
 

--- a/tests/sim/atomic_actions/test_core.py
+++ b/tests/sim/atomic_actions/test_core.py
@@ -19,6 +19,7 @@
 from __future__ import annotations
 
 from dataclasses import FrozenInstanceError
+from unittest.mock import Mock
 
 import pytest
 import torch
@@ -46,18 +47,34 @@ from embodichain.lab.sim.atomic_actions.goals import (
     collect_scene_dependencies,
     resolve_pose_goal,
 )
+from embodichain.lab.sim.common import BatchEntity
 
 
-def _semantics(label: str = "object") -> ObjectSemantics:
-    return ObjectSemantics(affordance=Affordance(), geometry={}, label=label)
+def _semantics(
+    label: str = "object",
+    *,
+    entity: BatchEntity | None = None,
+) -> ObjectSemantics:
+    return ObjectSemantics(
+        affordance=Affordance(),
+        geometry={},
+        label=label,
+        entity=entity,
+    )
 
 
-def _held(batch_size: int = 2) -> HeldObjectState:
+def _held(
+    batch_size: int = 2,
+    *,
+    semantics: ObjectSemantics | None = None,
+    env_mask: torch.Tensor | None = None,
+) -> HeldObjectState:
     pose = torch.eye(4).repeat(batch_size, 1, 1)
     return HeldObjectState(
-        semantics=_semantics(),
+        semantics=semantics or _semantics(),
         object_to_eef=pose,
         grasp_xpos=pose,
+        env_mask=env_mask,
     )
 
 
@@ -153,6 +170,39 @@ def test_task_state_normalizes_held_relations_and_masks_updates() -> None:
     assert left is not None and left.env_mask.tolist() == [False, True]
     assert right is not None and right.env_mask.tolist() == [True, False]
     assert state.get_held_object("right_arm") is None
+
+
+def test_task_state_reports_per_environment_exclusive_holds() -> None:
+    entity = Mock(spec=BatchEntity)
+    shared = _semantics("shared", entity=entity)
+    same_entity = ObjectSemantics(
+        affordance=Affordance(),
+        geometry={},
+        label="same-entity-alias",
+        entity=entity,
+    )
+    independent = _semantics("shared")
+    state = TaskState(
+        batch_size=2,
+        device="cpu",
+        held_objects={
+            "left_arm": _held(semantics=shared),
+            "right_arm": _held(
+                semantics=same_entity,
+                env_mask=torch.tensor([True, False]),
+            ),
+            "third_arm": _held(
+                semantics=independent,
+                env_mask=torch.tensor([False, True]),
+            ),
+        },
+    )
+
+    assert state.held_object_mask("left_arm").tolist() == [True, True]
+    assert state.exclusive_held_object_mask("left_arm").tolist() == [False, True]
+    assert state.exclusive_held_object_mask("right_arm").tolist() == [False, False]
+    assert state.exclusive_held_object_mask("third_arm").tolist() == [False, True]
+    assert state.held_object_mask("missing").tolist() == [False, False]
 
 
 def test_robot_observation_owns_input_tensors() -> None:

--- a/tests/sim/atomic_actions/test_core.py
+++ b/tests/sim/atomic_actions/test_core.py
@@ -85,15 +85,6 @@ def test_action_binding_is_role_based_and_immutable() -> None:
         binding.manipulator("destination")
 
 
-def test_invocation_rejects_values_without_goal_contract() -> None:
-    with pytest.raises(TypeError, match="goal_kind"):
-        ActionInvocation(
-            skill_id="move_end_effector",
-            goal=object(),  # type: ignore[arg-type]
-            binding=ActionBinding(manipulators={"primary": "arm"}),
-        )
-
-
 def test_motion_and_recovery_policy_validate_shared_parameters() -> None:
     policy = MotionPolicy(sample_count=24, control_dt=0.01)
     assert policy.sample_count == 24
@@ -269,9 +260,9 @@ def test_timed_trajectory_snapshot_owns_its_tensor_storage() -> None:
     snapshot = trajectory.snapshot()
     snapshot.positions.zero_()
     snapshot.dt.zero_()
-    snapshot.duration.zero_()
     snapshot.env_ids.zero_()
 
+    assert snapshot.duration.item() == 0.0
     assert torch.count_nonzero(trajectory.positions).item() > 0
     assert torch.count_nonzero(trajectory.dt).item() > 0
     assert trajectory.duration.item() > 0.0

--- a/tests/sim/atomic_actions/test_engine.py
+++ b/tests/sim/atomic_actions/test_engine.py
@@ -42,9 +42,6 @@ from embodichain.lab.sim.atomic_actions import (
     PressGoal,
     PressOptions,
     ResolvedActionRequest,
-    register_action,
-    get_registered_actions,
-    unregister_action,
 )
 
 
@@ -129,16 +126,6 @@ def _invocation(
     )
 
 
-def test_global_registry_uses_stable_skill_id() -> None:
-    unregister_action("stub")
-    register_action(StubAction)
-    try:
-        assert get_registered_actions()["stub"] is StubAction
-        register_action(StubAction)
-    finally:
-        unregister_action("stub")
-
-
 def test_action_subclass_cannot_override_framework_plan() -> None:
     with pytest.raises(TypeError, match="must implement _plan"):
 
@@ -192,7 +179,7 @@ def test_auto_registered_builtin_accepts_per_invocation_options() -> None:
         skill_options=options,
     )
 
-    request = engine.resolve(invocation)
+    request = engine.actions["press"].resolve_request(invocation)
 
     assert request.skill_options.hand_interp_steps == 7
     assert request.skill_options is not options
@@ -313,11 +300,13 @@ def test_engine_resolves_invocation_control_override_into_request() -> None:
         revision=2,
     )
 
-    request = engine.resolve(invocation)
+    request = engine.actions["stub"].resolve_request(invocation)
 
     assert request.revision == 2
     assert torch.allclose(
-        request.binding.manipulator().joint_positions("ready", n_envs=2, device="cpu"),
+        request.binding.manipulator().joint_positions(
+            "ready", num_envs=2, device="cpu"
+        ),
         torch.full((2, 3), 0.4),
     )
 
@@ -343,27 +332,20 @@ def test_engine_motion_generator_is_read_only() -> None:
         engine.motion_generator = Mock()  # type: ignore[misc]
 
 
-def test_engine_plan_action_supports_unregistered_configured_instance() -> None:
-    engine = _engine()
-    action = StubAction()
-
-    plan = engine.plan_action(
-        action,
-        _invocation(torch.ones(2, 3)),
-        engine.initial_context(),
-    )
-
-    assert plan.plan_success.tolist() == [True, True]
-    assert action.is_bound
-    assert engine.actions == {}
-
-
 def test_action_cannot_be_rebound_to_another_engine() -> None:
     action = StubAction()
     _engine().register(action)
 
     with pytest.raises(ValueError, match="another AtomicActionEngine"):
         _engine().register(action)
+
+
+def test_bound_action_exposes_num_envs_property() -> None:
+    engine = _engine(batch_size=3)
+    action = StubAction()
+    engine.register(action)
+
+    assert action.num_envs == 3
 
 
 def test_unbound_action_rejects_direct_planning() -> None:

--- a/tests/sim/atomic_actions/test_primitives_helpers.py
+++ b/tests/sim/atomic_actions/test_primitives_helpers.py
@@ -22,15 +22,64 @@ import pytest
 import torch
 
 from embodichain.lab.sim.atomic_actions.primitives._helpers import (
+    assemble_full_robot_trajectory,
+    repeat_qpos,
+    resolve_batched_pose,
     resolve_object_target,
 )
+
+BATCH_SIZE = 2
+ROBOT_DOF = 6
+WAYPOINT_COUNT = 3
+
+
+def test_resolve_batched_pose_broadcasts_and_owns_global_pose() -> None:
+    source = torch.eye(4)
+
+    result = resolve_batched_pose(
+        source,
+        num_envs=BATCH_SIZE,
+        device=torch.device("cpu"),
+        name="target_pose",
+    )
+    result[0, 0, 0] = 2.0
+
+    assert result.shape == (BATCH_SIZE, 4, 4)
+    assert source[0, 0] == 1.0
+
+
+def test_assemble_full_robot_trajectory_overlays_control_parts() -> None:
+    base = torch.zeros(BATCH_SIZE, ROBOT_DOF)
+    first = torch.ones(BATCH_SIZE, WAYPOINT_COUNT, 2)
+    second = torch.full((BATCH_SIZE, WAYPOINT_COUNT, 1), 2.0)
+
+    result = assemble_full_robot_trajectory(
+        base,
+        (
+            ((0, 2), first),
+            ((5,), second),
+        ),
+    )
+
+    expected = repeat_qpos(base, WAYPOINT_COUNT)
+    expected[:, :, [0, 2]] = 1.0
+    expected[:, :, 5] = 2.0
+    assert torch.equal(result, expected)
+
+
+def test_assemble_full_robot_trajectory_rejects_empty_parts() -> None:
+    with pytest.raises(ValueError, match="must not be empty"):
+        assemble_full_robot_trajectory(
+            torch.zeros(BATCH_SIZE, ROBOT_DOF),
+            (),
+        )
 
 
 def test_resolve_object_target_uses_custom_name_in_shape_error() -> None:
     with pytest.raises(ValueError, match="placing_object_target_pose"):
         resolve_object_target(
             torch.zeros(2, 4, 4),
-            n_envs=3,
+            num_envs=3,
             device=torch.device("cpu"),
             name="placing_object_target_pose",
         )

--- a/tests/sim/atomic_actions/test_trajectory_ops.py
+++ b/tests/sim/atomic_actions/test_trajectory_ops.py
@@ -46,7 +46,7 @@ class TestNormalizeSuccessMask:
     def test_python_bool_is_expanded_without_collapsing_batch(self):
         success = normalize_success_mask(
             True,
-            n_envs=2,
+            num_envs=2,
             device=CPU,
             name="IK success",
         )
@@ -56,7 +56,7 @@ class TestNormalizeSuccessMask:
     def test_per_environment_tensor_is_preserved(self):
         success = normalize_success_mask(
             torch.tensor([True, False]),
-            n_envs=2,
+            num_envs=2,
             device=CPU,
             name="IK success",
         )
@@ -66,7 +66,7 @@ class TestNormalizeSuccessMask:
     def test_binary_integer_success_is_normalized_at_planner_boundary(self):
         success = normalize_success_mask(
             torch.tensor([1, 0], dtype=torch.int32),
-            n_envs=2,
+            num_envs=2,
             device=CPU,
             name="IK success",
         )
@@ -78,7 +78,7 @@ class TestNormalizeSuccessMask:
         with pytest.raises(TypeError, match="binary integer"):
             normalize_success_mask(
                 torch.tensor([1, 2], dtype=torch.int32),
-                n_envs=2,
+                num_envs=2,
                 device=CPU,
                 name="IK success",
             )
@@ -87,46 +87,46 @@ class TestNormalizeSuccessMask:
 class TestResolvePoseTarget:
     def test_unbatched_pose_broadcasts(self):
         pose = torch.eye(4)
-        out = resolve_pose_target(pose, n_envs=2, device=CPU)
+        out = resolve_pose_target(pose, num_envs=2, device=CPU)
         assert out.shape == (2, 4, 4)
 
     def test_batched_pose_passes_through(self):
         pose = torch.eye(4).unsqueeze(0).repeat(2, 1, 1)
-        out = resolve_pose_target(pose, n_envs=2, device=CPU)
+        out = resolve_pose_target(pose, num_envs=2, device=CPU)
         assert torch.equal(out, pose)
 
     def test_batched_pose_returns_owned_tensor(self):
         pose = torch.eye(4).unsqueeze(0).repeat(2, 1, 1)
-        out = resolve_pose_target(pose, n_envs=2, device=CPU)
+        out = resolve_pose_target(pose, num_envs=2, device=CPU)
         out[:, 0, 0] = 2.0
         assert torch.equal(pose, torch.eye(4).unsqueeze(0).repeat(2, 1, 1))
 
     def test_pose_converts_to_float32_on_requested_device(self):
         pose = torch.eye(4, dtype=torch.float64)
-        out = resolve_pose_target(pose, n_envs=2, device=CPU)
+        out = resolve_pose_target(pose, num_envs=2, device=CPU)
         assert out.dtype == torch.float32
         assert out.device == CPU
 
     def test_wrong_shape_raises(self):
         with pytest.raises(ValueError):
-            resolve_pose_target(torch.eye(3), n_envs=2, device=CPU)
+            resolve_pose_target(torch.eye(3), num_envs=2, device=CPU)
 
     def test_multi_waypoint_passes_through(self):
         pose = torch.eye(4).unsqueeze(0).unsqueeze(0).repeat(2, 3, 1, 1)
         pose[0, 1, :3, 3] = torch.tensor([1.0, 0.0, 0.0])
-        out = resolve_pose_target(pose, n_envs=2, device=CPU)
+        out = resolve_pose_target(pose, num_envs=2, device=CPU)
         assert out.shape == (2, 3, 4, 4)
         assert torch.equal(out, pose.to(torch.float32))
 
     def test_multi_waypoint_wrong_envs_raises(self):
         pose = torch.eye(4).unsqueeze(0).unsqueeze(0).repeat(3, 2, 1, 1)
         with pytest.raises(ValueError):
-            resolve_pose_target(pose, n_envs=2, device=CPU)
+            resolve_pose_target(pose, num_envs=2, device=CPU)
 
     def test_multi_waypoint_empty_raises(self):
         empty = torch.zeros((2, 0, 4, 4), dtype=torch.float32)
         with pytest.raises(ValueError, match="zero waypoints"):
-            resolve_pose_target(empty, n_envs=2, device=CPU)
+            resolve_pose_target(empty, num_envs=2, device=CPU)
 
 
 class TestResolveObjectTarget:
@@ -134,7 +134,7 @@ class TestResolveObjectTarget:
         pose = torch.eye(4).unsqueeze(0).repeat(2, 1, 1)
         out = resolve_object_target(
             pose,
-            n_envs=2,
+            num_envs=2,
             device=CPU,
         )
 
@@ -148,7 +148,7 @@ class TestResolveJointTarget:
         qpos = torch.arange(6, dtype=torch.float32)
         out = resolve_joint_target(
             qpos,
-            n_envs=2,
+            num_envs=2,
             joint_dof=6,
             control_part="arm",
             device=CPU,
@@ -161,7 +161,7 @@ class TestResolveJointTarget:
         qpos = torch.arange(12, dtype=torch.float32).reshape(2, 6)
         out = resolve_joint_target(
             qpos,
-            n_envs=2,
+            num_envs=2,
             joint_dof=6,
             control_part="arm",
             device=CPU,
@@ -173,7 +173,7 @@ class TestResolveJointTarget:
         expected = qpos.clone()
         out = resolve_joint_target(
             qpos,
-            n_envs=2,
+            num_envs=2,
             joint_dof=6,
             control_part="arm",
             device=CPU,
@@ -185,7 +185,7 @@ class TestResolveJointTarget:
         with pytest.raises(ValueError):
             resolve_joint_target(
                 torch.zeros(5),
-                n_envs=2,
+                num_envs=2,
                 joint_dof=6,
                 control_part="arm",
                 device=CPU,
@@ -195,7 +195,7 @@ class TestResolveJointTarget:
         qpos = torch.arange(24, dtype=torch.float32).reshape(2, 2, 6)
         out = resolve_joint_target(
             qpos,
-            n_envs=2,
+            num_envs=2,
             joint_dof=6,
             control_part="arm",
             device=CPU,
@@ -207,7 +207,7 @@ class TestResolveJointTarget:
         with pytest.raises(ValueError):
             resolve_joint_target(
                 torch.zeros(3, 2, 6),
-                n_envs=2,
+                num_envs=2,
                 joint_dof=6,
                 control_part="arm",
                 device=CPU,
@@ -217,7 +217,7 @@ class TestResolveJointTarget:
         with pytest.raises(ValueError):
             resolve_joint_target(
                 torch.zeros(2, 2, 5),
-                n_envs=2,
+                num_envs=2,
                 joint_dof=6,
                 control_part="arm",
                 device=CPU,
@@ -228,7 +228,7 @@ class TestResolveJointTarget:
         with pytest.raises(ValueError, match="zero waypoints"):
             resolve_joint_target(
                 empty,
-                n_envs=2,
+                num_envs=2,
                 joint_dof=6,
                 control_part="arm",
                 device=CPU,

--- a/tests/sim/objects/test_cloth_object.py
+++ b/tests/sim/objects/test_cloth_object.py
@@ -78,7 +78,7 @@ class BaseSoftObjectTest:
         self.sim = SimulationManager(sim_cfg)
 
         # Enable manual physics update for precise control
-        self.n_envs = 4
+        self.num_envs = 4
 
         cloth_verts, cloth_faces = create_2d_grid_mesh(
             width=0.3, height=0.3, nx=12, ny=12

--- a/tests/sim/objects/test_soft_object.py
+++ b/tests/sim/objects/test_soft_object.py
@@ -65,7 +65,7 @@ class BaseSoftObjectTest:
         assert os.path.isfile(COW_PATH)
 
         # Enable manual physics update for precise control
-        self.n_envs = 4
+        self.num_envs = 4
 
         # add softbody to the scene
         self.cow: SoftObject = self.sim.add_soft_object(

--- a/tests/toolkits/test_grasp_pose_generator.py
+++ b/tests/toolkits/test_grasp_pose_generator.py
@@ -153,7 +153,7 @@ def create_mug(sim: SimulationManager):
 
 
 def get_grasp_traj(sim: SimulationManager, robot: Robot, grasp_xpos: torch.Tensor):
-    n_envs = sim.num_envs
+    num_envs = sim.num_envs
     rest_arm_qpos = robot.get_qpos("arm")
 
     approach_xpos = grasp_xpos.clone()
@@ -183,12 +183,12 @@ def get_grasp_traj(sim: SimulationManager, robot: Robot, grasp_xpos: torch.Tenso
     )
     hand_trajectory = torch.cat(
         [
-            hand_open_qpos[None, None, :].repeat(n_envs, 1, 1),
-            hand_open_qpos[None, None, :].repeat(n_envs, 1, 1),
-            hand_open_qpos[None, None, :].repeat(n_envs, 1, 1),
-            hand_close_qpos[None, None, :].repeat(n_envs, 1, 1),
-            hand_close_qpos[None, None, :].repeat(n_envs, 1, 1),
-            hand_close_qpos[None, None, :].repeat(n_envs, 1, 1),
+            hand_open_qpos[None, None, :].repeat(num_envs, 1, 1),
+            hand_open_qpos[None, None, :].repeat(num_envs, 1, 1),
+            hand_open_qpos[None, None, :].repeat(num_envs, 1, 1),
+            hand_close_qpos[None, None, :].repeat(num_envs, 1, 1),
+            hand_close_qpos[None, None, :].repeat(num_envs, 1, 1),
+            hand_close_qpos[None, None, :].repeat(num_envs, 1, 1),
         ],
         dim=1,
     )


### PR DESCRIPTION
## Description

This PR simplifies the Atomic Action planning and runtime contracts, removes duplicated primitive logic, and establishes one authoritative path for validation, registration, and attachment state.

The previous design combined repeated per-primitive validation, a disconnected process-wide extension registry, a marker-only goal protocol, and parallel individual/coordinated attachment representations. This made extensions harder to reason about and allowed equivalent state to drift between abstractions.

Dependencies: none.

Issue: no issue is linked.

### What changed

- Centralize goal, option, binding, and planning validation at the framework boundary.
- Share batched pose resolution, qpos repetition, trajectory assembly, and named-arm planning helpers across primitives.
- Keep action registration engine-local and remove the global extension catalog and unregistered planning escape hatch.
- Remove the marker-only `ActionGoal` protocol and `goal_kind`; each action declares and validates its concrete `GoalType`.
- Consolidate attachment state into `TaskState.held_objects`, including coordinated grasps represented by one `HeldObjectState` per manipulator.
- Derive trajectory duration from `dt` and share simulator command writing logic.
- Rename `n_envs` to `num_envs` across public APIs, implementations, tests, examples, and documentation.
- Update Atomic Action documentation and project agent context for the new contracts.

### Breaking API migrations

- `n_envs` and `n_envs=` become `num_envs` and `num_envs=`.
- `ActionGoal` and `goal_kind` are removed; define an action-owned goal dataclass and set `AtomicAction.GoalType`.
- `register_action`, `unregister_action`, and `get_registered_actions` are removed; instantiate the action and call `engine.register(action)`.
- `engine.plan_action` is removed; register the action and use `engine.plan`.
- Public request-resolution helpers are internalized; application code should use `plan`, `compile`, or `start`.
- `CoordinatedHeldObjectState` and the coordinated attachment map are removed; use per-manipulator `HeldObjectState` entries.

## Type of change

- [x] Breaking change (existing functionality requires migration)

## Screenshots

Not applicable.

## Validation

- `conda run -n open black .` — 905 files unchanged with Black 26.3.1.
- Targeted pytest suite — 244 passed, 7 skipped, 5 deselected.
- Python compilation of all 50 changed Python files.
- Apache header, future annotations, public `__all__`, and `git diff --check` checks.
- Repository-wide searches confirm no remaining `n_envs` or removed Atomic Action API symbols.
- `conda run -n open make -C docs html` — succeeded; the repository still emits pre-existing Sphinx warnings unrelated to this change.

## Checklist

- [x] I have run the `black .` command to format the code base.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove the refactor and migration work.
- [x] No dependency updates are required.
