### PR TITLE
feat(gym): make event randomization reproducible

### DIFF
--- a/docs/source/overview/gym/env.md
+++ b/docs/source/overview/gym/env.md
@@ -109,6 +109,45 @@ If configuration is easier in hertz, set ``target_control_frequency``. For examp
 * **max_episode_steps** (int): 
   Maximum number of steps per episode. If set to ``-1``, episodes will not have a step limit and will only end due to success/failure conditions. Defaults to ``300``.
 
+### Reproducible Event Randomization
+
+Configuration-defined tasks can set a top-level ``seed`` before the scene and
+event managers are constructed:
+
+```yaml
+id: EmbodiedEnv-v1
+seed: 2026
+num_envs: 4
+env:
+  events:
+    randomize_light:
+      func: randomize_emission_light
+      mode: interval
+      interval_step: 10
+      is_global: true
+      params:
+        intensity_range: [0.5, 2.0]
+```
+
+The common environment launcher can override this value with
+``--seed 2026``. When a seed is configured, the Event Manager derives a stable
+random stream for every functor name, mode, and invocation. Function-style and
+class-style event functors using Python ``random``, NumPy's process RNG, or
+Torch's CPU/simulation-device RNG are therefore reproducible and isolated from
+policy-side random draws. Class construction is also scoped because visual
+randomizers may create random palettes during initialization.
+
+Calling ``env.reset(seed=2026)`` rewinds the event streams and interval
+counters. Calling ``reset()`` without a seed continues the existing sequence.
+If the environment seed is ``None``, events retain the process-global RNG
+behavior from earlier releases. Custom functors that own an explicitly created
+generator remain responsible for seeding that generator.
+
+Reproducibility assumes the same task configuration, event call/reset schedule,
+assets, software versions, and device class. A seed controls randomization; it
+does not promise bitwise-identical physics or rendering across different
+hardware or simulator versions.
+
 ### EmbodiedEnvCfg Parameters
 
 The {class}`~envs.EmbodiedEnvCfg` class exposes the following additional parameters:

--- a/docs/source/overview/gym/event_functors.md
+++ b/docs/source/overview/gym/event_functors.md
@@ -5,6 +5,13 @@
 
 This page lists all available event functors that can be used with the Event Manager. Event functors are configured using {class}`~cfg.EventCfg` and can be triggered at different stages: ``startup``, ``reset``, or ``interval``.
 
+Set the task's top-level ``seed`` (or pass ``--seed`` to the common environment
+launcher) to make all standard-RNG event functors reproducible. The Event
+Manager isolates each named functor's Python, NumPy, and Torch random stream, so
+unrelated event or policy random draws do not change its sequence. Passing a
+seed again through ``env.reset(seed=...)`` rewinds that sequence. See
+{doc}`env` for the complete contract and limitations.
+
 ````{tip}
 **Using an AI coding agent?** Use the **`/add-functor`** skill to scaffold a new event or randomization functor with the correct signature (`env, env_ids, ...`), function or class style, and module placement. Use **`/add-test`** to generate mock-based tests.
 ````

--- a/embodichain/lab/gym/envs/base_env.py
+++ b/embodichain/lab/gym/envs/base_env.py
@@ -51,11 +51,11 @@ class EnvCfg:
     """Simulation configuration for the environment."""
 
     seed: int | None = None
-    """The seed for the random number generator. Defaults to -1, in which case the seed is not set.
+    """The task-environment seed. Defaults to None, in which case the seed is not set.
 
     Note:
-      The seed is set at the beginning of the environment initialization. This ensures that the environment
-      creation is deterministic and behaves similarly across different runs.
+      The seed is set before scene initialization and controls process RNGs and
+      deterministic event-functor streams.
     """
 
     sim_steps_per_control: int = 4
@@ -154,7 +154,8 @@ class BaseEnv(gym.Env):
             self.sim_cfg.profiler = self.cfg.profiler
 
         if self.cfg.seed is not None:
-            self.cfg.seed = set_seed(self.cfg.seed)
+            effective_seed = self._set_seed(self.cfg.seed)
+            super().reset(seed=effective_seed)
         else:
             logger.log_info(f"No seed is set for the environment.")
 
@@ -832,7 +833,8 @@ class BaseEnv(gym.Env):
             A tuple containing the observations and infos.
         """
         if seed is not None:
-            torch.manual_seed(seed)
+            seed = self._set_seed(seed)
+        super().reset(seed=seed)
 
         if options is None:
             options = dict()
@@ -865,6 +867,23 @@ class BaseEnv(gym.Env):
                 info = self.get_info(**options)
 
         return obs, info
