### PR TITLE
Improve list-task output details

### DIFF
--- a/agent_context/topics/env-framework/env-framework.md
+++ b/agent_context/topics/env-framework/env-framework.md
@@ -212,8 +212,15 @@ Or via gymnasium: `gym.make("MyTask-v1")`.
 
 `embodichain list-task` calls `discover_task_packages()` and prints a stable
 table whose `Task` column is a directory tree derived from task-first modules
-and packaged `configs/tasks/` paths. The other columns show the environment ID
-and supported use:
+and packaged `configs/tasks/` paths. Deployments for the same logical task are
+kept together, with one divider between task groups; the title reports both
+logical-task and environment counts. The other columns show the environment ID,
+selected embodiment, supported use, and runnable config filename:
+
+- the embodiment is the selected component filename without its extension, or
+  an inline robot's `robot_type` with `uid` as the fallback;
+- `Config` lists every top-level runnable config that declares the environment
+  ID; `-` means that metadata does not come from a Gym deployment config;
 
 - `[Expert Demo: Task Program]` comes from a task-local Gym config declaring
   the `task_program` component mapping;

--- a/embodichain/cli/list_task.py
+++ b/embodichain/cli/list_task.py
@@ -23,7 +23,9 @@ import importlib.metadata
 import importlib.resources
 import json
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from itertools import groupby
+from pathlib import PurePosixPath
 from typing import Any
 
 try:
@@ -45,6 +47,8 @@ class _EnvironmentListEntry:
     env_id: str
     task_path: tuple[str, ...]
     capabilities: set[str]
+    embodiments: set[str] = field(default_factory=set)
+    config_names: set[str] = field(default_factory=set)
 
 
 def _task_package_module_names() -> tuple[str, ...]:
