### PR TITLE
Add codebase navigation to project context skill

### DIFF
--- a/.agents/skills/project-dev-context/SKILL.md
+++ b/.agents/skills/project-dev-context/SKILL.md
@@ -1,22 +1,17 @@
 ---
 name: project-dev-context
-description: Use when a request asks to reference, refresh, write, or register project development context so the agent resolves the topic through agent_context/MAP.yaml and reads or updates the mapped Markdown context files.
+description: >
+  Route EmbodiChain development-context and codebase-navigation requests through
+  agent_context/MAP.yaml. Use when asked to locate files, configs, defaults,
+  entry points, registration paths, or change sites; explain a code or
+  configuration resolution chain; reference project context; refresh or write
+  context; register a context topic; or work with a named topic such as
+  simulation-system, env-framework, rl-learning, manager-functor, ik-solvers,
+  or atomic-actions. Chinese triggers include 文件在哪里、配置或默认值在哪里、
+  入口或注册逻辑在哪里、应该修改哪个文件、参考项目上下文、刷新项目上下文。
 ---
 
-# Project Dev Context
-
-Use this skill when:
-- the request says `reference project development docs`
-- the request says `reference project context`
-- the request says `refresh project context`
-- the request says `update project context`
-- the request says `write project context`
-- the request says `参考项目开发文档`
-- the request says `参考项目上下文`
-- the request says `刷新项目上下文`
-- the request says `更新项目上下文`
-- the request says `写项目上下文`
-- the request names a known project topic such as `env-framework`, `manager-functor`, `ik-solvers`, or `atomic-actions`
+# Project Development Context and Codebase Navigation
 
 ## Start here
 
@@ -25,18 +20,50 @@ Use this skill when:
 - Read `agents/openai.yaml` for the canonical agent metadata
 - Read `agent_context/conventions/*.md` when creating or updating context files
 
-## Workflow
+## Select the operation
 
-1. Resolve the topic through `agent_context/MAP.yaml`
-2. Match in this order: exact `id`, then `aliases`, then `keywords`
-3. Choose the operation mode:
-   - **read**: load only the matched Markdown files under `agent_context/`
-   - **refresh existing topic**: re-read `source_of_truth` and rewrite the mapped topic Markdown so it matches current implementation
-   - **add new topic**: write a new topic Markdown file and register it in `agent_context/MAP.yaml`
-4. Load `agent_context/conventions/*.md` if you add or update context files
-5. Do not re-read `docs/source/` unless the user explicitly asks for Sphinx documentation
+- **navigate**: locate a file, symbol, config, default, entry point,
+  registration path, or recommended change site.
+- **read**: load the matched agent context without changing it.
+- **refresh**: rebuild an existing topic from its current
+  `source_of_truth`.
+- **add**: create and register a new topic from current source code.
 
-This skill routes context. It does not replace the underlying source-of-truth files listed in each topic entry.
+An explicit refresh or add request determines the mode. If the user asks to
+implement work covered by a specialized skill such as `add-robot`,
+`add-solver`, or `add-functor`, let that skill own the implementation and
+use this skill only for orientation or mapped context.
+
+## Route the request
+
+1. Resolve the topic through `agent_context/MAP.yaml`.
+2. Match in this order: exact `id`, then `aliases`, then `keywords`.
+3. For a matched read request, load only the Markdown files in `paths`.
+4. For a matched navigation request, load the mapped topic and verify the
+   relevant path or behavior against the current `source_of_truth`.
+5. For an unmatched navigation request:
+   - list candidate files with `rg --files`;
+   - search symbols, flags, config keys, registries, and imports with `rg -n`;
+   - inspect the closest package `__init__.py`, config loader, registry,
+     test, and entry point as relevant;
+   - inspect `pyproject.toml` and `embodichain/__main__.py` for CLI or
+     package-discovery questions.
+6. Do not add a topic merely because navigation did not match. Propose or add
+   one only when the user requests it or the missing area is recurring.
+7. Do not read `docs/source/` unless the user explicitly asks for Sphinx
+   documentation.
+
+Never treat topic Markdown as a substitute for current code. For navigation,
+report only paths and behavior verified in the working tree.
+
+## Navigation answer contract
+
+Include the parts relevant to the request:
+
+- the entry point or owning location;
+- the call, registration, or configuration-resolution path;
+- the file or symbol to change;
+- the focused tests or documentation affected by that change.
 
 ## Explicit refresh mode
 
@@ -53,6 +80,16 @@ In refresh mode:
 2. Re-read the files listed in `source_of_truth`
 3. Rewrite the mapped topic Markdown from current implementation, not stale notes
 4. Update `aliases`, `keywords`, `paths`, `related_topics` if needed
+5. Load and follow `agent_context/conventions/*.md`
+
+## Add mode
+
+1. Choose a stable kebab-case topic id.
+2. Read the current source files that define the topic.
+3. Write one focused Markdown file under
+   `agent_context/topics/<topic-id>/`.
+4. Register the topic in `agent_context/MAP.yaml`.
+5. Load and follow `agent_context/conventions/*.md`.
 
 ## Update contract
 
@@ -66,7 +103,8 @@ If code behavior changes a routed topic, update all relevant pieces in the same 
 
 ## Source-of-truth
 
-This skill does not store the project knowledge itself. The canonical project context lives in:
+This skill stores the routing procedure, not project facts. Canonical project
+context lives in:
 - `agent_context/MAP.yaml`
 - `agent_context/topics/**/*.md`
 - `agent_context/conventions/*.md`

--- a/.agents/skills/project-dev-context/references/context-system.md
+++ b/.agents/skills/project-dev-context/references/context-system.md
@@ -5,13 +5,33 @@ EmbodiChain keeps agent-facing context in `agent_context/`, indexed by
 Claude Code project adapters use `.claude/skills/<skill>/SKILL.md`, and
 GitHub Copilot adapters under `.github/copilot/` should stay thin.
 
+## Operation Modes
+
+- `navigate`: locate current files, symbols, configs, defaults, entry points,
+  registration paths, and recommended change sites.
+- `read`: load an existing topic without changing it.
+- `refresh`: rebuild an existing topic from its current source of truth.
+- `add`: create and register a new topic from current source code.
+
 ## Routing Rules
 
 1. Read `agent_context/MAP.yaml` first.
 2. Resolve the requested topic by exact `id`, then `aliases`, then `keywords`.
-3. Load only the matched Markdown files listed in the topic `paths`.
-4. Do not read `docs/source/` unless the user explicitly asks for Sphinx
+3. For read requests, load only the matched Markdown files listed in `paths`.
+4. For navigation requests, verify the relevant mapped facts against the
+   current `source_of_truth`.
+5. If navigation does not match a topic, search the working tree with
+   `rg --files` and `rg -n`. Inspect package exports, config loaders,
+   registries, tests, `pyproject.toml`, and `embodichain/__main__.py` as
+   relevant.
+6. Do not create a topic for a one-off unmatched lookup unless the user asks
+   for it.
+7. Do not read `docs/source/` unless the user explicitly asks for Sphinx
    documentation.
+
+Navigation answers should identify the owning entry point, the call or config
+resolution path, the recommended change site, and the focused validation
+surface when those details are relevant.
 
 ## Update Rules
 

--- a/.claude/skills/project-dev-context/SKILL.md
+++ b/.claude/skills/project-dev-context/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: project-dev-context
-description: Claude adapter for the canonical EmbodiChain project-dev-context skill.
+description: Claude adapter for locating EmbodiChain code, configs, defaults, entry points, and change sites or for reading and maintaining registered project context.
 ---
 
 # Project Dev Context - Claude Adapter
@@ -9,6 +9,8 @@ Canonical source: `.agents/skills/project-dev-context/`
 
 ## When to use
 