+
+    def _set_seed(self, seed: int) -> int:
+        """Set the effective environment seed and rewind seeded managers."""
+        cudnn_benchmark = torch.backends.cudnn.benchmark
+        cudnn_deterministic = torch.backends.cudnn.deterministic
+        try:
+            effective_seed = set_seed(seed)
+        finally:
+            # Seeding selects random streams; it must not silently change the
+            # caller's deterministic-kernel policy.
+            torch.backends.cudnn.benchmark = cudnn_benchmark
+            torch.backends.cudnn.deterministic = cudnn_deterministic
+        self.cfg.seed = effective_seed
+        event_manager = getattr(self, "event_manager", None)
+        if event_manager is not None:
+            event_manager.set_seed(effective_seed)
+        return effective_seed
 
     def step(
         self, action: EnvAction, **kwargs

--- a/embodichain/lab/gym/envs/managers/event_manager.py
+++ b/embodichain/lab/gym/envs/managers/event_manager.py
@@ -15,18 +15,80 @@
 
 from __future__ import annotations
 
+import hashlib
 import inspect
-import torch
-from collections.abc import Sequence
-from prettytable import PrettyTable
+import random
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
+from numbers import Integral
 from typing import TYPE_CHECKING, Union
 
+import numpy as np
+import torch
+from prettytable import PrettyTable
+
 from embodichain.utils import logger
-from .manager_base import ManagerBase
+from .manager_base import Functor, ManagerBase
 from .cfg import EventCfg
 
 if TYPE_CHECKING:
     from embodichain.lab.gym.envs import EmbodiedEnv
+
+
+_MAX_TORCH_SEED = 2**63 - 1
+
+
+def _derive_functor_seed(
+    seed: int,
+    phase: str,
+    mode: str,
+    functor_name: str,
+    invocation: int,
+) -> int:
+    """Derive a stable seed for one event-functor invocation."""
+    digest = hashlib.blake2b(digest_size=8, person=b"EmbodiEventRNG")
+    for value in (seed, phase, mode, functor_name, invocation):
+        encoded = str(value).encode("utf-8")
+        digest.update(len(encoded).to_bytes(4, byteorder="little"))
+        digest.update(encoded)
+    return int.from_bytes(digest.digest(), byteorder="little") % _MAX_TORCH_SEED
+
+
+@contextmanager
+def _scoped_random_seed(seed: int, device: torch.device | str) -> Iterator[None]:
+    """Temporarily seed the global RNG APIs used by event functors."""
+    python_state = random.getstate()
+    numpy_state = np.random.get_state()
+    torch_cpu_state = torch.get_rng_state()
+
+    torch_device = torch.device(device)
+    cuda_device: torch.device | None = None
+    cuda_state: torch.Tensor | None = None
+    if torch_device.type == "cuda":
+        cuda_index = torch_device.index
+        if cuda_index is None:
+            cuda_index = torch.cuda.current_device()
+        cuda_device = torch.device("cuda", cuda_index)
+        cuda_state = torch.cuda.get_rng_state(cuda_device)
+
+    try:
+        random.seed(seed)
+        np.random.seed(seed % 2**32)
+
+        cpu_generator = torch.Generator(device="cpu")
+        cpu_generator.manual_seed(seed)
+        torch.set_rng_state(cpu_generator.get_state())
+        if cuda_device is not None:
+            cuda_generator = torch.Generator(device=cuda_device)
+            cuda_generator.manual_seed(seed)
+            torch.cuda.set_rng_state(cuda_generator.get_state(), cuda_device)
+        yield
+    finally:
+        random.setstate(python_state)
+        np.random.set_state(numpy_state)
+        torch.set_rng_state(torch_cpu_state)
+        if cuda_device is not None and cuda_state is not None:
+            torch.cuda.set_rng_state(cuda_state, cuda_device)
 
 
 class EventManager(ManagerBase):
@@ -76,6 +138,14 @@ class EventManager(ManagerBase):
         self._mode_functor_names: dict[str, list[str]] = dict()
         self._mode_functor_cfgs: dict[str, list[EventCfg]] = dict()
         self._mode_class_functor_cfgs: dict[str, list[EventCfg]] = dict()
+        self._functor_invocation_counts: dict[tuple[str, str, str], int] = {}
+
+        cfg_seed = getattr(getattr(env, "cfg", None), "seed", None)
+        self._seed = (
+            int(cfg_seed)
+            if isinstance(cfg_seed, Integral) and not isinstance(cfg_seed, bool)
+            else None
+        )
 
         # call the base class (this will parse the functors config)
         super().__init__(cfg, env)
@@ -126,26 +196,52 @@ class EventManager(ManagerBase):
         """Modes of events."""
         return list(self._mode_functor_names.keys())
 
+    @property
+    def seed(self) -> int | None:
+        """Return the base seed used for event-functor randomization."""
+        return self._seed
+
     """
     Operations.
     """
 
     def reset(self, env_ids: Union[Sequence[int], None] = None) -> dict[str, float]:
         # call all functors that are classes
-        for mode_cfg in self._mode_class_functor_cfgs.values():
-            for functor_cfg in mode_cfg:
-                functor_cfg.func.reset(env_ids=env_ids)
-
-        # resolve number of environments
-        if env_ids is None:
-            num_envs = self._env.num_envs
-        else:
-            num_envs = len(env_ids)
+        for mode, functor_cfgs in self._mode_functor_cfgs.items():
+            for functor_name, functor_cfg in zip(
+                self._mode_functor_names[mode], functor_cfgs
+            ):
+                if isinstance(functor_cfg.func, Functor):
+                    with self._functor_seed_scope(
+                        phase="reset",
+                        mode=mode,
+                        functor_name=functor_name,
+                    ):
+                        functor_cfg.func.reset(env_ids=env_ids)
 
         # May be add more useful reset logic later.
 
         # nothing to log here
         return {}
+
+    def set_seed(self, seed: int | None) -> None:
+        """Set the event seed and rewind all deterministic event streams.
+
+        Args:
+            seed: Base task-environment seed. ``None`` disables scoped event
+                randomization and preserves the process-global RNG behavior.
+
+        Raises:
+            TypeError: If ``seed`` is not an integer or ``None``.
+        """
+        if seed is not None and (
+            not isinstance(seed, Integral) or isinstance(seed, bool)
+        ):
+            raise TypeError(f"Event seed must be an integer or None, got {type(seed)}.")
+        self._seed = None if seed is None else int(seed)
+        self._functor_invocation_counts.clear()
+        for count in getattr(self, "_interval_functor_step_count", []):
+            count.zero_()
 
     def apply(
         self,
@@ -205,7 +301,9 @@ class EventManager(ManagerBase):
                 ):
 
                     # call the event functor (with None for env_ids)
-                    self._call_functor(functor_name, functor_cfg, self._env, None)
+                    self._call_event_functor(
+                        mode, functor_name, functor_cfg, self._env, None
+                    )
                 else:
                     valid_env_ids = (
                         (
@@ -218,18 +316,26 @@ class EventManager(ManagerBase):
                     )
                     if len(valid_env_ids) > 0:
                         # call the event functor
-                        self._call_functor(
-                            functor_name, functor_cfg, self._env, valid_env_ids
+                        self._call_event_functor(
+                            mode,
+                            functor_name,
+                            functor_cfg,
+                            self._env,
+                            valid_env_ids,
                         )
             elif mode == "reset":
                 # resolve the environment indices
                 if env_ids is None:
                     env_ids = slice(None)
 
-                self._call_functor(functor_name, functor_cfg, self._env, env_ids)
+                self._call_event_functor(
+                    mode, functor_name, functor_cfg, self._env, env_ids
+                )
             else:
                 # call the event functor
-                self._call_functor(functor_name, functor_cfg, self._env, env_ids)
+                self._call_event_functor(
+                    mode, functor_name, functor_cfg, self._env, env_ids
+                )
 
     """
     Operations - Functor settings.
@@ -326,8 +432,14 @@ class EventManager(ManagerBase):
                     f" Received: '{type(functor_cfg)}'."
                 )
 
-            # resolve common parameters
-            self._resolve_common_functor_cfg(functor_name, functor_cfg, min_argc=2)
+            # Resolve class functors in their own deterministic stream because
+            # constructors may build random palettes or other random state.
+            with self._functor_seed_scope(
+                phase="initialize",
+                mode=functor_cfg.mode,
+                functor_name=functor_name,
+            ):
+                self._resolve_common_functor_cfg(functor_name, functor_cfg, min_argc=2)
 
             # check if mode is a new mode
             if functor_cfg.mode not in self._mode_functor_names:
@@ -339,8 +451,9 @@ class EventManager(ManagerBase):
             self._mode_functor_names[functor_cfg.mode].append(functor_name)
             self._mode_functor_cfgs[functor_cfg.mode].append(functor_cfg)
 
-            # check if the functor is a class
-            if inspect.isclass(functor_cfg.func):
+            # Resolution replaces class-style functors (including string
+            # references to classes) with initialized Functor instances.
+            if isinstance(functor_cfg.func, Functor):
                 self._mode_class_functor_cfgs[functor_cfg.mode].append(functor_cfg)
 
             # resolve the mode of the events
@@ -355,3 +468,42 @@ class EventManager(ManagerBase):
                         self.num_envs, dtype=torch.int32, device=self.device
                     )
                     self._interval_functor_step_count.append(count)
+
+    def _call_event_functor(
+        self,
+        mode: str,
+        functor_name: str,
+        functor_cfg: EventCfg,
+        *args,
+    ):
+        """Call one event functor inside its deterministic random stream."""
+        with self._functor_seed_scope(
+            phase="call", mode=mode, functor_name=functor_name
+        ):
+            return super()._call_functor(functor_name, functor_cfg, *args)
+
+    @contextmanager
+    def _functor_seed_scope(
+        self,
+        *,
+        phase: str,
+        mode: str,
+        functor_name: str,
+    ) -> Iterator[None]:
+        """Enter the next deterministic stream for a named event functor."""
+        if self._seed is None:
+            yield
+            return
+
+        key = (phase, mode, functor_name)
+        invocation = self._functor_invocation_counts.get(key, 0)
+        self._functor_invocation_counts[key] = invocation + 1
+        functor_seed = _derive_functor_seed(
+            self._seed,
+            phase,
+            mode,
+            functor_name,
+            invocation,
+        )
+        with _scoped_random_seed(functor_seed, self.device):
+            yield

--- a/embodichain/lab/gym/envs/managers/events.py
+++ b/embodichain/lab/gym/envs/managers/events.py
@@ -133,12 +133,12 @@ class replace_assets_from_group(Functor):
             # remove regular expression from patterns
             patterns = remove_regex_chars(patterns)
             self._full_path = get_data_path(f"{folder_path}/")
-            self._asset_group_path = get_all_files_in_directory(
-                self._full_path, patterns=patterns
+            self._asset_group_path = sorted(
+                get_all_files_in_directory(self._full_path, patterns=patterns)
             )
         else:
             self._full_path = get_data_path(folder_path)
-            self._asset_group_path = get_all_files_in_directory(self._full_path)
+            self._asset_group_path = sorted(get_all_files_in_directory(self._full_path))
 
     def __call__(
         self,

--- a/embodichain/lab/gym/utils/gym_utils.py
+++ b/embodichain/lab/gym/utils/gym_utils.py
@@ -596,6 +596,7 @@ def config_to_cfg(
 
     env_cfg.max_episode_steps = config.get("max_episode_steps", 300)
     env_cfg.num_envs = config.get("num_envs", 1)
+    env_cfg.seed = config.get("seed", None)
 
     physics_config = deepcopy(config.get("physics_config", {}))
     if "gravity" in physics_config:
@@ -778,6 +779,7 @@ def config_to_cfg(
                 mode=event_params_modified["mode"],
                 params=event_params_modified["params"],
                 interval_step=interval_step,
+                is_global=event_params_modified.get("is_global", False),
             )
             setattr(env_cfg.events, event_name, event)
 
@@ -980,6 +982,7 @@ def add_env_launcher_args_to_parser(
 
     This function adds the following arguments to the provided parser:
         --num_envs: Number of environments to run in parallel (default: 1)
+        --seed: Task-environment seed. The task config is used when omitted.
         --device: Device to run the environment on (default: 'cpu')
         --headless: Whether to perform the simulation in headless mode (default: False)
         --renderer: Renderer backend to use for the simulation. Options are 'hybrid', 'fast-rt', and 'rt'. (default: 'hybrid')
@@ -1006,6 +1009,12 @@ def add_env_launcher_args_to_parser(
         help="The number of environments to run in parallel. "
         "If not given, falls back to the gym config's `num_envs` (default 1).",
         default=1,
+        type=int,
+    )
+    parser.add_argument(
+        "--seed",
+        help="Task-environment seed. Overrides the gym config when provided.",
+        default=None,
         type=int,
     )
     parser.add_argument(
@@ -1128,6 +1137,8 @@ def merge_args_with_gym_config(args: argparse.Namespace, gym_config: dict) -> di
     merged_config = deepcopy(gym_config)
     if args.num_envs is not None:
         merged_config["num_envs"] = args.num_envs
+    if getattr(args, "seed", None) is not None:
+        merged_config["seed"] = args.seed
     merged_config["device"] = args.device
     viser_enabled = bool(getattr(args, "viser", False))
     merged_config["headless"] = args.headless or viser_enabled

--- a/embodichain/learning/rl/train.py
+++ b/embodichain/learning/rl/train.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import random
 import time
 from collections.abc import Sequence
 from pathlib import Path
@@ -56,6 +57,15 @@ from embodichain.utils.module_utils import find_function_from_modules
 from embodichain.lab.sim import SimulationManagerCfg
 from embodichain.lab.sim.cfg import RenderCfg
 from embodichain.lab.gym.envs.managers.cfg import EventCfg
+
+
+def _seed_training_rng(seed: int, device: torch.device) -> None:
+    """Seed policy/trainer RNGs without changing deterministic-kernel settings."""
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    if device.type == "cuda":
+        torch.cuda.manual_seed_all(seed)
 
 
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
@@ -373,6 +383,7 @@ def train_from_config(
     eval_freq = int(trainer_cfg.get("eval_freq", 10000))
     save_freq = int(trainer_cfg.get("save_freq", 50000))
     num_eval_episodes = int(trainer_cfg.get("num_eval_episodes", 5))
+    eval_seed = int(trainer_cfg.get("eval_seed", seed + 10_000))
     headless = bool(trainer_cfg.get("headless", True))
     renderer = trainer_cfg.get("renderer", "hybrid")
     gpu_id = int(trainer_cfg.get("gpu_id", 0))
@@ -414,11 +425,8 @@ def train_from_config(
 
     # Seeds
     effective_seed = seed + rank
-    np.random.seed(effective_seed)
-    torch.manual_seed(effective_seed)
+    _seed_training_rng(effective_seed, device)
     torch.backends.cudnn.deterministic = True
-    if device.type == "cuda":
-        torch.cuda.manual_seed_all(effective_seed)
 
     # Outputs
     if distributed:
@@ -447,6 +455,7 @@ def train_from_config(
 
     gym_config_data = load_config(str(gym_config_path))
     gym_env_cfg = config_to_cfg(gym_config_data, manager_modules=get_manager_modules())
+    gym_env_cfg.seed = effective_seed
     if num_envs is not None:
         gym_env_cfg.num_envs = int(num_envs)
 
@@ -480,7 +489,7 @@ def train_from_config(
         )
 
     env = build_env(gym_config_data["id"], base_env_cfg=gym_env_cfg)
-    sample_obs, _ = env.reset()
+    sample_obs, _ = env.reset(seed=effective_seed)
     sample_obs_td = dict_to_tensordict(sample_obs, device)
     obs_dim = flatten_dict_observation(sample_obs_td).shape[-1]
     flat_obs_space = env.flattened_observation_space
@@ -491,12 +500,17 @@ def train_from_config(
     if enable_eval and rank == 0:
         eval_gym_env_cfg = deepcopy(gym_env_cfg)
         eval_gym_env_cfg.num_envs = num_eval_envs
+        eval_gym_env_cfg.seed = eval_seed
         eval_gym_env_cfg.sim_cfg.headless = True
         eval_gym_env_cfg.profiler = None
         eval_env = build_env(gym_config_data["id"], base_env_cfg=eval_gym_env_cfg)
         logger.log_info(
             f"Evaluation environment created (num_envs={num_eval_envs}, headless=True)"
         )
+
+    # Environment construction intentionally uses task/evaluation seeds. Reset
+    # the trainer stream so policy initialization is independent of scene work.
+    _seed_training_rng(effective_seed, device)
 
     # Build Policy via registry
     policy_name = policy_block["name"]
@@ -591,6 +605,7 @@ def train_from_config(
             mode=mode,
             params=params,
             interval_step=interval_step,
+            is_global=event_info.get("is_global", False),
         )
     # Parse eval events (only if evaluation is enabled)
     if enable_eval:
@@ -607,6 +622,7 @@ def train_from_config(
                 mode=mode,
                 params=params,
                 interval_step=interval_step,
+                is_global=event_info.get("is_global", False),
             )
     trainer = Trainer(
         policy=policy,
@@ -627,7 +643,7 @@ def train_from_config(
         distributed=distributed,
         rank=rank,
         world_size=world_size,
-        eval_seed=int(trainer_cfg.get("eval_seed", seed + 10_000)),
+        eval_seed=eval_seed,
         best_eval_metric=trainer_cfg.get("best_eval_metric", "eval/avg_reward"),
         best_eval_mode=trainer_cfg.get("best_eval_mode", "max"),
     )

--- a/embodichain/learning/rl/utils/trainer.py
+++ b/embodichain/learning/rl/utils/trainer.py
@@ -349,6 +349,9 @@ class Trainer:
     def _eval_once(self, num_episodes: int = 5) -> dict[str, float]:
         """Evaluate ``num_episodes`` completed asynchronous episodes."""
 
+        if hasattr(self, "eval_event_manager") and self.eval_seed is not None:
+            self.eval_event_manager.set_seed(self.eval_seed)
+
         def on_step(_: dict[str, Any]) -> None:
             if hasattr(self, "eval_event_manager"):
                 if "interval" in self.eval_event_manager.available_modes:

--- a/embodichain/utils/utility.py
+++ b/embodichain/utils/utility.py
@@ -242,6 +242,7 @@ def read_all_folder_images(base_path: str) -> List[np.ndarray]:
         for file in files:
             if file.endswith((".png", ".jpg", ".jpeg")):
                 image_files.append(os.path.join(subdir, file))
+    image_files.sort()
 
     # Then process with progress bar
     for image_path in tqdm(image_files, desc="Loading images"):

--- a/tests/gym/envs/managers/test_event_manager_seed.py
+++ b/tests/gym/envs/managers/test_event_manager_seed.py
@@ -1,0 +1,260 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+"""Tests for deterministic event-functor randomization streams."""
+
+from __future__ import annotations
+
+import random
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+from embodichain.lab.gym.envs.managers import EventCfg, Functor
+from embodichain.lab.gym.envs.managers.event_manager import EventManager
+
+
+class _StubEnv:
+    """Minimal environment surface consumed by :class:`EventManager`."""
+
+    def __init__(self, seed: int | None, device: torch.device | str = "cpu") -> None:
+        self.cfg = SimpleNamespace(seed=seed)
+        self.num_envs = 2
+        self.device = torch.device(device)
+        self.sim = SimpleNamespace()
+        self._profiler = None
+        self.samples: dict[str, list[tuple[float, float, list[float]]]] = {}
+        self.initialization_samples: list[tuple[float, float, float]] = []
+        self.reset_samples: list[tuple[float, float, float]] = []
+
+
+def _mixed_rng_event(
+    env: _StubEnv,
+    env_ids: torch.Tensor | None,
+    *,
+    label: str,
+) -> None:
+    """Record values from every RNG family used by built-in event functors."""
+    del env_ids
+    env.samples.setdefault(label, []).append(
+        (
+            random.random(),
+            float(np.random.random()),
+            torch.rand(3, device=env.device).cpu().tolist(),
+        )
+    )
+
+
+class _RandomClassFunctor(Functor):
+    """Class-style event whose constructor and call both consume randomness."""
+
+    def __init__(self, cfg: EventCfg, env: _StubEnv) -> None:
+        super().__init__(cfg, env)
+        env.initialization_samples.append(
+            (random.random(), float(np.random.random()), torch.rand(()).item())
+        )
+
+    def __call__(
+        self,
+        env: _StubEnv,
+        env_ids: torch.Tensor | None,
+        *,
+        label: str,
+    ) -> None:
+        _mixed_rng_event(env, env_ids, label=label)
+
+    def reset(self, env_ids: torch.Tensor | None = None) -> None:
+        del env_ids
+        self._env.reset_samples.append(
+            (random.random(), float(np.random.random()), torch.rand(()).item())
+        )
+
+
+def _manager(
+    seed: int | None,
+    *,
+    include_noise: bool = False,
+    class_style: bool = False,
+    device: torch.device | str = "cpu",
+) -> tuple[_StubEnv, EventManager]:
+    env = _StubEnv(seed, device=device)
+    target_func = _RandomClassFunctor if class_style else _mixed_rng_event
+    cfg: dict[str, EventCfg] = {}
+    if include_noise:
+        cfg["noise"] = EventCfg(
+            func=_mixed_rng_event,
+            mode="reset",
+            params={"label": "noise"},
+        )
+    cfg["target"] = EventCfg(
+        func=target_func,
+        mode="reset",
+        params={"label": "target"},
+    )
+    return env, EventManager(cfg, env)
+
+
+def test_same_seed_replays_all_event_rng_families() -> None:
+    """Python, NumPy, and Torch samples replay for an identical event schedule."""
+    env_a, manager_a = _manager(1234)
+    env_b, manager_b = _manager(1234)
+    env_ids = torch.tensor([0, 1])
+
+    for _ in range(2):
+        manager_a.apply("reset", env_ids)
+        manager_b.apply("reset", env_ids)
+
+    assert env_a.samples["target"] == env_b.samples["target"]
+
+
+def test_different_seed_changes_event_randomization() -> None:
+    """Changing the task seed changes its domain-randomization sequence."""
+    env_a, manager_a = _manager(1234)
+    env_b, manager_b = _manager(1235)
+
+    manager_a.apply("reset", torch.tensor([0, 1]))
+    manager_b.apply("reset", torch.tensor([0, 1]))
+
+    assert env_a.samples["target"] != env_b.samples["target"]
+
+
+def test_event_stream_is_independent_of_global_rng_and_other_functors() -> None:
+    """Policy-side draws and unrelated events do not perturb a named event stream."""
+    env_a, manager_a = _manager(41)
+    env_b, manager_b = _manager(41, include_noise=True)
+
+    manager_a.apply("reset", torch.tensor([0, 1]))
+    for _ in range(20):
+        random.random()
+        np.random.random()
+        torch.rand(8)
+    manager_b.apply("reset", torch.tensor([0, 1]))
+
+    assert env_a.samples["target"] == env_b.samples["target"]
+
+
+def test_event_call_restores_process_rng_states() -> None:
+    """Event randomization does not consume the caller's process RNG streams."""
+    _, manager = _manager(99)
+
+    random.seed(7)
+    np.random.seed(7)
+    torch.manual_seed(7)
+    expected = (random.random(), float(np.random.random()), torch.rand(3))
+
+    random.seed(7)
+    np.random.seed(7)
+    torch.manual_seed(7)
+    manager.apply("reset", torch.tensor([0, 1]))
+    actual = (random.random(), float(np.random.random()), torch.rand(3))
+
+    assert actual[0] == expected[0]
+    assert actual[1] == expected[1]
+    torch.testing.assert_close(actual[2], expected[2])
+
+
+def test_reseed_rewinds_event_and_interval_sequences() -> None:
+    """Reseeding rewinds invocation streams and interval scheduling."""
+    env = _StubEnv(55)
+    manager = EventManager(
+        {
+            "target": EventCfg(
+                func=_mixed_rng_event,
+                mode="interval",
+                interval_step=2,
+                is_global=True,
+                params={"label": "target"},
+            )
+        },
+        env,
+    )
+
+    manager.apply("interval")
+    assert "target" not in env.samples
+    manager.apply("interval")
+    first = env.samples["target"][0]
+
+    manager.set_seed(55)
+    manager.apply("interval")
+    assert len(env.samples["target"]) == 1
+    manager.apply("interval")
+
+    assert env.samples["target"][1] == first
+
+
+def test_class_functor_initialization_and_calls_are_seeded() -> None:
+    """Class-style functors use deterministic streams during init and invocation."""
+    random.seed(1)
+    np.random.seed(1)
+    torch.manual_seed(1)
+    env_a, manager_a = _manager(808, class_style=True)
+
+    random.seed(999)
+    np.random.seed(999)
+    torch.manual_seed(999)
+    env_b, manager_b = _manager(808, class_style=True)
+
+    manager_a.apply("reset", torch.tensor([0, 1]))
+    manager_b.apply("reset", torch.tensor([0, 1]))
+
+    manager_a.reset(torch.tensor([0, 1]))
+    random.random()
+    np.random.random()
+    torch.rand(10)
+    manager_b.reset(torch.tensor([0, 1]))
+
+    assert env_a.initialization_samples == env_b.initialization_samples
+    assert env_a.samples["target"] == env_b.samples["target"]
+    assert env_a.reset_samples == env_b.reset_samples
+
+
+def test_string_class_functor_is_tracked_for_seeded_reset() -> None:
+    """String-referenced class functors retain deterministic reset handling."""
+    env = _StubEnv(808)
+    manager = EventManager(
+        {
+            "target": EventCfg(
+                func="embodichain.lab.gym.envs.managers.events:prepare_extra_attr",
+                mode="reset",
+                params={"attrs": []},
+            )
+        },
+        env,
+    )
+
+    assert len(manager._mode_class_functor_cfgs["reset"]) == 1
+
+
+@pytest.mark.gpu
+def test_cuda_event_stream_replays_and_restores_device_rng() -> None:
+    """The simulation-device generator is scoped and restored on CUDA."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is not available.")
+    device = torch.device("cuda:0")
+    env_a, manager_a = _manager(314, device=device)
+    env_b, manager_b = _manager(314, device=device)
+
+    torch.cuda.manual_seed(17)
+    expected_after_event = torch.rand(3, device=device)
+    torch.cuda.manual_seed(17)
+    manager_a.apply("reset", torch.tensor([0, 1], device=device))
+    actual_after_event = torch.rand(3, device=device)
+    manager_b.apply("reset", torch.tensor([0, 1], device=device))
+
+    torch.testing.assert_close(actual_after_event, expected_after_event)
+    assert env_a.samples["target"] == env_b.samples["target"]

--- a/tests/gym/envs/test_env_seed.py
+++ b/tests/gym/envs/test_env_seed.py
@@ -1,0 +1,94 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+"""Tests for task-environment seed reset behavior."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import torch
+
+import embodichain.lab.gym.envs.base_env as base_env_module
+from embodichain.lab.gym.envs import BaseEnv
+
+
+class _ProfilerStub:
+    @contextmanager
+    def section(self, *args, **kwargs):
+        del args, kwargs
+        yield
+
+
+class _ResetEnv(BaseEnv):
+    """BaseEnv reset surface without constructing a simulator."""
+
+    def __init__(self) -> None:
+        self.cfg = SimpleNamespace(seed=None)
+        self._num_envs = 1
+        self.sim = SimpleNamespace(
+            device=torch.device("cpu"),
+            reset_objects_state=MagicMock(),
+            capture_visualization_safely=MagicMock(),
+        )
+        self._profiler = _ProfilerStub()
+        self._task_success = torch.zeros(1, dtype=torch.bool)
+        self._detached_uids_for_reset: list[str] = []
+        self._elapsed_steps = torch.zeros(1, dtype=torch.int32)
+        self.event_manager = MagicMock()
+        self.initial_random_value = 0.0
+
+    def is_task_success(self, **kwargs) -> torch.Tensor:
+        del kwargs
+        return torch.zeros(1, dtype=torch.bool)
+
+    def _initialize_episode(self, env_ids: torch.Tensor, **kwargs) -> None:
+        del env_ids, kwargs
+        self.initial_random_value = float(self.np_random.random())
+
+    def get_obs(self, **kwargs) -> dict[str, float]:
+        del kwargs
+        return {"random": self.initial_random_value}
+
+    def get_info(self, **kwargs) -> dict:
+        del kwargs
+        return {}
+
+
+def test_reset_seed_replays_gym_rng_and_reseeds_event_manager(monkeypatch) -> None:
+    """A Gym reset seed becomes the effective task and event-manager seed."""
+    monkeypatch.setattr(torch.backends.cudnn, "benchmark", False)
+    monkeypatch.setattr(torch.backends.cudnn, "deterministic", True)
+
+    def _set_seed(seed: int) -> int:
+        torch.backends.cudnn.benchmark = True
+        torch.backends.cudnn.deterministic = False
+        return seed + 1
+
+    monkeypatch.setattr(base_env_module, "set_seed", _set_seed)
+    env = _ResetEnv()
+
+    first_obs, _ = env.reset(seed=2026)
+    second_obs, _ = env.reset(seed=2026)
+
+    assert first_obs == second_obs
+    assert env.cfg.seed == 2027
+    assert env.event_manager.set_seed.call_count == 2
+    env.event_manager.set_seed.assert_called_with(2027)
+    assert torch.backends.cudnn.benchmark is False
+    assert torch.backends.cudnn.deterministic is True

--- a/tests/gym/utils/test_gym_utils.py
+++ b/tests/gym/utils/test_gym_utils.py
@@ -398,6 +398,28 @@ def test_launcher_preserves_gym_renderer_when_cli_omits_override():
     assert merged_config["render_cfg"]["renderer"] == "rt"
 
 
+def test_launcher_seed_overrides_gym_config() -> None:
+    """The common launcher exposes an explicit task-environment seed override."""
+    parser = argparse.ArgumentParser()
+    add_env_launcher_args_to_parser(parser, require_gym_config=True)
+
+    args = parser.parse_args(["--gym_config", "gym_config.yaml", "--seed", "1234"])
+    merged_config = merge_args_with_gym_config(args, {"seed": 99})
+
+    assert merged_config["seed"] == 1234
+
+
+def test_launcher_preserves_config_seed_without_override() -> None:
+    """Omitting ``--seed`` keeps the value declared by the task config."""
+    parser = argparse.ArgumentParser()
+    add_env_launcher_args_to_parser(parser, require_gym_config=True)
+
+    args = parser.parse_args(["--gym_config", "gym_config.yaml"])
+    merged_config = merge_args_with_gym_config(args, {"seed": 99})
+
+    assert merged_config["seed"] == 99
+
+
 def test_env_launcher_includes_viser_arguments():
     """The common environment launcher registers Viser options by default."""
     parser = argparse.ArgumentParser()
@@ -1366,6 +1388,7 @@ class TestConfigToCfgFromFile:
     def test_yaml_gym_config_parses_to_cfg(self, tmp_path):
         config = {
             "id": "EmbodiedEnv-v1",
+            "seed": 2026,
             "max_episode_steps": 100,
             "physics_config": {
                 "gravity": [0.0, 0.0, -1.62],
@@ -1391,7 +1414,15 @@ class TestConfigToCfgFromFile:
             "env": {
                 "sim_steps_per_control": 2,
                 "target_control_frequency": 20.0,
-                "events": {},
+                "events": {
+                    "global_light": {
+                        "func": "randomize_emission_light",
+                        "mode": "interval",
+                        "interval_step": 7,
+                        "is_global": True,
+                        "params": {"intensity_range": [0.1, 0.9]},
+                    }
+                },
                 "observations": {},
                 "rewards": {},
             },
@@ -1418,6 +1449,9 @@ class TestConfigToCfgFromFile:
         cfg = config_to_cfg(loaded, manager_modules=DEFAULT_MANAGER_MODULES)
 
         assert cfg.max_episode_steps == 100
+        assert cfg.seed == 2026
+        assert cfg.events.global_light.interval_step == 7
+        assert cfg.events.global_light.is_global is True
         assert cfg.robot.uid == "TestRobot"
         assert cfg.sim_steps_per_control == 2
         assert cfg.target_control_frequency == 20.0

--- a/tests/learning/test_evaluation.py
+++ b/tests/learning/test_evaluation.py
@@ -16,10 +16,13 @@
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock, call
+
 import gymnasium as gym
 import torch
 
 from embodichain.learning.rl.evaluation import evaluate_episodes
+from embodichain.learning.rl.utils.trainer import Trainer
 
 
 class _DeterministicPolicy(torch.nn.Module):
@@ -96,3 +99,32 @@ def test_evaluate_episodes_counts_actual_completions_and_restores_mode() -> None
     assert result["eval/success_rate"] == 1.0
     assert result["eval/metrics/terminal_step"] == 1.25
     assert "eval/metrics/final_position" not in result
+
+
+def test_trainer_rewinds_external_eval_event_manager() -> None:
+    """Repeated model validation starts external event functors from eval_seed."""
+    trainer = object.__new__(Trainer)
+    trainer.policy = _DeterministicPolicy()
+    trainer.eval_env = _AsyncAutoResetEnv()
+    trainer.device = torch.device("cpu")
+    trainer.eval_seed = 123
+    trainer.eval_event_manager = MagicMock()
+    trainer.eval_event_manager.available_modes = []
+    trainer.global_step = 0
+    trainer.eval_history = []
+    trainer.last_eval_metrics = {}
+    trainer.writer = None
+    trainer.rank = 1
+    trainer.use_wandb = False
+    trainer.best_eval_metric = "missing"
+    trainer.best_eval_value = None
+    trainer.best_eval_mode = "max"
+    trainer._finalize_eval_events = MagicMock()
+
+    trainer._eval_once(num_episodes=1)
+    trainer._eval_once(num_episodes=1)
+
+    assert trainer.eval_event_manager.set_seed.call_args_list == [
+        call(123),
+        call(123),
+    ]

--- a/tests/learning/test_train_profile.py
+++ b/tests/learning/test_train_profile.py
@@ -18,10 +18,15 @@
 
 from __future__ import annotations
 
+import random
+
+import numpy as np
 import pytest
+import torch
 
 from embodichain.learning.rl.train import (
     _resolve_profile_output,
+    _seed_training_rng,
     parse_args,
     train_from_config,
 )
@@ -52,6 +57,17 @@ def test_resolve_profile_output_disambiguates_ranks():
     assert _resolve_profile_output("out/prof.json", rank=1, world_size=2) == (
         "out/prof_rank1.json"
     )
+
+
+def test_seed_training_rng_replays_all_policy_rngs() -> None:
+    _seed_training_rng(73, torch.device("cpu"))
+    first = (random.random(), float(np.random.random()), torch.rand(3))
+
+    _seed_training_rng(73, torch.device("cpu"))
+    second = (random.random(), float(np.random.random()), torch.rand(3))
+
+    assert first[:2] == second[:2]
+    torch.testing.assert_close(first[2], second[2])
 
 
 def test_learning_env_rejects_profile(tmp_path):

--- a/tests/utils/test_utility.py
+++ b/tests/utils/test_utility.py
@@ -17,10 +17,12 @@
 from __future__ import annotations
 
 import json
+import os
 
 import pytest
 
-from embodichain.utils.utility import load_config, save_config
+import embodichain.utils.utility as utility_module
+from embodichain.utils.utility import load_config, read_all_folder_images, save_config
 
 
 @pytest.fixture
@@ -87,6 +89,34 @@ class TestLoadConfig:
         )
 
         assert loaded["id"] == "PourWater-v1"
+
+
+def test_read_all_folder_images_uses_stable_path_order(monkeypatch, tmp_path) -> None:
+    """Seeded texture selection sees the same catalog order across filesystems."""
+    monkeypatch.setattr(
+        os,
+        "walk",
+        lambda path: [(str(path), [], ["z.png", "a.png", "m.png"])],
+    )
+    monkeypatch.setattr(utility_module.cv2, "imread", lambda path: path)
+    monkeypatch.setattr(
+        utility_module.cv2,
+        "cvtColor",
+        lambda image, color_conversion: image,
+    )
+    monkeypatch.setattr(
+        utility_module,
+        "tqdm",
+        lambda values, **kwargs: values,
+    )
+
+    images = read_all_folder_images(str(tmp_path))
+
+    assert images == [
+        str(tmp_path / "a.png"),
+        str(tmp_path / "m.png"),
+        str(tmp_path / "z.png"),
+    ]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

Ports the deterministic task-environment seeding and event-randomization support from the v0.2.4 line onto current main.

The environment now accepts a seed in configuration and the CLI, replays it on reset, and gives each event functor an isolated deterministic Python, NumPy, and Torch RNG scope. Asset and texture catalog ordering is stabilized; RL training and evaluation receive the configured seed; and documentation plus focused regression coverage are included.

This supports repeatable simulator-model validation, including material, lighting, object-pose, and camera-image consistency. No new runtime dependencies are required.

v0.2.4 counterpart: #579.

## Type of change

- New feature (non-breaking change which adds functionality)
- Documentation update

## Screenshots

Camera acceptance was run locally with the CobotMagic camera fixture under this main-based runtime. Three resets with seed 20260903 produced byte-identical raw RGBA images, fork pose, point-light state, and material selection; a different seed changed all four signals. Generated PNG, NPY, diff, manifest, and contact-sheet artifacts are intentionally ignored from the repository.

## Checklist

- [x] I have run the black . command to format the code base.
- [x] I have made corresponding changes to the documentation
- [x] Public API changes are reflected in the API docs (python docs/scripts/check_api_docs.py), if applicable
- [x] I have added tests that prove my feature works
- [x] Dependencies have been updated, if applicable.