### PR TITLE
Organize unified CLI command adapters

### DIFF
--- a/docs/source/api_reference/public_api.rst
+++ b/docs/source/api_reference/public_api.rst
@@ -1890,15 +1890,6 @@ embodichain.toolkits.urdf_assembly.urdf_assembly_manager
 
    URDFAssemblyManager
 
-embodichain.workspace_cache_cli
--------------------------------
-
-.. currentmodule:: embodichain.workspace_cache_cli
-
-.. autosummary::
-
-   main
-
 embodichain_tasks.classic_control.cart_pole
 --------------------------------------------
 

--- a/embodichain/cli/__init__.py
+++ b/embodichain/cli/__init__.py
@@ -14,14 +14,8 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
-"""Module entry point for the unified EmbodiChain command-line interface."""
+"""Command adapters used by the unified EmbodiChain CLI."""
 
 from __future__ import annotations
 
-from embodichain.cli.main import COMMANDS, Command, build_parser, main
-
-__all__ = ["COMMANDS", "Command", "build_parser", "main"]
-
-
-if __name__ == "__main__":
-    main()
+__all__: list[str] = []

--- a/embodichain/cli/list_env.py
+++ b/embodichain/cli/list_env.py
@@ -1,0 +1,359 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+"""List task environments available through installed task packages."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.metadata
+import importlib.resources
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+try:
+    from importlib.resources.abc import Traversable
+except ModuleNotFoundError:  # Python 3.10 compatibility.
+    from importlib.abc import Traversable
+
+
+_EXPERT_PROGRAM = "Expert Demo: Expert Program"
+_HANDWRITTEN_DEMO = "Expert Demo: Handwritten Trajectory"
+_RL = "RL"
+_CAPABILITY_ORDER = (_EXPERT_PROGRAM, _HANDWRITTEN_DEMO, _RL)
+
+
+@dataclass
+class _EnvironmentListEntry:
+    """One environment and its task-catalog metadata."""
+
+    env_id: str
+    task_path: tuple[str, ...]
+    capabilities: set[str]
+
+
+def _task_package_module_names() -> tuple[str, ...]:
+    """Return module names declared by installed task-package entry points."""
+    try:
+        entry_points = importlib.metadata.entry_points(group="embodichain.tasks")
+    except TypeError:
+        entry_points = importlib.metadata.entry_points().get("embodichain.tasks", [])
+
+    module_names: list[str] = []
+    for entry_point in entry_points:
+        module_name = getattr(entry_point, "module", None)
+        if module_name is None:
+            module_name = entry_point.value.partition(":")[0]
+        if module_name not in module_names:
+            module_names.append(module_name)
+    return tuple(module_names)
+
+
+def _task_path_from_module(
+    module_name: str,
+    task_package_modules: Sequence[str],
+) -> tuple[str, ...] | None:
+    """Resolve a task module to its path below an installed task package."""
+    matching_packages = [
+        package
+        for package in task_package_modules
+        if module_name == package or module_name.startswith(package + ".")
+    ]
+    if not matching_packages:
+        return None
+    package = max(matching_packages, key=len)
+    relative_module = module_name.removeprefix(package).removeprefix(".")
+    if not relative_module:
+        return None
+    return tuple(relative_module.split("."))
+
+
+def _task_config_roots(
+    task_package_modules: Sequence[str],
+) -> tuple[Traversable, ...]:
+    """Locate packaged ``configs/tasks`` trees for installed task packages."""
+    roots: list[Traversable] = []
+    visited_packages: set[str] = set()
+    for task_package in task_package_modules:
+        config_packages = (
+            f"{task_package}.configs",
+            f"{task_package.partition('.')[0]}.configs",
+        )
+        for config_package in config_packages:
+            if config_package in visited_packages:
+                continue
+            visited_packages.add(config_package)
+            try:
+                root = importlib.resources.files(config_package).joinpath("tasks")
+            except (ModuleNotFoundError, TypeError):
+                continue
+            if root.is_dir():
+                roots.append(root)
+                break
+    return tuple(roots)
+
+
+def _load_mapping(resource: Traversable) -> Mapping[str, Any]:
+    """Load one JSON or YAML task configuration as a mapping."""
+    text = resource.read_text(encoding="utf-8")
+    if resource.name.endswith(".json"):
+        value = json.loads(text)
+    else:
+        import yaml
+
+        value = yaml.safe_load(text)
+    if not isinstance(value, Mapping):
+        raise TypeError(f"Task config must contain a mapping: {resource}")
+    return value
+
+
+def _iter_task_directories(
+    root: Traversable,
+    relative_path: tuple[str, ...] = (),
+):
+    """Yield task directories and their paths below a config root."""
+    children = sorted(root.iterdir(), key=lambda child: child.name.casefold())
+    child_by_name = {child.name: child for child in children}
+    env_configs = [
+        child
+        for child in children
+        if child.is_file()
+        and child.name.startswith("env")
+        and child.name.endswith((".json", ".yaml", ".yml"))
+    ]
+    agents = child_by_name.get("agents")
+    if env_configs or (agents is not None and agents.is_dir()):
+        yield relative_path, env_configs, agents
+
+    for child in children:
+        if not child.is_dir() or child.name in {"agents", "expert"}:
+            continue
+        yield from _iter_task_directories(child, (*relative_path, child.name))
+
+
+def _merge_environment_entry(
+    entries: dict[str, _EnvironmentListEntry],
+    *,
+    env_id: str,
+    task_path: tuple[str, ...],
+    capabilities: Sequence[str] = (),
+) -> _EnvironmentListEntry:
+    """Merge one catalog source into a case-insensitive environment record."""
+    key = env_id.casefold()
+    entry = entries.get(key)
+    if entry is None:
+        entry = _EnvironmentListEntry(env_id, task_path, set())
+        entries[key] = entry
+    entry.capabilities.update(capabilities)
+    return entry
+
+
+def _config_environment_entries(
+    config_roots: Sequence[Traversable],
+) -> dict[str, _EnvironmentListEntry]:
+    """Collect environment metadata encoded by task-local configs."""
+    entries: dict[str, _EnvironmentListEntry] = {}
+    for root in config_roots:
+        for task_path, env_resources, agents in _iter_task_directories(root):
+            env_ids: list[str] = []
+            for resource in env_resources:
+                config = _load_mapping(resource)
+                env_id = config.get("id")
+                if not isinstance(env_id, str) or not env_id:
+                    continue
+                capabilities = []
+                if (
+                    "expert_program_path" in config
+                    or "expert_program_runtime" in config
+                ):
+                    capabilities.append(_EXPERT_PROGRAM)
+                _merge_environment_entry(
+                    entries,
+                    env_id=env_id,
+                    task_path=task_path,
+                    capabilities=capabilities,
+                )
+                env_ids.append(env_id)
+
+            if agents is None or not agents.is_dir():
+                continue
+            agent_resources = sorted(
+                (
+                    child
+                    for child in agents.iterdir()
+                    if child.is_file()
+                    and child.name.endswith((".json", ".yaml", ".yml"))
+                ),
+                key=lambda child: child.name.casefold(),
+            )
+            if agent_resources:
+                for env_id in env_ids:
+                    _merge_environment_entry(
+                        entries,
+                        env_id=env_id,
+                        task_path=task_path,
+                        capabilities=(_RL,),
+                    )
+            for resource in agent_resources:
+                config = _load_mapping(resource)
+                trainer = config.get("trainer")
+                if not isinstance(trainer, Mapping):
+                    continue
+                learning_env = trainer.get("learning_env")
+                if isinstance(learning_env, Mapping):
+                    learning_env = learning_env.get("name")
+                if isinstance(learning_env, str) and learning_env:
+                    _merge_environment_entry(
+                        entries,
+                        env_id=learning_env,
+                        task_path=task_path,
+                        capabilities=(_RL,),
+                    )
+    return entries
+
+
+def _implements_handwritten_demo(env_cls: type[Any]) -> bool:
+    """Return whether an environment overrides either demo authoring hook."""
+    from embodichain.lab.gym.envs import EmbodiedEnv
+
+    return any(
+        getattr(env_cls, method_name, None)
+        is not getattr(EmbodiedEnv, method_name, None)
+        for method_name in ("create_demo_segments", "create_demo_action_list")
+    )
+
+
+def _collect_environment_entries() -> list[_EnvironmentListEntry]:
+    """Build the task listing from packaged configs and runtime registries."""
+    from embodichain.lab.gym.utils.registration import REGISTERED_ENVS
+    from embodichain.learning.rl.env import get_registered_learning_env_names
+
+    task_packages = _task_package_module_names()
+    entries = _config_environment_entries(_task_config_roots(task_packages))
+
+    for env_id, spec in REGISTERED_ENVS.items():
+        task_path = _task_path_from_module(spec.cls.__module__, task_packages)
+        existing = entries.get(env_id.casefold())
+        if task_path is None and existing is None:
+            continue
+        capabilities: list[str] = []
+        if (
+            spec.expert_program_registration is not None
+            or spec.expert_program_adapter_factory is not None
+        ):
+            capabilities.append(_EXPERT_PROGRAM)
+        elif _implements_handwritten_demo(spec.cls):
+            capabilities.append(_HANDWRITTEN_DEMO)
+        if spec.supports_rl:
+            capabilities.append(_RL)
+        _merge_environment_entry(
+            entries,
+            env_id=env_id,
+            task_path=task_path if existing is None else existing.task_path,
+            capabilities=capabilities,
+        )
+
+    for env_id in get_registered_learning_env_names():
+        existing = entries.get(env_id.casefold())
+        _merge_environment_entry(
+            entries,
+            env_id=env_id,
+            task_path=(
+                ("uncategorized", env_id) if existing is None else existing.task_path
+            ),
+            capabilities=(_RL,),
+        )
+
+    return sorted(
+        entries.values(),
+        key=lambda entry: (
+            tuple(part.casefold() for part in entry.task_path),
+            entry.env_id.casefold(),
+        ),
+    )
+
+
+def _print_environment_entries(entries: Sequence[_EnvironmentListEntry]) -> None:
+    """Print environment entries as a table with a task-directory tree."""
+    from prettytable import PrettyTable
+
+    table = PrettyTable()
+    table.title = f"Environments ({len(entries)})"
+    table.field_names = ["Task", "Environment ID", "Capability"]
+    table.align = "l"
+    active_categories: tuple[str, ...] = ()
+    for entry in entries:
+        categories = entry.task_path[:-1]
+        shared_depth = 0
+        for active, category in zip(active_categories, categories):
+            if active != category:
+                break
+            shared_depth += 1
+        for depth in range(shared_depth, len(categories)):
+            table.add_row([f"{'  ' * depth}{categories[depth]}/", "", ""])
+
+        task_name = entry.task_path[-1]
+        labels = [
+            capability
+            for capability in _CAPABILITY_ORDER
+            if capability in entry.capabilities
+        ]
+        if not labels:
+            labels.append("Environment Only")
+        table.add_row(
+            [
+                f"{'  ' * len(categories)}{task_name}",
+                entry.env_id,
+                ", ".join(labels),
+            ]
+        )
+        active_categories = categories
+    print(table)
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """List discovered EmbodiChain task environments.
+
+    Args:
+        argv: Arguments excluding the command name.
+    """
+    parser = argparse.ArgumentParser(
+        prog="embodichain list-env",
+        description="List task environments by category and capability.",
+        epilog=(
+            "Environment Only means the task currently exposes neither an "
+            "Expert Demo entry point nor a supported RL configuration."
+        ),
+    )
+    parser.parse_args(argv)
+
+    from embodichain.lab.gym.utils.registration import discover_task_packages
+
+    discover_task_packages()
+    entries = _collect_environment_entries()
+    if not entries:
+        print("No registered environments found.")
+        return
+    _print_environment_entries(entries)
+
+
+if __name__ == "__main__":
+    main()
+
+
+__all__: list[str] = []

--- a/embodichain/cli/main.py
+++ b/embodichain/cli/main.py
@@ -1,0 +1,190 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+"""Dispatcher for unified EmbodiChain CLI commands."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import sys
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+
+from embodichain import __version__
+
+
+@dataclass(frozen=True)
+class Command:
+    """Description of one lazily imported CLI command."""
+
+    name: str
+    target: str
+    help: str
+
+
+COMMANDS = (
+    Command(
+        name="data",
+        target="embodichain.data.download:main",
+        help="List and download EmbodiChain data assets.",
+    ),
+    Command(
+        name="simready",
+        target="embodichain.gen_sim.simready_pipeline.cli.start:main",
+        help="Convert a raw asset directory into a SimReady asset.",
+    ),
+    Command(
+        name="scene-engine",
+        target="embodichain.gen_sim.scene_engine.cli.start:main",
+        help="Generate a scene export from an input image using gen_sim/.env.",
+    ),
+    Command(
+        name="preview-scene",
+        target="embodichain.gen_sim.scene_engine.cli.preview:main",
+        help="Preview a generated Scene Engine scene export.",
+    ),
+    Command(
+        name="preview-asset",
+        target="embodichain.lab.scripts.preview_asset:cli",
+        help="Preview a USD, URDF, or mesh asset in simulation.",
+    ),
+    Command(
+        name="run-env",
+        target="embodichain.lab.scripts.run_env:cli",
+        help="Run an environment for data generation or preview.",
+    ),
+    Command(
+        name="list-env",
+        target="embodichain.cli.list_env:main",
+        help="List task environments by category and capability.",
+    ),
+    Command(
+        name="preview_lerobot_data",
+        target="embodichain.lab.scripts.preview_lerobot_data:cli",
+        help="Print and validate a recorded LeRobot dataset episode.",
+    ),
+    Command(
+        name="train-rl",
+        target="embodichain.learning.rl.train:cli",
+        help="Train an RL agent from a JSON or YAML config.",
+    ),
+    Command(
+        name="annotate-grasp",
+        target="embodichain.toolkits.graspkit.scripts.annotate_grasp:cli",
+        help="Interactively annotate a grasp region on a mesh.",
+    ),
+    Command(
+        name="decompose-urdf",
+        target="embodichain.toolkits.acd.cli:main",
+        help="Generate convex collision meshes for a URDF.",
+    ),
+    Command(
+        name="benchmark",
+        target="scripts.benchmark.__main__:main",
+        help="Run EmbodiChain performance benchmarks.",
+    ),
+    Command(
+        name="workspace-cache",
+        target="embodichain.cli.workspace_cache:main",
+        help="Inspect and clean workspace analyzer caches.",
+    ),
+    Command(
+        name="analyze-workspace",
+        target="embodichain.lab.scripts.analyze_workspace:cli",
+        help="Analyze a robot's reachable workspace from a URDF/USD asset.",
+    ),
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the top-level argument parser.
+
+    Returns:
+        The parser used for top-level help and command validation.
+    """
+    parser = argparse.ArgumentParser(
+        prog="embodichain",
+        description="EmbodiChain command-line interface.",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}",
+    )
+    subparsers = parser.add_subparsers(
+        dest="command",
+        metavar="COMMAND",
+        title="commands",
+    )
+    for command in COMMANDS:
+        # The command module owns its parser. Disabling help here lets
+        # ``embodichain <command> --help`` reach that complete parser.
+        subparsers.add_parser(
+            command.name,
+            add_help=False,
+            help=command.help,
+            description=command.help,
+        )
+    return parser
+
+
+def _load_handler(target: str) -> Callable[[Sequence[str] | None], None]:
+    """Load a command handler from a ``module:attribute`` target."""
+    module_name, attribute = target.split(":", maxsplit=1)
+    module = importlib.import_module(module_name)
+    return getattr(module, attribute)
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """Dispatch a command through the unified CLI.
+
+    Args:
+        argv: Arguments excluding the executable name. Uses ``sys.argv`` when
+            omitted.
+    """
+    parser = build_parser()
+    arguments = list(sys.argv[1:] if argv is None else argv)
+
+    if not arguments:
+        parser.print_help()
+        return
+
+    if arguments[0] in {"-h", "--help"}:
+        parser.parse_args(arguments)
+        return
+
+    if arguments[0] == "--version":
+        parser.parse_args(arguments)
+        return
+
+    command_by_name = {command.name: command for command in COMMANDS}
+    command = command_by_name.get(arguments[0])
+    if command is None:
+        parser.error(
+            f"argument COMMAND: invalid choice: {arguments[0]!r} "
+            f"(choose from {', '.join(command_by_name)})"
+        )
+
+    handler = _load_handler(command.target)
+    handler(arguments[1:])
+
+
+if __name__ == "__main__":
+    main()
+
+
+__all__: list[str] = []

--- a/embodichain/cli/workspace_cache.py
+++ b/embodichain/cli/workspace_cache.py
@@ -88,4 +88,4 @@ if __name__ == "__main__":
     main()
 
 
-__all__ = ["main"]
+__all__: list[str] = []

--- a/embodichain/lab/sim/workspace/caches/cache_utils.py
+++ b/embodichain/lab/sim/workspace/caches/cache_utils.py
@@ -226,7 +226,7 @@ def main(argv: Sequence[str] | None = None) -> None:
         argv: Arguments excluding the command name. Uses ``sys.argv`` when
             omitted.
     """
-    from embodichain.workspace_cache_cli import main as cli_main
+    from embodichain.cli.workspace_cache import main as cli_main
 
     cli_main(argv)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -22,7 +22,9 @@ from pathlib import Path
 
 import pytest
 
-from embodichain import __main__ as cli
+import embodichain.cli.list_env as list_env
+import embodichain.cli.main as cli
+from embodichain import __main__ as entrypoint
 
 EXPECTED_COMMANDS = {
     "analyze-workspace",
@@ -45,6 +47,26 @@ EXPECTED_COMMANDS = {
 def test_all_public_commands_are_registered() -> None:
     """Every documented public CLI should have one unified command."""
     assert {command.name for command in cli.COMMANDS} == EXPECTED_COMMANDS
+    assert entrypoint.COMMANDS is cli.COMMANDS
+    assert entrypoint.Command is cli.Command
+    assert entrypoint.build_parser is cli.build_parser
+    assert entrypoint.main is cli.main
+
+
+def test_workspace_cache_command_uses_dedicated_cli_adapter() -> None:
+    """The workspace cache command resolves its dedicated CLI adapter."""
+    command = next(
+        command for command in cli.COMMANDS if command.name == "workspace-cache"
+    )
+
+    assert command.target == "embodichain.cli.workspace_cache:main"
+
+
+def test_list_env_command_uses_dedicated_cli_adapter() -> None:
+    """The environment listing command resolves its dedicated CLI adapter."""
+    command = next(command for command in cli.COMMANDS if command.name == "list-env")
+
+    assert command.target == "embodichain.cli.list_env:main"
 
 
 def test_root_help_does_not_import_command_modules(
@@ -93,25 +115,25 @@ def test_list_env_discovers_and_prints_task_tree(
         lambda: discovery_calls.append(None),
     )
     monkeypatch.setattr(
-        cli,
+        list_env,
         "_collect_environment_entries",
         lambda: [
-            cli._EnvironmentListEntry(
+            list_env._EnvironmentListEntry(
                 "CartPoleRL",
                 ("classic_control", "cart_pole"),
-                {cli._RL},
+                {list_env._RL},
             ),
-            cli._EnvironmentListEntry(
+            list_env._EnvironmentListEntry(
                 "HandOver-v1",
                 ("manipulation", "hand_over"),
-                {cli._EXPERT_PROGRAM},
+                {list_env._EXPERT_PROGRAM},
             ),
-            cli._EnvironmentListEntry(
+            list_env._EnvironmentListEntry(
                 "BlocksRankingRGB-v1",
                 ("manipulation", "tableware", "blocks_ranking_rgb"),
-                {cli._HANDWRITTEN_DEMO},
+                {list_env._HANDWRITTEN_DEMO},
             ),
-            cli._EnvironmentListEntry(
+            list_env._EnvironmentListEntry(
                 "StackCups-v1",
                 ("manipulation", "tableware", "stack_cups"),
                 set(),
@@ -180,14 +202,14 @@ def test_config_environment_entries_use_task_paths_and_artifacts(
         encoding="utf-8",
     )
 
-    entries = cli._config_environment_entries([tmp_path])
+    entries = list_env._config_environment_entries([tmp_path])
 
     expert = entries["pickplace-v1"]
     assert expert.task_path == ("manipulation", "pick_place")
-    assert expert.capabilities == {cli._EXPERT_PROGRAM}
+    assert expert.capabilities == {list_env._EXPERT_PROGRAM}
     learning = entries["pointmassrl"]
     assert learning.task_path == ("classic_control", "point_mass")
-    assert learning.capabilities == {cli._RL}
+    assert learning.capabilities == {list_env._RL}
 
 
 def test_handwritten_demo_detection_uses_environment_hooks() -> None:
@@ -197,8 +219,8 @@ def test_handwritten_demo_detection_uses_environment_hooks() -> None:
     )
     from embodichain_tasks.special.simple_task import SimpleTaskEnv
 
-    assert cli._implements_handwritten_demo(SimpleTaskEnv)
-    assert not cli._implements_handwritten_demo(BlocksRankingSizeEnv)
+    assert list_env._implements_handwritten_demo(SimpleTaskEnv)
+    assert not list_env._implements_handwritten_demo(BlocksRankingSizeEnv)
 
 
 def test_subcommand_help_uses_complete_command_parser(


### PR DESCRIPTION
## Description

This PR organizes the unified CLI beneath `embodichain.cli`.

- Move command registration and dispatch to `embodichain.cli.main`.
- Move `list-env` discovery and rendering to `embodichain.cli.list_env`.
- Move the workspace-cache handler to `embodichain.cli.workspace_cache` and remove the obsolete top-level module.
- Keep `embodichain.__main__` as the `python -m embodichain` entry point and preserve its public dispatcher re-exports.

The prior `embodichain.workspace_cache_cli` Python import path is removed; the `embodichain workspace-cache` command is unchanged.

Dependencies: none.

No linked issue.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)
- [ ] New feature (non-breaking change which adds new functionality)
- [x] Breaking change (existing functionality will not work without user modification)
- [ ] Documentation update

## Screenshots

Not applicable.

## Validation

- `black --check --diff --color ./`
- `python docs/scripts/check_api_docs.py`
- `pytest tests/test_main.py -q`
- `pytest tests/docs/test_check_api_docs.py -q --confcutdir=tests/docs`
- `python -m sphinx -b dummy -q docs/source docs/build/api-docs-check`
- `python -m embodichain list-env`

## Checklist

- [x] I have run the `black .` command to format the code base.
- [x] I have made corresponding changes to the documentation.
- [x] Public API changes are reflected in the API docs (`python docs/scripts/check_api_docs.py`).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] Dependencies have been updated, if applicable.