### PR TITLE
Remove private index from cuRobo install commands

### DIFF
--- a/docs/source/quick_start/install.md
+++ b/docs/source/quick_start/install.md
@@ -187,13 +187,11 @@ the non-`torch` variants:
 ```bash
 # CUDA 12.x
 uv pip install \
-  "nvidia-curobo[cu12] @ git+https://github.com/NVlabs/curobo.git@v0.8.0" \
-  ${PIP_EXTRA_ARGS}
+  "nvidia-curobo[cu12] @ git+https://github.com/NVlabs/curobo.git@v0.8.0"
 
 # CUDA 13.x
 uv pip install \
-  "nvidia-curobo[cu13] @ git+https://github.com/NVlabs/curobo.git@v0.8.0" \
-  ${PIP_EXTRA_ARGS}
+  "nvidia-curobo[cu13] @ git+https://github.com/NVlabs/curobo.git@v0.8.0"
 ```
 
 For a fresh environment that also needs cuRobo to select and install PyTorch,
@@ -204,9 +202,7 @@ requirements work with `pip`; replace `uv pip install` with `pip install`.
 
 ```bash
 uv pip install \
-  "nvidia-curobo[cu12] @ git+https://github.com/NVlabs/curobo.git@v0.8.0" \
-  --extra-index-url http://pyp.open3dv.site:2345/simple/ \
-  --trusted-host pyp.open3dv.site
+  "nvidia-curobo[cu12] @ git+https://github.com/NVlabs/curobo.git@v0.8.0"
 
 python -c "import curobo; print(curobo.__version__)"
 pytest --pyargs curobo.tests


### PR DESCRIPTION
## Description

This PR removes the DexForce private package index and trusted-host arguments from the optional cuRobo V2 installation commands. cuRobo is installed directly from NVIDIA's pinned Git source and does not require the Open3DV index.

Dependencies: None.

Issue reference: None.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (existing functionality will not work without user modification)
- [x] Documentation update

## Screenshots

Not applicable.

## Validation

- `black --check --diff --color ./`
- `git diff --check`
- `sphinx-build -b html -D autosummary_generate=0 docs/source <temporary-build-dir>`

The normal Sphinx build's autosummary generation requires project runtime dependencies such as `dexsim` that are unavailable in the local environment. With autosummary generation disabled, all 160 documentation pages render successfully; existing project-wide warnings remain.

## Checklist

- [x] Black formatting check passes
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works (not applicable: documentation-only change)
- [ ] Dependencies have been updated (not applicable)