+- locate a file, config, default, entry point, registration path, or change site
+- explain a code or configuration resolution chain
 - reference project development docs
 - reference project context
 - refresh project context
@@ -20,10 +22,14 @@ Canonical source: `.agents/skills/project-dev-context/`
 - 刷新项目上下文
 - 更新项目上下文
 - 写项目上下文
+- 文件在哪里
+- 配置或默认值在哪里
+- 应该修改哪个文件
 
 ## Start here
 
-1. Use this adapter when the request asks to reference, refresh, write, or register project development context.
+1. Use this adapter for codebase navigation or when the request asks to
+   reference, refresh, write, or register project development context.
 2. Then follow `.agents/skills/project-dev-context/SKILL.md`.
 3. Resolve topics through `agent_context/MAP.yaml`.
 
@@ -32,4 +38,3 @@ Canonical source: `.agents/skills/project-dev-context/`
 Keep this file thin. If canonical routing behavior changes, update the
 canonical skill first, then only adjust this adapter if Claude needs a
 different local entry hint.
-

--- a/.github/copilot/project-dev-context.md
+++ b/.github/copilot/project-dev-context.md
@@ -4,6 +4,8 @@ Canonical source: `.agents/skills/project-dev-context/`
 
 ## When to use
 
+- locate a file, config, default, entry point, registration path, or change site
+- explain a code or configuration resolution chain
 - reference project development docs
 - reference project context
 - refresh project context
@@ -15,10 +17,14 @@ Canonical source: `.agents/skills/project-dev-context/`
 - 刷新项目上下文
 - 更新项目上下文
 - 写项目上下文
+- 文件在哪里
+- 配置或默认值在哪里
+- 应该修改哪个文件
 
 ## Start here
 
-1. Use this adapter when the request asks to reference, refresh, write, or register project development context.
+1. Use this adapter for codebase navigation or when the request asks to
+   reference, refresh, write, or register project development context.
 2. Then follow `.agents/skills/project-dev-context/SKILL.md`.
 3. Resolve topics through `agent_context/MAP.yaml`.
 
@@ -27,4 +33,3 @@ Canonical source: `.agents/skills/project-dev-context/`
 Keep this file thin. If canonical routing behavior changes, update the
 canonical skill first, then only adjust this adapter if Copilot needs a
 different local entry hint.
-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,22 +6,36 @@ EmbodiChain keeps agent-facing context in a structured topic registry:
 
 - `agent_context/` — agent-readable Markdown context, indexed by `agent_context/MAP.yaml`
 - `docs/source/` — human-facing Sphinx documentation
-- `.agents/skills/project-dev-context/` — the skill that routes "reference project context" requests
+- `.agents/skills/project-dev-context/` — the skill that routes project-context and codebase-navigation requests
 - `.claude/skills/` and `.github/copilot/` — thin tool-specific adapters that point back to `.agents/skills/`
 
 When a request says things like:
 
 - `reference project development docs`
 - `reference project context`
+- `where is X`
+- `where do I change X`
+- `配置或默认值在哪里`
+- `入口或注册逻辑在哪里`
 
 the agent should:
 
 1. Read `agent_context/MAP.yaml` first
 2. Resolve the topic by `id`, `aliases`, then `keywords`
-3. Load only the matched Markdown files under `agent_context/`
-4. Avoid reading `docs/source/` unless the user explicitly asks for the Sphinx documentation
+3. For context reads, load only the matched Markdown files under
+   `agent_context/`
+4. For navigation, verify matched facts against the current
+   `source_of_truth`; if no topic matches, use `rg --files` and `rg -n`
+   against the current tree
+5. Report the owning entry point, resolution path, recommended change site,
+   and focused validation surface when relevant
+6. Avoid reading `docs/source/` unless the user explicitly asks for the
+   Sphinx documentation
 
-Available topics: `env-framework`, `manager-functor`, `ik-solvers`, `robot-system`, `sensor-system`, `sim-visualization`, `motion-planning`, `atomic-actions`, `rl-learning`, `configclass-pattern`, `randomization`.
+Available topics: `simulation-system`, `env-framework`,
+`manager-functor`, `ik-solvers`, `robot-system`, `sensor-system`,
+`sim-visualization`, `motion-planning`, `atomic-actions`, `rl-learning`,
+`configclass-pattern`, `randomization`.
 
 ---
 
@@ -43,14 +57,11 @@ EmbodiChain/
 ├── .claude/                      # Claude adapters for canonical skills
 │   └── skills/
 ├── embodichain/                  # Main Python package
-│   ├── agents/                   # AI agents
-│   │   ├── hierarchy/            # LLM-based hierarchical agents (task, code, validation)
-│   │   ├── mllm/                 # Multimodal LLM prompt scaffolding
-│   │   └── prompts/              # Agent prompt templates
-│   ├── data_pipeline/            # Datasets and online data streaming
-│   ├── learning/                 # Learning systems: RL, IL, frontier model architectures
-│   │   └── rl/                   # RL: PPO/GRPO algo, rollout buffer, collectors, policies
 │   ├── data/                     # Assets, datasets, constants, enums
+│   ├── data_pipeline/            # Datasets and online data streaming
+│   ├── gen_sim/                  # Scene Engine and SimReady generation pipelines
+│   ├── learning/                 # Learning systems
+│   │   └── rl/                   # RL: PPO/GRPO/APG, buffers, collectors, policies
 │   ├── lab/                      # Simulation lab
 │   │   ├── visualization/        # Browser visualization protocol, runtime, and Viser backend
 │   │   ├── gym/                  # OpenAI Gym-compatible environments
@@ -62,14 +73,18 @@ EmbodiChain/
 │   │   │   │   └── wrapper/      # Env wrappers (e.g. no_fail)
 │   │   │   └── utils/            # Gym registration, misc helpers
 │   │   ├── sim/                  # Simulation core
+│   │   │   ├── atomic_actions/   # Typed planning and execution primitives
 │   │   │   ├── objects/          # Robot, RigidObject, Articulation, Light, Gizmo, SoftObject
 │   │   │   ├── sensors/          # Camera, StereoCamera, BaseSensor
 │   │   │   ├── robots/           # Robot-specific configs and params (dexforce_w1, cobotmagic)
 │   │   │   ├── planners/         # Motion planners (TOPPRA, motion generator)
-│   │   │   └── solvers/          # IK solvers (SRS, OPW, pink, pinocchio, pytorch)
+│   │   │   ├── solvers/          # IK solvers (SRS, OPW, pink, pinocchio, pytorch)
+│   │   │   ├── skills/           # Semantic scene and robot-skill binding contracts
+│   │   │   └── workspace/        # Reachability analysis and runtime workspace queries
 │   │   ├── devices/              # Real-device controllers
-│   │   └── scripts/              # Entry-point scripts (run_env, run_agent)
+│   │   └── scripts/              # Environment, preview, and analysis entry points
 │   ├── toolkits/                 # Standalone tools
+│   │   ├── acd/                  # URDF convex-decomposition CLI
 │   │   ├── graspkit/pg_grasp/    # Parallel-gripper grasp sampling
 │   │   └── urdf_assembly/        # URDF builder utilities
 │   └── utils/                    # Shared utilities
@@ -82,6 +97,7 @@ EmbodiChain/
 │   └── source/                   # .md doc pages (overview, quick_start, features, resources)
 ├── tests/                        # Test suite
 ├── .github/                      # CI workflows, issue/PR templates, Copilot adapters