@@ -144,12 +148,33 @@ def _iter_task_directories(
         yield from _iter_task_directories(child, (*relative_path, child.name))
 
 
+def _config_embodiment_names(config: Mapping[str, Any]) -> tuple[str, ...]:
+    """Infer display names for the embodiment selected by a task config."""
+    embodiment = config.get("embodiment")
+    if isinstance(embodiment, Mapping):
+        component = embodiment.get("component")
+        if type(component) is str and component and component == component.strip():
+            component_name = PurePosixPath(component).stem
+            if component_name:
+                return (component_name,)
+
+    robot = config.get("robot")
+    if isinstance(robot, Mapping):
+        for field_name in ("robot_type", "uid"):
+            value = robot.get(field_name)
+            if type(value) is str and value and value == value.strip():
+                return (value,)
+    return ()
+
+
 def _merge_environment_entry(
     entries: dict[str, _EnvironmentListEntry],
     *,
     env_id: str,
     task_path: tuple[str, ...],
     capabilities: Sequence[str] = (),
+    embodiments: Sequence[str] = (),
+    config_names: Sequence[str] = (),
 ) -> _EnvironmentListEntry:
     """Merge one catalog source into a case-insensitive environment record."""
     key = env_id.casefold()
@@ -158,6 +183,8 @@ def _merge_environment_entry(
         entry = _EnvironmentListEntry(env_id, task_path, set())
         entries[key] = entry
     entry.capabilities.update(capabilities)
+    entry.embodiments.update(embodiments)
+    entry.config_names.update(config_names)
     return entry
 
 
@@ -185,6 +212,8 @@ def _config_environment_entries(
                     env_id=env_id,
                     task_path=task_path,
                     capabilities=capabilities,
+                    embodiments=_config_embodiment_names(config),
+                    config_names=(resource.name,),
                 )
                 env_ids.append(env_id)
 
@@ -290,36 +319,58 @@ def _print_environment_entries(entries: Sequence[_EnvironmentListEntry]) -> None
     """Print environment entries as a table with a task-directory tree."""
     from prettytable import PrettyTable
 
+    task_groups = [
+        (task_path, list(task_entries))
+        for task_path, task_entries in groupby(
+            entries,
+            key=lambda entry: entry.task_path,
+        )
+    ]
     table = PrettyTable()
-    table.title = f"Tasks ({len(entries)})"
-    table.field_names = ["Task", "Environment ID", "Capability"]
+    table.title = f"Tasks ({len(task_groups)}) / Environments ({len(entries)})"
+    table.field_names = [
+        "Task",
+        "Environment ID",
+        "Embodiment",
+        "Capability",
+        "Config",
+    ]
     table.align = "l"
     active_categories: tuple[str, ...] = ()
-    for entry in entries:
-        categories = entry.task_path[:-1]
+    for group_index, (task_path, task_entries) in enumerate(task_groups):
+        categories = task_path[:-1]
         shared_depth = 0
         for active, category in zip(active_categories, categories):
             if active != category:
                 break
             shared_depth += 1
         for depth in range(shared_depth, len(categories)):
-            table.add_row([f"{'  ' * depth}{categories[depth]}/", "", ""])
+            table.add_row([f"{'  ' * depth}{categories[depth]}/", "", "", "", ""])
 
-        task_name = entry.task_path[-1]
-        labels = [
-            capability
-            for capability in _CAPABILITY_ORDER
-            if capability in entry.capabilities
-        ]
-        if not labels:
-            labels.append("Environment Only")
-        table.add_row(
-            [
-                f"{'  ' * len(categories)}{task_name}",
-                entry.env_id,
-                ", ".join(labels),
+        task_name = task_path[-1]
+        for entry_index, entry in enumerate(task_entries):
+            labels = [
+                capability
+                for capability in _CAPABILITY_ORDER
+                if capability in entry.capabilities
             ]
-        )
+            if not labels:
+                labels.append("Environment Only")
+            table.add_row(
+                [
+                    (
+                        f"{'  ' * len(categories)}{task_name}"
+                        if entry_index == 0
+                        else ""
+                    ),
+                    entry.env_id,
+                    ", ".join(sorted(entry.embodiments, key=str.casefold)) or "-",
+                    ", ".join(labels),
+                    ", ".join(sorted(entry.config_names, key=str.casefold)) or "-",
+                ]
+            )
+        if group_index < len(task_groups) - 1:
+            table.add_divider()
         active_categories = categories
     print(table)
 
@@ -332,7 +383,7 @@ def main(argv: Sequence[str] | None = None) -> None:
     """
     parser = argparse.ArgumentParser(
         prog="embodichain list-task",
-        description="List tasks by category and capability.",
+        description="List tasks by category, deployment, and capability.",
         epilog=(
             "Environment Only means the task currently exposes neither an "
             "Expert Demo entry point nor a supported RL configuration."

--- a/embodichain/cli/main.py
+++ b/embodichain/cli/main.py
@@ -72,7 +72,7 @@ COMMANDS = (
     Command(
         name="list-task",
         target="embodichain.cli.list_task:main",
-        help="List tasks by category and capability.",
+        help="List tasks by category, deployment, and capability.",
     ),
     Command(
         name="preview_lerobot_data",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -144,16 +144,36 @@ def test_list_task_discovers_and_prints_task_tree(
                 "CartPoleRL",
                 ("classic_control", "cart_pole"),
                 {list_task._RL},
+                {"Cart"},
+                {"env.json", "env.yaml"},
             ),
             list_task._EnvironmentListEntry(
                 "HandOver-v1",
                 ("manipulation", "hand_over"),
                 {list_task._TASK_PROGRAM},
+                {"dual_ur5_dh_pgi_140_80"},
+                {"task.dual_ur5_dh_pgi_140_80.yaml"},
+            ),
+            list_task._EnvironmentListEntry(
+                "TaskProgramOpenDrawer-Franka-v1",
+                ("manipulation", "open_drawer"),
+                {list_task._TASK_PROGRAM},
+                {"franka_panda"},
+                {"task.franka.yaml"},
+            ),
+            list_task._EnvironmentListEntry(
+                "TaskProgramOpenDrawer-v1",
+                ("manipulation", "open_drawer"),
+                {list_task._TASK_PROGRAM},
+                {"ur5_dh_pgi_140_80"},
+                {"task.ur5.yaml"},
             ),
             list_task._EnvironmentListEntry(
                 "BlocksRankingRGB-v1",
                 ("manipulation", "tableware", "blocks_ranking_rgb"),
                 {list_task._HANDWRITTEN_DEMO},
+                {"cobotmagic"},
+                {"env.json"},
             ),
             list_task._EnvironmentListEntry(
                 "StackCups-v1",
@@ -167,19 +187,25 @@ def test_list_task_discovers_and_prints_task_tree(
 
     assert discovery_calls == [None]
     assert capsys.readouterr().out == """\
-+------------------------------------------------------------------------------------+
-|                                     Tasks (4)                                      |
-+------------------------+---------------------+-------------------------------------+
-| Task                   | Environment ID      | Capability                          |
-+------------------------+---------------------+-------------------------------------+
-| classic_control/       |                     |                                     |
-|   cart_pole            | CartPoleRL          | RL                                  |
-| manipulation/          |                     |                                     |
-|   hand_over            | HandOver-v1         | Expert Demo: Task Program           |
-|   tableware/           |                     |                                     |
-|     blocks_ranking_rgb | BlocksRankingRGB-v1 | Expert Demo: Handwritten Trajectory |
-|     stack_cups         | StackCups-v1        | Environment Only                    |
-+------------------------+---------------------+-------------------------------------+
++------------------------------------------------------------------------------------------------------------------------------------------------------------+
+|                                                                Tasks (5) / Environments (6)                                                                |
++------------------------+---------------------------------+------------------------+-------------------------------------+----------------------------------+
+| Task                   | Environment ID                  | Embodiment             | Capability                          | Config                           |
++------------------------+---------------------------------+------------------------+-------------------------------------+----------------------------------+
+| classic_control/       |                                 |                        |                                     |                                  |
+|   cart_pole            | CartPoleRL                      | Cart                   | RL                                  | env.json, env.yaml               |
++------------------------+---------------------------------+------------------------+-------------------------------------+----------------------------------+
+| manipulation/          |                                 |                        |                                     |                                  |
+|   hand_over            | HandOver-v1                     | dual_ur5_dh_pgi_140_80 | Expert Demo: Task Program           | task.dual_ur5_dh_pgi_140_80.yaml |
++------------------------+---------------------------------+------------------------+-------------------------------------+----------------------------------+
+|   open_drawer          | TaskProgramOpenDrawer-Franka-v1 | franka_panda           | Expert Demo: Task Program           | task.franka.yaml                 |
+|                        | TaskProgramOpenDrawer-v1        | ur5_dh_pgi_140_80      | Expert Demo: Task Program           | task.ur5.yaml                    |
++------------------------+---------------------------------+------------------------+-------------------------------------+----------------------------------+
+|   tableware/           |                                 |                        |                                     |                                  |
+|     blocks_ranking_rgb | BlocksRankingRGB-v1             | cobotmagic             | Expert Demo: Handwritten Trajectory | env.json                         |
++------------------------+---------------------------------+------------------------+-------------------------------------+----------------------------------+
+|     stack_cups         | StackCups-v1                    | -                      | Environment Only                    | -                                |
++------------------------+---------------------------------+------------------------+-------------------------------------+----------------------------------+
 """
 
 
@@ -208,6 +234,9 @@ def test_config_environment_entries_use_task_paths_and_artifacts(
                     "program": "task_program/program.yaml",
                     "integration": "task_program/integration.yaml",
                     "execution_policy": "policies/trajectory.yaml",
+                },
+                "embodiment": {
+                    "component": "../../../components/embodiments/ur5.yaml",
                 },
             }
         ),
@@ -240,10 +269,40 @@ def test_config_environment_entries_use_task_paths_and_artifacts(
     expert = entries["pickplace-v1"]
     assert expert.task_path == ("manipulation", "pick_place")
     assert expert.capabilities == {list_task._TASK_PROGRAM}
+    assert expert.embodiments == {"ur5"}
+    assert expert.config_names == {"task.ur5.yaml"}
     assert "pick_place" not in entries
     learning = entries["pointmassrl"]
     assert learning.task_path == ("classic_control", "point_mass")
     assert learning.capabilities == {list_task._RL}
+    assert learning.embodiments == set()
+    assert learning.config_names == set()
+
+
+def test_config_environment_entries_infer_inline_robot_embodiments(
+    tmp_path: Path,
+) -> None:
+    """Inline robot configs expose their type or UID as the embodiment name."""
+    task = tmp_path / "special" / "inline_robot"
+    task.mkdir(parents=True)
+    (task / "typed.json").write_text(
+        json.dumps(
+            {
+                "id": "TypedRobot-v1",
+                "robot": {"robot_type": "URRobot", "uid": "Manipulator"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (task / "uid.json").write_text(
+        json.dumps({"id": "UidRobot-v1", "robot": {"uid": "UR10"}}),
+        encoding="utf-8",
+    )
+
+    entries = list_task._config_environment_entries([tmp_path])
+
+    assert entries["typedrobot-v1"].embodiments == {"URRobot"}
+    assert entries["uidrobot-v1"].embodiments == {"UR10"}
 
 
 def test_handwritten_demo_detection_uses_environment_hooks() -> None:


### PR DESCRIPTION
## Description

This PR enriches `embodichain list-task` output with embodiment and runnable config metadata. It groups multiple environment deployments under one logical task, adds dividers between task groups, and reports separate task and environment counts.

The additional context makes multi-embodiment tasks easier to compare and identifies the exact config used to launch each environment without loading simulation or eagerly registering Task Program integrations.

Dependencies: None.

Issue: None.

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)

## Screenshots

Not applicable. The terminal table layout is covered by an exact-output regression test.

## Validation

- `black --check --diff --color ./` — 824 files unchanged
- `black .` — 824 files unchanged
- `python docs/scripts/check_api_docs.py` — 1672/1672 exports documented
- `pytest -q tests/test_main.py` — 15 passed
- `python -m embodichain list-task` — verified against the installed official task catalog

## Checklist

- [x] I have run the `black .` command to format the code base.
- [x] I have made corresponding changes to the documentation.
- [x] Public API changes are reflected in the API docs, if applicable; no public API changed and the API docs gate passes.
- [x] I have added tests that prove the enhancement works.
- [x] Dependencies have been updated, if applicable; none are required.