### PR TITLE
Fix Python 3.10 unified CLI imports

### DIFF
--- a/embodichain/__main__.py
+++ b/embodichain/__main__.py
@@ -30,8 +30,12 @@ import json
 import sys
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
-from importlib.resources.abc import Traversable
 from typing import Any
+
+try:
+    from importlib.resources.abc import Traversable
+except ModuleNotFoundError:  # Python 3.10 compatibility.
+    from importlib.abc import Traversable
 
 from embodichain import __version__
 


### PR DESCRIPTION
# Description

Restore the unified `embodichain` CLI on Python 3.10 by falling back to `importlib.abc.Traversable` when `importlib.resources.abc` is unavailable.

Commit `1352f988` introduced the Python 3.11+ import path while the project still declares `requires-python = ">=3.10"`. On Python 3.10, every `python -m embodichain ...` command failed during module import before subcommand dispatch. Python 3.11+ keeps using the existing resource import path.

Dependencies: none.

Issue: none.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (existing functionality will not work without user modification)
- [ ] Documentation update

## Screenshots

Not applicable; this is a CLI import compatibility fix.

## Validation

- `conda run -n embodichain040 black --check --diff --color ./` (`811 files unchanged`)
- `python docs/scripts/check_api_docs.py` (`1714/1714 exports documented`)
- Python 3.10.20: `python -m embodichain --help`
- Python 3.10.20: `python -m embodichain preview-asset --help`
- Python 3.10.20: `pytest tests/test_main.py -q` (`11 passed`)
- `git diff --check`

## Checklist

- [x] I have run the Black formatting gate.
- [x] Documentation changes are not required for this compatibility fix.
- [x] Public API documentation coverage is aligned.
- [x] Existing CLI tests prove the fix under Python 3.10.
- [x] Dependencies have not changed.