+├── pyproject.toml                # Distribution metadata and unified CLI entry point
 ├── setup.py                      # Package setup
 └── VERSION                       # Package version file
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,7 @@ Agent-facing development context lives in [`agent_context/`](agent_context/). Th
 Reference the project context for manager-functor before implementing this change.
 ```
 
-Both agents are instructed to read `agent_context/MAP.yaml` first, resolve the requested topic, and load only the matching context files. The files under `docs/source/` remain the human-facing Sphinx documentation and should be consulted only when explicitly requested.
+Both agents are instructed to read `agent_context/MAP.yaml` first, resolve the requested topic, and load only the matching context files. For codebase-navigation questions they also verify mapped paths against the current source tree and fall back to live search when no topic matches. The files under `docs/source/` remain the human-facing Sphinx documentation and should be consulted only when explicitly requested.
 
 ### Shared project skills
 
@@ -80,7 +80,7 @@ Canonical skills live in [`.agents/skills/`](.agents/skills/). Claude Code uses 
 
 | Skill | Purpose |
 |-------|---------|
-| `/project-dev-context` | Resolve or update agent development context |
+| `/project-dev-context` | Navigate, resolve, or update agent development context |
 | `/add-functor`, `/add-task-env`, `/add-robot`, `/add-solver`, `/add-atomic-action` | Scaffold project components following repository conventions |
 | `/add-test`, `/benchmark` | Add validation or performance benchmarks |
 | `/pre-commit-check` | Run proportional checks before committing |

--- a/agent_context/MAP.yaml
+++ b/agent_context/MAP.yaml
@@ -5,6 +5,61 @@ defaults:
     - conventions/naming.md
     - conventions/topic-lifecycle.md
 topics:
+  - id: simulation-system
+    title: Simulation System
+    aliases:
+      - simulation system
+      - simulation core
+      - sim system
+      - lab sim
+      - simulation manager
+      - 仿真系统
+      - 仿真核心
+      - 仿真管理器
+    keywords:
+      - sim
+      - simulation
+      - SimulationManager
+      - SimulationManagerCfg
+      - DexSim
+      - world
+      - arena
+      - physics step
+      - sim update
+      - scene object
+      - asset registry
+      - manual update
+      - GPU physics
+      - simulation lifecycle
+    paths:
+      - topics/simulation-system/simulation-system.md
+    source_of_truth:
+      - embodichain/lab/sim/__init__.py
+      - embodichain/lab/sim/sim_manager.py
+      - embodichain/lab/sim/cfg.py
+      - embodichain/lab/sim/common.py
+      - embodichain/lab/sim/material.py
+      - embodichain/lab/sim/profiler.py
+      - embodichain/lab/sim/objects/__init__.py
+      - embodichain/lab/sim/sensors/__init__.py
+      - embodichain/lab/sim/solvers/__init__.py
+      - embodichain/lab/sim/planners/__init__.py
+      - embodichain/lab/sim/skills/__init__.py
+      - embodichain/lab/sim/workspace/__init__.py
+      - embodichain/lab/gym/envs/base_env.py
+      - embodichain/lab/gym/envs/embodied_env.py
+    related_topics:
+      - env-framework
+      - robot-system
+      - sensor-system
+      - sim-visualization
+      - ik-solvers
+      - motion-planning
+      - atomic-actions
+      - rl-learning
+      - configclass-pattern
+    status: active
+
   - id: env-framework
     title: Environment Framework
     aliases:
@@ -47,6 +102,7 @@ topics:
       - embodichain_tasks/embodichain_tasks/
       - embodichain/lab/gym/utils/
     related_topics:
+      - simulation-system
       - manager-functor
       - sim-visualization
     status: active
@@ -143,6 +199,7 @@ topics:
       - embodichain/lab/sim/solvers/pytorch_solver.py
       - embodichain/lab/sim/solvers/differential_solver.py
     related_topics:
+      - simulation-system
       - robot-system
       - motion-planning
     status: active
@@ -179,6 +236,7 @@ topics:
       - embodichain/lab/sim/robots/
       - embodichain/lab/sim/cfg.py
     related_topics:
+      - simulation-system
       - ik-solvers
       - motion-planning
       - sensor-system
@@ -215,6 +273,7 @@ topics:
       - embodichain/lab/sim/sensors/stereo.py
       - embodichain/lab/sim/sensors/contact_sensor.py
     related_topics:
+      - simulation-system
       - robot-system
       - env-framework
       - sim-visualization
@@ -236,7 +295,6 @@ topics:
     keywords:
       - visualization
       - viser
-      - SimulationManager
       - VisualizationCfg
       - ViserServerCfg
       - VisualizationRuntime
@@ -266,6 +324,7 @@ topics:
       - embodichain/lab/sim/objects/soft_object.py
       - embodichain/lab/sim/objects/cloth_object.py
     related_topics:
+      - simulation-system
       - env-framework
       - sensor-system
       - robot-system
@@ -318,6 +377,7 @@ topics:
       - embodichain/lab/sim/planners/motion_generator.py
       - embodichain/lab/sim/skills/scene.py
     related_topics:
+      - simulation-system
       - robot-system
       - ik-solvers
       - atomic-actions
@@ -329,6 +389,10 @@ topics:
       - rl learning
       - learning rl
       - rl training
+      - rl pipeline
+      - rl config
+      - train rl
+      - train-rl
       - reinforcement learning
       - ppo
       - apg
@@ -339,6 +403,7 @@ topics:
       - rollout buffer
       - 强化学习
       - RL训练
+      - 强化学习训练
     keywords:
       - rl
       - reinforcement
@@ -354,23 +419,42 @@ topics:
       - collector
       - policy
       - reward
+      - RolloutKind
+      - DifferentiableTrainer
+      - SyncCollector
+      - learning_env
+      - gym_config
+      - checkpoint
+      - evaluation
+      - distributed
     paths:
       - topics/rl-learning/rl-learning.md
     source_of_truth:
+      - embodichain/__main__.py
+      - embodichain/learning/rl/train.py
       - embodichain/learning/rl/env.py
       - embodichain/learning/rl/evaluation.py
       - embodichain/learning/rl/routing.py
       - embodichain/learning/rl/differentiable_trainer.py
-      - embodichain/learning/rl/experimental/newton/
-      - embodichain/learning/rl/train.py
+      - embodichain/learning/rl/utils/config.py
+      - embodichain/learning/rl/utils/helper.py
+      - embodichain/learning/rl/utils/optimizer.py
+      - embodichain/learning/rl/utils/trainer.py
       - embodichain/learning/rl/algo/
       - embodichain/learning/rl/buffer/
       - embodichain/learning/rl/models/
       - embodichain/learning/rl/collector/
-      - embodichain_tasks/embodichain_tasks/rl/basic/point_mass.py
+      - embodichain/learning/rl/experimental/newton/
+      - embodichain/lab/gym/utils/gym_utils.py
+      - embodichain/lab/gym/utils/registration.py
+      - embodichain/utils/utility.py
+      - embodichain_tasks/configs/agents/rl/
+      - embodichain_tasks/embodichain_tasks/rl/
     related_topics:
+      - simulation-system
       - env-framework
       - manager-functor
+      - configclass-pattern
     status: active
 
   - id: configclass-pattern
@@ -396,6 +480,7 @@ topics:
     source_of_truth:
       - embodichain/utils/configclass.py
     related_topics:
+      - simulation-system
       - env-framework
       - manager-functor
       - robot-system
@@ -595,6 +680,7 @@ topics:
       - embodichain/lab/sim/skills/profiles.py
       - embodichain/lab/sim/skills/__init__.py
     related_topics:
+      - simulation-system
       - motion-planning
       - robot-system
       - ik-solvers

--- a/agent_context/topics/rl-learning/rl-learning.md
+++ b/agent_context/topics/rl-learning/rl-learning.md
@@ -4,262 +4,230 @@
 
 | What | Path |
 |------|------|
-| CLI entry | `embodichain/learning/rl/train.py` → `parse_args()` + `train_from_config(config_path)` |
-| Trainer class | `embodichain/learning/rl/utils/trainer.py` → `Trainer` |
-| Package init | `embodichain/learning/rl/__init__.py` — re-exports `algo`, `buffer`, `models`, `utils` |
+| Unified CLI | `embodichain train-rl --config <train.yaml-or-json>` |
+| CLI implementation | `embodichain/learning/rl/train.py` → `cli()` |
+| Programmatic training | `embodichain/learning/rl/train.py` → `train_from_config()` |
+| Algorithm registry | `embodichain/learning/rl/algo/__init__.py` |
+| Policy registry | `embodichain/learning/rl/models/__init__.py` |
+| Lightweight env registry | `embodichain/learning/rl/env.py` |
+| Standard trainer | `embodichain/learning/rl/utils/trainer.py` → `Trainer` |
+| Differentiable trainer | `embodichain/learning/rl/differentiable_trainer.py` |
+| Official configs | `embodichain_tasks/configs/agents/rl/` |
 
-Run training:
-```bash
-python -m embodichain.learning.rl.train --config <path-to-yaml-or-json> [--distributed | --no-distributed]
-```
-
-## Overview
-
-The RL subsystem implements on-policy reinforcement learning with a modular pipeline:
-
-1. **Config** — JSON/YAML file defines `trainer`, `policy`, and `algorithm` blocks.
-2. **Environment** — Simulator tasks use `build_env()`; lightweight tensor
-   tasks use the `learning_env` registry. Official tasks live in
-   `embodichain_tasks`.
-3. **Policy** — Neural-network module (`Policy` ABC) producing actions from observations.
-4. **Collector** — Steps the env, writes transitions into a preallocated `TensorDict`.
-5. **Buffer** — `RolloutBuffer` owns the preallocated storage; marks it full after collection.
-6. **Algorithm** — Consumes the rollout, computes losses, and updates policy weights.
-7. **Trainer** — Orchestrates the collect → update → log → eval → checkpoint loop.
-
-Standard PPO/GRPO rollout data flows as `TensorDict` objects (from the
-`tensordict` library).
-
-## Differentiable RL
-
-**Sources**: `env.py`, `collector/differentiable.py`, `algo/apg.py`,
-`differentiable_trainer.py`
-
-- `DifferentiableVecEnv.step()` preserves gradients through rewards and the
-  differentiable next state.
-- `detach_state()` creates the TBPTT boundary without resetting the environment.
-- `DifferentiableCollector` keeps graph-connected transitions outside the
-  standard preallocated buffer and preserves the policy mode selected by its
-  caller.
-- Differentiable policy sampling uses `get_differentiable_action()` and
-  `rsample()`.
-- `APG` maximizes segmented discounted return with optional entropy, gradient
-  clipping, and non-finite update protection.
-- `DifferentiableTrainer.segment_length` controls the TBPTT boundary, while
-  `update_horizon` independently controls environment steps per optimizer
-  update. Segment losses backpropagate immediately, state is detached after
-  each segment, and policy gradients accumulate until one update horizon is
-  complete.
-- Checkpoints store policy, optimizer, optional LR scheduler, trainer counters, and best-evaluation
-  state.
-- Training selects `policy.train()`, while evaluation temporarily selects
-  `policy.eval()` and restores the previous mode afterward.
-
-The collector paths are intentionally separate:
-- PPO/GRPO use `SyncCollector` and `TensorDict`.
-- APG uses `DifferentiableCollector` and `DifferentiableRollout`.
-
-APG is registered with `RolloutKind.DIFFERENTIABLE`. The shared `train.py`
-entry point routes it to `DifferentiableTrainer`; PPO/GRPO declare
-`RolloutKind.STANDARD` and continue to use `Trainer`. Collectors and rollout
-types remain separate even though environment construction, policy building,
-evaluation, logging, and checkpoint conventions are shared.
-
-`PointMassRL` in
-`embodichain_tasks/embodichain_tasks/rl/basic/point_mass.py` is the canonical
-dual-path task. The same differentiable PyTorch dynamics run under
-`torch.no_grad()` for PPO and preserve the action-to-reward graph for APG.
-
-### Newton Reference
-
-`experimental/newton/planar_reach.py` is an FK-only two-link test environment.
-It bridges reward, joint-state, and end-effector gradients from
-`newton.eval_fk` and a Warp tape into PyTorch. It is not a dynamics simulator
-or a task implementation for NMG.
-
-The training demo runs APG through `DifferentiableTrainer`, samples new initial
-joints and FK-reachable targets for every update, then evaluates the learned
-policy on held-out random seeds:
+The compatibility module entry point is:
 
 ```bash
-python -m embodichain.learning.rl.experimental.newton.train_planar_reach \
-  --device cuda:0
+python -m embodichain.learning.rl.train --config <train.yaml-or-json>
 ```
 
-With the default seeds, 600 updates improve the mean minimum distance from
-`1.85` to `0.039` and reach an `86.7%` success rate across 512 held-out samples
-at the `0.05` threshold. Tests also cover analytical FK, finite-difference
-gradients, TBPTT, APG updates, and held-out improvement.
+Prefer the unified `embodichain train-rl` command.
 
-## Architecture
+## Configuration Resolution
 
-```
-train_from_config()
-  ├─ build_env() | build_learning_env()
-  ├─ build_policy(policy_block, ...) → Policy (ActorCritic | ActorOnly | custom)
-  ├─ build_algo(name, cfg, policy)   → Algorithm (PPO | GRPO | APG)
-  └─ route by RolloutKind
-       ├─ STANDARD       → Trainer + SyncCollector + RolloutBuffer
-       └─ DIFFERENTIABLE → DifferentiableTrainer + DifferentiableCollector
-```
+Training configs are JSON or YAML mappings with three top-level blocks:
 
-Both trainers call `evaluation.evaluate_episodes()` with an independent
-evaluation environment. It counts actual completed episodes under asynchronous
-auto-reset and logs terminal-only metrics as `eval/*`.
+- `trainer`: environment selection, runtime, rollout, evaluation, logging,
+  checkpoint, and distributed settings;
+- `policy`: registered policy name and network definitions;
+- `algorithm`: registered algorithm name plus its config mapping.
+
+The resolution flow is:
 
 ```text
-Trainer(policy, env, algorithm, ...)
-       ├─ RolloutBuffer  [buffer/standard_buffer.py]
-       ├─ SyncCollector  [collector/sync_collector.py]
-       └─ .train(total_timesteps)
-            loop:
-              _collect_rollout()  →  buffer.start_rollout() → collector.collect() → buffer.add()
-              algorithm.update(buffer.get())
-              _log_train(losses)
-              _eval_once()  (if eval_freq hit)
-              save_checkpoint()  (if save_freq hit)
+CLI --config
+  → load_config()
+  → trainer / policy / algorithm blocks
+  → choose trainer.learning_env or trainer.gym_config
+  → build environment
+  → build policy and optional MLP modules
+  → build algorithm config from the registry
+  → route by algorithm.rollout_kind
+  → train, evaluate, log, and checkpoint
 ```
 
-## PPO Algorithm
+Read concrete values from the selected config and current config classes. Do
+not assume example-config values are global defaults.
 
-**Source**: `embodichain/learning/rl/algo/ppo.py`
+## Environment Paths
 
-- Config: `PPOCfg(AlgorithmCfg)` — `n_epochs=10`, `clip_coef=0.2`, `ent_coef=0.01`, `vf_coef=0.5`.
-- Inherits `AlgorithmCfg` defaults: nested `optimizer` (`adam`, `lr=3e-4`), optional `lr_scheduler`, `batch_size=64`, `gamma=0.99`, `gae_lambda=0.95`, `max_grad_norm=0.5`.
-- `update(rollout)` flow:
-  1. `compute_gae(rollout, gamma, gae_lambda)` — writes `advantage` and `return` into the TensorDict.
-  2. `transition_view(rollout, flatten=True)` — drops padded final slot, flattens to `[N*T]`.
-  3. For `n_epochs` × minibatch iterations:
-     - Evaluate current policy: `policy.evaluate_actions(batch)` → `logprobs`, `entropy`, `values`.
-     - Clipped surrogate objective + value loss + entropy bonus.
-     - Adam step with `max_grad_norm` clipping.
+### Simulator Gym Environment
 
-### GRPO Algorithm
+Select this path with `trainer.gym_config`.
 
-**Source**: `embodichain/learning/rl/algo/grpo.py`
+1. The CLI discovers installed task packages and executes their init hooks.
+2. `train_from_config()` loads the gym config.
+3. `config_to_cfg()` builds the environment config and manager functors.
+4. Trainer runtime fields override simulation device, GPU, renderer, headless
+   mode, environment count, and optional profiling.
+5. `build_env()` constructs the registered Gym environment.
+6. A sample reset determines flattened observation and action dimensions.
 
-- Config: `GRPOCfg(AlgorithmCfg)` — `group_size=4`, `kl_coef=0.02`, `ent_coef=0.0`, `reset_every_rollout=True`, `truncate_at_first_done=True`.
-- Maintains a frozen `ref_policy` deepcopy for KL penalty when `kl_coef > 0`.
-- Requires `group_size >= 2` for within-group advantage normalization.
+Simulator environments use standard rollouts. A differentiable algorithm on
+this path is rejected.
 
-### Algorithm Registry
+Direct callers of `train_from_config()` that bypass `cli()` must ensure
+task packages and init hooks needed by a simulator environment have already
+been loaded.
 
-**Source**: `embodichain/learning/rl/algo/__init__.py`
+### Lightweight Learning Environment
 
-```python
-_ALGO_REGISTRY = {
-    "apg": (APGCfg, APG),
-    "ppo": (PPOCfg, PPO),
-    "grpo": (GRPOCfg, GRPO),
-}
-build_algo(name, cfg_kwargs, policy, device, distributed=False)
+Select this path with `trainer.learning_env`, either as a registered name or
+as a mapping with `name` and `cfg`.
+
+`build_learning_env()` resolves factories registered with
+`@register_learning_env`. A learning environment implements the
+`LearningVecEnv` protocol. Differentiable algorithms additionally require
+`DifferentiableVecEnv.detach_state()` as the truncated-backpropagation
+boundary.
+
+This path supports both standard algorithms and differentiable algorithms,
+but currently rejects distributed training and environment profiling.
+
+## Rollout and Trainer Routing
+
+`BaseAlgorithm.rollout_kind` is the routing contract:
+
+```text
+RolloutKind.STANDARD
+  → Trainer
+  → SyncCollector
+  → RolloutBuffer backed by TensorDict
+  → PPO or GRPO update
+
+RolloutKind.DIFFERENTIABLE
+  → DifferentiableTrainer
+  → DifferentiableCollector
+  → graph-connected DifferentiableRollout segments
+  → APG update
 ```
 
-`APG.rollout_kind` is `RolloutKind.DIFFERENTIABLE`; PPO/GRPO use
-`RolloutKind.STANDARD`. When `distributed=True`, wraps the policy in
-`DistributedDataParallel` before passing to the algorithm and rejects
-differentiable algorithms.
+PPO and GRPO use `STANDARD`. APG uses `DIFFERENTIABLE`.
+`get_trainer_class()` centralizes this selection for lightweight learning
+environments.
 
-## Rollout Buffer
+The standard buffer reserves shape `[num_envs, rollout_length + 1]`; the
+last slot holds the bootstrap observation/value while transition-only fields
+use it as padding. The collector writes into the preallocated rollout and the
+algorithm consumes it after collection.
 
-**Source**: `embodichain/learning/rl/buffer/standard_buffer.py`
+The differentiable path does not copy transitions into the standard buffer.
+It preserves the action-to-reward autograd graph across short segments.
+`segment_length` sets TBPTT boundaries, while `update_horizon` controls
+how many environment steps contribute to one optimizer update.
 
-- `RolloutBuffer(num_envs, rollout_len, obs_dim, action_dim, device)`.
-- Preallocates a single TensorDict with batch shape `[num_envs, rollout_len + 1]`.
-- The `+1` slot holds the bootstrap observation/value; transition-only fields (`action`, `reward`, `done`) pad the final index.
-- API: `start_rollout()` → returns the shared TensorDict for the collector to write into; `add(rollout)` → marks full; `get(flatten=True)` → returns transition view and clears.
-- **Invariant**: the buffer holds at most one rollout at a time. Calling `start_rollout()` when full raises `RuntimeError`.
+## Component Ownership
 
-### Buffer Utilities
+| Component | Owner |
+|-----------|-------|
+| Algorithm base, rollout kind, optimizer scheduling | `algo/base.py`, `utils/optimizer.py` |
+| PPO, GRPO, APG implementations | `algo/ppo.py`, `algo/grpo.py`, `algo/apg.py` |
+| Standard rollout storage and views | `buffer/` |
+| Standard and differentiable collection | `collector/` |
+| Policy interface, actor-critic, actor-only, MLP builder | `models/` |
+| Standard collect/update loop | `utils/trainer.py` |
+| Differentiable TBPTT/update loop | `differentiable_trainer.py` |
+| Shared completed-episode evaluation | `evaluation.py` |
+| Learning environment protocol and registry | `env.py` |
+| End-to-end config and runtime assembly | `train.py` |
 
-**Source**: `embodichain/learning/rl/buffer/utils.py`
+Rollout payloads on the standard path are `TensorDict` objects. Policies
+consume observations and write action, log-probability, entropy, and value
+fields needed by their algorithm. Differentiable policies must expose
+graph-preserving action sampling.
 
-- `transition_view(rollout, flatten)` — slices `[:, :-1]` on transition fields, optionally reshapes to `[N*T]`.
-- `iterate_minibatches(rollout, batch_size, device)` — yields shuffled minibatches from a flattened rollout.
+## Training and Evaluation Lifecycle
 
-## Actor-Critic Models
+The standard trainer repeats:
 
-**Source**: `embodichain/learning/rl/models/`
+1. start and collect a rollout;
+2. update the algorithm;
+3. log train metrics;
+4. evaluate when the configured step boundary is reached;
+5. save periodic and best-evaluation checkpoints.
 
-### Policy ABC (`policy.py`)
-- `Policy(nn.Module, ABC)` — requires `forward()`, `get_value()`, `evaluate_actions()`.
-- `get_action()` — convenience wrapper calling `forward()` under `torch.no_grad()`.
-- `get_differentiable_action()` — explicit graph-preserving action API;
-  implementations must provide reparameterized stochastic sampling.
-- All methods consume and return `TensorDict`.
+Evaluation uses an independent environment and
+`evaluate_episodes()`. It counts completed asynchronous episodes, reports
+terminal metrics, temporarily switches the policy to evaluation mode, and
+restores its prior mode.
 
-### ActorCritic (`actor_critic.py`)
-- Gaussian policy with learnable `log_std` per action dim (clamped `[-5, 2]`).
-- Requires externally injected `actor` and `critic` `nn.Module` instances.
-- `forward(td)` → samples action from `Normal(actor(obs), exp(log_std))`, writes `action`, `sample_log_prob`, `value`.
+Checkpoints include policy parameters, trainer counters, best-evaluation
+state, and optimizer or LR-scheduler state when present.
 
-### ActorOnly (`actor_only.py`)
-- Same interface but `value` is always zeros (for algorithms like GRPO that don't use a critic).
+On the simulator path, distributed mode initializes NCCL, assigns one CUDA
+device per local rank, wraps the policy in
+`DistributedDataParallel`, aggregates step and episode statistics, and
+keeps logging, evaluation, and checkpoint ownership on rank zero.
+Differentiable algorithms and lightweight learning environments do not
+currently support this distributed path.
 
-### MLP (`mlp.py`)
-- `MLP(nn.Sequential)` — configurable hidden dims, activation, LayerNorm, dropout, orthogonal init.
+## Official Examples
 
-### Policy Registry (`__init__.py`)
-```python
-_POLICY_REGISTRY: {"actor_critic": ActorCritic, "actor_only": ActorOnly}
-build_policy(policy_block, obs_space, action_space, device, actor, critic)
-build_mlp_from_cfg(module_cfg, in_dim, out_dim)  # expects {"type": "mlp", "network_cfg": {...}}
-```
+| Example | Environment path | Config location |
+|---------|------------------|-----------------|
+| CartPole | registered simulator Gym env | `embodichain_tasks/configs/agents/rl/basic/cart_pole/` |
+| PushCube | registered simulator Gym env | `embodichain_tasks/configs/agents/rl/push_cube/` |
+| PointMass PPO | registered lightweight env, standard rollout | `embodichain_tasks/configs/agents/rl/basic/point_mass/train_ppo.yaml` |
+| PointMass APG | differentiable lightweight env | `embodichain_tasks/configs/agents/rl/basic/point_mass/train_apg.yaml` |
+| Newton planar reach | experimental differentiable FK reference | `embodichain/learning/rl/experimental/newton/` |
 
-## Training Pipeline
+`PointMassRL` is the reference environment for comparing standard and
+differentiable training over the same task dynamics. The Newton planar-reach
+example is an experimental gradient reference, not a general simulator task.
 
-**Source**: `embodichain/learning/rl/utils/trainer.py`
+## Extension Points
 
-`Trainer.__init__` creates `RolloutBuffer` and `SyncCollector`.
+### Add an Algorithm
 
-`Trainer.train(total_timesteps)` loop:
-1. `_collect_rollout()` — calls `buffer.start_rollout()`, then `collector.collect(buffer_size, rollout, on_step_callback)`, then `buffer.add(rollout)`.
-2. `algorithm.update(buffer.get(flatten=False))` — algorithm decides its own flatten/GAE logic.
-3. `_log_train(losses)` — writes to TensorBoard + optional W&B.
-4. Periodic `_eval_once(num_episodes)` and `save_checkpoint()`.
+1. Implement a `BaseAlgorithm` subclass and config under `algo/`.
+2. Declare the correct `RolloutKind`.
+3. Register the config/class pair in `algo/__init__.py`.
+4. Add focused algorithm, routing, and rollout-contract tests.
 
-Distributed training:
-- `train_from_config` initializes NCCL process group, offsets seed by rank.
-- Only rank 0 creates log dirs, TensorBoard writer, and W&B.
-- Timestamps are broadcast from rank 0 to ensure consistent run directories.
+### Add a Policy
 
-### Collector
+1. Implement the `Policy` contract under `models/`.
+2. Register it in `models/__init__.py`.
+3. Ensure its outputs satisfy every intended algorithm.
+4. Provide graph-preserving sampling if used with differentiable rollouts.
 
-**Source**: `embodichain/learning/rl/collector/sync_collector.py`
+### Add a Lightweight Environment
 
-`SyncCollector(env, policy, device, reset_every_rollout)`:
-- `collect(num_steps, rollout, on_step_callback)` — steps env synchronously, writing obs/action/reward/done into the preallocated rollout TensorDict.
-- Observations are flattened via `flatten_dict_observation()` before storage.
-- Requires a preallocated rollout (`rollout=None` raises `ValueError`).
+1. Implement `LearningVecEnv`, or `DifferentiableVecEnv` for APG.
+2. Register the factory with `@register_learning_env`.
+3. Ensure finished rows auto-reset while returning terminal reward/done with
+   the next initial observation.
+4. Add an official config under `embodichain_tasks/configs/agents/rl/` when
+   it is a bundled task.
 
-`DifferentiableCollector(env, policy, device)`:
-- Collects short segments without `torch.no_grad()` or preallocated copies.
-- Returns `DifferentiableRollout` with immutable transition records.
-- `rollout.rewards` stacks rewards as `[time, num_envs]` while retaining their
-  autograd history.
-- `detach_state()` updates the collector to the environment's detached boundary
-  observation before the next segment.
+Use `add-task-env` for simulator-backed task environments and
+`manager-functor` for their observation, reward, event, and action
+components.
 
-### Helper Utilities
+## Invariants
 
-**Source**: `embodichain/learning/rl/utils/helper.py`
-
-- `flatten_dict_observation(obs: TensorDict)` → `[num_envs, obs_dim]` tensor.
-- `dict_to_tensordict(obs_dict, device)` → converts env observation mapping to TensorDict.
+- The selected environment must expose batched observation/action spaces and
+  `num_envs`.
+- Policy observation and action dimensions must match the built environment.
+- An algorithm's `RolloutKind` must match its collector, rollout type, and
+  trainer.
+- The standard buffer holds at most one unconsumed rollout.
+- APG must retain differentiable rewards until its optimizer boundary;
+  `detach_state()` must not reset or resample the task.
+- GRPO environment count must satisfy its grouping contract.
+- Evaluation must use completed episodes and an independent environment.
+- Only rank zero owns external logging and checkpoints in distributed runs.
 
 ## Common Failure Modes
 
-| Symptom | Likely Cause |
-|---------|-------------|
-| `RuntimeError: RolloutBuffer already contains a rollout` | Called `start_rollout()` without consuming via `get()`. |
-| `ValueError: Preallocated rollout batch size mismatch` | `buffer_size` in trainer config doesn't match `num_steps` passed to collector. |
-| `ValueError: Algorithm 'X' not found` | Algo name not in `_ALGO_REGISTRY`. Check `get_registered_algo_names()`. |
-| `ValueError: ActorCritic policy requires external 'actor' and 'critic' modules` | Config uses `actor_critic` policy but doesn't define `actor`/`critic` MLP blocks in the JSON. |
-| `ValueError: Configured policy.action_dim=N does not match env action dim M` | `policy.action_dim` in config disagrees with the env's action manager. |
-| `RuntimeError: torch.distributed is not initialized` | `distributed=True` but `init_process_group()` was not called (launch via `torchrun`). |
-| `GRPO: group_size >= 2` | GRPO requires at least 2 environments per group for normalization. |
-| NaN losses | Check `log_std` bounds, gradient clipping, and reward scale. `max_grad_norm` defaults to 0.5. |
-| Stale observations after reset | `SyncCollector` resets obs via `_reset_env()` on init; set `reset_every_rollout=True` if episodes must fully reset between rollouts. |
-| `Learning environment 'X' is not registered` | Task package was not imported. Call `discover_task_packages()` / `execute_init_hooks()`, or import the task module that uses `@register_learning_env`. |
-| `Differentiable algorithms require trainer.learning_env` | APG cannot train simulator `gym_config` envs; use a registered `learning_env` such as `PointMassRL`. |
-| Eval success rate stuck near zero | Confirm `evaluate_episodes` reads terminal-only `success`/`metrics`, and that the eval env uses a held-out `eval_seed`. |
+| Symptom | Likely cause |
+|---------|--------------|
+| Algorithm or policy name is not found | Name is absent from the corresponding registry |
+| Learning environment is not found | Its task package was not discovered or the module containing its decorator was not imported |
+| Differentiable algorithm rejects the config | The config selected `trainer.gym_config` instead of a differentiable `learning_env` |
+| Distributed training is rejected | The request uses a lightweight/differentiable path, or the process group/CUDA device is not initialized |
+| Policy dimension mismatch | Policy config disagrees with the built environment's observation or action space |
+| Standard buffer is already full | A rollout was started before the previous one was consumed with `get()` |
+| APG gradients disappear | Actions were sampled under `no_grad`, transitions were copied/detached, or the state was detached too early |
+| GRPO reshape or grouping fails | `num_envs` is not divisible by `group_size` |
+| Evaluation never completes | The environment does not emit completed asynchronous episodes or terminal metrics correctly |
+| Output/checkpoint directories diverge across ranks | Distributed run metadata was not coordinated through rank zero |

--- a/agent_context/topics/simulation-system/simulation-system.md
+++ b/agent_context/topics/simulation-system/simulation-system.md
@@ -1,0 +1,147 @@
+# Simulation System
+
+## Entry Points
+
+| What | Path |
+|------|------|
+| Public simulation package | `embodichain/lab/sim/__init__.py` |
+| World and scene owner | `embodichain/lab/sim/sim_manager.py` → `SimulationManager` |
+| Global simulation config | `embodichain/lab/sim/sim_manager.py` → `SimulationManagerCfg` |
+| Object and physics configs | `embodichain/lab/sim/cfg.py` |
+| Gym lifecycle integration | `embodichain/lab/gym/envs/base_env.py` |
+| Task scene construction | `embodichain/lab/gym/envs/embodied_env.py` |
+
+`embodichain.lab.sim` exports the manager, its config, shared material
+types, `BatchEntity`, and the simulation profiler. Import a specialized
+object, sensor, solver, planner, or atomic-action API from its own subpackage.
+
+## Ownership
+
+`SimulationManager` owns one DexSim `World`, its global environment,
+parallel arenas, and the Python registries for scene resources:
+
+- rigid objects and rigid-object groups;
+- soft and cloth objects;
+- articulations and robots;
+- rigid constraints, sensors, lights, gizmos, and markers;
+- visual materials and texture caches;
+- the optional browser-visualization runtime.
+
+The manager owns simulation resources and physics stepping. `BaseEnv` owns
+the Gym reset/step contract. `EmbodiedEnv` translates task configuration
+into robots, sensors, lights, backgrounds, articulations, and interactive
+objects added through the manager.
+
+## Lifecycle
+
+The environment-owned lifecycle is:
+
+```text
+EnvCfg.sim_cfg
+  → BaseEnv._setup_scene()
+  → SimulationManager(SimulationManagerCfg)
+  → create World, global environment, defaults, and N arenas
+  → EmbodiedEnv adds robot, objects, lights, and sensors
+  → initialize GPU physics after scene construction when using CUDA
+  → BaseEnv.step()
+       → preprocess/apply action
+       → SimulationManager.update(physics_dt, sim_steps_per_control)
+       → update task state, observations, rewards, and termination
+  → BaseEnv.reset()
+       → SimulationManager.reset_objects_state(env_ids)
+       → task episode-initialization hook
+  → BaseEnv.close()
+       → profiler report
+       → SimulationManager.destroy()
+```
+
+`BaseEnv._setup_scene()` temporarily constructs the manager headlessly so
+the scene can be assembled before a native window is opened. It sets
+`SimulationManagerCfg.num_envs` from `EnvCfg.num_envs`.
+
+`SimulationManager` enables physics, selects manual physics updates, creates
+the configured arenas, installs default plane/background/lighting resources,
+and starts configured visualization during initialization. A Viser backend
+forces `headless=True`; Viser and the native DexSim window are mutually
+exclusive.
+
+`SimulationManager.update()` initializes GPU physics lazily if needed and
+then advances the world for the requested number of physics steps. Each
+environment control step normally calls it with
+`sim_steps_per_control`.
+
+## Module Boundaries
+
+| Area | Owner | Routed topic |
+|------|-------|--------------|
+| World, arenas, asset registries, physics update, cleanup | `sim_manager.py` | `simulation-system` |
+| Shared object, render, physics, drive, and URDF configs | `cfg.py` | `configclass-pattern` for config mechanics |
+| Rigid, deformable, articulation, robot, light, constraint, gizmo | `objects/` | `robot-system` for robots |
+| Camera, stereo camera, contact sensor | `sensors/` | `sensor-system` |
+| Robot-specific configuration | `robots/` | `robot-system` |
+| Inverse kinematics | `solvers/` | `ik-solvers` |
+| Trajectory and motion generation | `planners/` | `motion-planning` |
+| Typed action planning and execution | `atomic_actions/` | `atomic-actions` |
+| Semantic scene and robot skill bindings | `skills/` | `atomic-actions` |
+| Reachability analysis and runtime workspace queries | `workspace/` | `robot-system` |
+| Browser scene export and Viser runtime | `embodichain/lab/visualization/` | `sim-visualization` |
+
+Use the narrow topic when a request names one of these subsystems. Use
+`simulation-system` for the overall `lab/sim` architecture, manager
+lifecycle, scene ownership, or cross-module flow.
+
+## Configuration Flow
+
+`SimulationManagerCfg` owns window size, headless mode, rendering, GPU/CPU
+selection, arena count and spacing, physics timestep, physics and GPU-memory
+settings, recording, profiling, and browser visualization.
+
+`EnvCfg` embeds `SimulationManagerCfg` and supplies the control-to-physics
+step ratio. CLI and task config loaders may override runtime fields before
+constructing the environment. Trace those overrides through the caller rather
+than changing a default in the manager blindly.
+
+Object-specific configuration belongs in `lab/sim/cfg.py` or the
+corresponding robot/sensor module. Scene composition belongs in
+`EmbodiedEnv` or a task config, not in `SimulationManagerCfg`.
+
+## Where to Make Changes
+
+| Change | Primary location |
+|--------|------------------|
+| Global world, renderer, device, arena, or physics lifecycle | `sim_manager.py` |
+| Shared object or physics config type | `cfg.py` |
+| Add/get/remove behavior for a scene entity | `sim_manager.py` plus its `objects/` implementation |
+| Task scene composition | `embodied_env.py` or the task config |
+| Environment timing, reset, or control-step behavior | `base_env.py` and `env-framework` |
+| Robot, sensor, solver, planner, or atomic action | Follow the corresponding routed topic and add-* skill |
+| Browser visualization | `embodichain/lab/visualization/` and `sim-visualization` |
+
+## Invariants
+
+- Configure `num_envs`, device, renderer, and physics settings before
+  constructing `SimulationManager`.
+- Treat resource UIDs as registry identities; retrieve and mutate resources
+  through the manager instead of maintaining a parallel scene registry.
+- Keep batched object and sensor state aligned with the manager's arena count.
+- Build scene assets before explicitly initializing GPU physics. The manager
+  will warn and initialize lazily on the first update if this was missed.
+- Manual update is the default; normal environment stepping must advance
+  physics through `SimulationManager.update()`.
+- Reset only the requested environment rows and honor
+  `excluded_uids` for resources detached from automatic reset.
+- `destroy()` queues deferred cleanup. Tests and non-exiting standalone
+  callers that use `exit_process=False` must call
+  `SimulationManager.flush_cleanup_queue()`.
+
+## Common Failure Modes
+
+| Symptom | Likely cause |
+|---------|--------------|
+| Scene resource cannot be found or the wrong object is returned | UID mismatch or code bypassed the manager registry |
+| CUDA physics data is stale on the first step | GPU physics was initialized before all assets were added, or not initialized explicitly |
+| Native window does not open | `headless=True`, often forced by the Viser backend |
+| Device and renderer use the wrong GPU | `sim_device` and `gpu_id` disagree; the device index takes precedence for CUDA simulation |
+| Simulation advances at the wrong control rate | `physics_dt` and `sim_steps_per_control` were configured inconsistently; see `env-framework` |
+| A test leaks a DexSim world | `destroy(exit_process=False)` was called without flushing the cleanup queue |
+| Python exits during cleanup | `destroy()` used its process-exit default; pass `exit_process=False` for embedded or test lifecycles |

--- a/tests/test_agent_context_map.py
+++ b/tests/test_agent_context_map.py
@@ -1,0 +1,181 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+_REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+_AGENT_CONTEXT_ROOT = _REPOSITORY_ROOT / "agent_context"
+_MAP_PATH = _AGENT_CONTEXT_ROOT / "MAP.yaml"
+_REQUIRED_TOPIC_FIELDS = {
+    "id",
+    "title",
+    "aliases",
+    "keywords",
+    "paths",
+    "source_of_truth",
+    "related_topics",
+    "status",
+}
+
+
+def _load_context_map() -> dict:
+    with _MAP_PATH.open(encoding="utf-8") as stream:
+        return yaml.safe_load(stream)
+
+
+def _topics_by_id() -> dict[str, dict]:
+    return {topic["id"]: topic for topic in _load_context_map()["topics"]}
+
+
+def test_topic_ids_are_unique() -> None:
+    topics = _load_context_map()["topics"]
+    topic_ids = [topic["id"] for topic in topics]
+
+    assert len(topic_ids) == len(set(topic_ids))
+
+
+def test_topic_entries_use_the_required_schema() -> None:
+    errors: list[str] = []
+    for topic in _load_context_map()["topics"]:
+        missing = _REQUIRED_TOPIC_FIELDS - set(topic)
+        if missing:
+            errors.append(
+                f"{topic.get('id', '<missing-id>')}: missing {sorted(missing)}"
+            )
+        if topic.get("status") not in {"active", "deprecated"}:
+            errors.append(
+                f"{topic.get('id', '<missing-id>')}: invalid status "
+                f"{topic.get('status')!r}"
+            )
+
+    assert errors == []
+
+
+def test_registered_context_and_source_paths_exist() -> None:
+    context_map = _load_context_map()
+    missing_paths: list[str] = []
+
+    for context_path in context_map["defaults"]["contexts"]:
+        resolved = _AGENT_CONTEXT_ROOT / context_path
+        if not resolved.exists():
+            missing_paths.append(str(resolved.relative_to(_REPOSITORY_ROOT)))
+
+    for topic in context_map["topics"]:
+        for context_path in topic["paths"]:
+            resolved = _AGENT_CONTEXT_ROOT / context_path
+            if not resolved.exists():
+                missing_paths.append(str(resolved.relative_to(_REPOSITORY_ROOT)))
+        for source_path in topic["source_of_truth"]:
+            resolved = _REPOSITORY_ROOT / source_path
+            if not resolved.exists():
+                missing_paths.append(str(resolved.relative_to(_REPOSITORY_ROOT)))
+
+    assert missing_paths == []
+
+
+def test_related_topics_reference_registered_ids() -> None:
+    topics = _topics_by_id()
+    invalid_relations = [
+        f"{topic_id} -> {related_id}"
+        for topic_id, topic in topics.items()
+        for related_id in topic["related_topics"]
+        if related_id not in topics
+    ]
+
+    assert invalid_relations == []
+
+
+def test_simulation_and_rl_topics_cover_their_primary_entry_points() -> None:
+    topics = _topics_by_id()
+
+    assert {
+        "embodichain/lab/sim/__init__.py",
+        "embodichain/lab/sim/sim_manager.py",
+        "embodichain/lab/gym/envs/base_env.py",
+    } <= set(topics["simulation-system"]["source_of_truth"])
+    assert {
+        "embodichain/__main__.py",
+        "embodichain/learning/rl/train.py",
+        "embodichain/learning/rl/utils/trainer.py",
+        "embodichain_tasks/configs/agents/rl/",
+    } <= set(topics["rl-learning"]["source_of_truth"])
+
+
+def test_simulation_and_rl_topics_have_operational_sections() -> None:
+    topics = _topics_by_id()
+    required_sections = {
+        "## Entry Points",
+        "## Invariants",
+        "## Common Failure Modes",
+    }
+    missing_sections: list[str] = []
+
+    for topic_id in ("simulation-system", "rl-learning"):
+        context_path = _AGENT_CONTEXT_ROOT / topics[topic_id]["paths"][0]
+        content = context_path.read_text(encoding="utf-8")
+        for section in required_sections:
+            if section not in content:
+                missing_sections.append(f"{topic_id}: {section}")
+
+    assert missing_sections == []
+
+
+def test_representative_navigation_terms_have_one_owner() -> None:
+    expected_owners = {
+        "simulation manager": "simulation-system",
+        "SimulationManager": "simulation-system",
+        "viser": "sim-visualization",
+        "rl config": "rl-learning",
+        "train-rl": "rl-learning",
+        "ik solver": "ik-solvers",
+    }
+    topics = _load_context_map()["topics"]
+    actual_owners: dict[str, set[str]] = {}
+
+    for term in expected_owners:
+        normalized_term = term.casefold()
+        actual_owners[term] = {
+            topic["id"]
+            for topic in topics
+            if normalized_term
+            in {
+                candidate.casefold()
+                for candidate in [*topic["aliases"], *topic["keywords"]]
+            }
+        }
+
+    assert actual_owners == {
+        term: {topic_id} for term, topic_id in expected_owners.items()
+    }
+
+
+def test_project_context_adapters_reference_the_canonical_skill() -> None:
+    canonical_path = ".agents/skills/project-dev-context/SKILL.md"
+    adapter_paths = (
+        _REPOSITORY_ROOT / ".claude/skills/project-dev-context/SKILL.md",
+        _REPOSITORY_ROOT / ".github/copilot/project-dev-context.md",
+    )
+    missing_references = [
+        str(path.relative_to(_REPOSITORY_ROOT))
+        for path in adapter_paths
+        if canonical_path not in path.read_text(encoding="utf-8")
+    ]
+
+    assert missing_references == []


### PR DESCRIPTION
## Description

This PR expands the canonical project development context skill from explicit context reads and maintenance into live codebase navigation.

It:

- adds a `navigate` mode for locating files, configs, defaults, entry points, registration paths, and recommended change sites;
- verifies matched context against current `source_of_truth` files and defines a live-search fallback for unmatched questions;
- adds the `simulation-system` topic and refreshes the `rl-learning` topic;
- synchronizes the canonical skill, adapters, contributor guidance, and project agent instructions;
- adds focused validation for the context map, topic paths, routing ownership, and adapter references.

This makes common questions such as “where is this configured?” usable without requiring an explicit “reference project context” prompt.

Issue: none.

Dependencies: none.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which improves an existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (existing functionality will not work without user modification)
- [ ] Documentation update

## Screenshots

Not applicable; this change has no visual surface.

## Validation

- `black --check --diff --color ./` — 667 files unchanged
- `black .` — 667 files unchanged
- `pytest -q tests/test_agent_context_map.py` — 8 passed
- `git diff --check`

The full pytest suite and Sphinx build were not run because runtime code, dependencies, test configuration, and `docs/source/` are unchanged.

## Checklist

- [x] I have run the `black .` command to format the code base.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove the change is effective.
- [x] Dependencies have been updated, if applicable (not applicable).
