### PR TITLE
Use CobotMagic Arm V4 assets

### DIFF
--- a/embodichain/data/assets/robot_assets.py
+++ b/embodichain/data/assets/robot_assets.py
@@ -53,9 +53,9 @@ class CobotMagicArm(EmbodiChainDataset):
     def __init__(self, data_root: str = None):
         data_descriptor = o3d.data.DataDescriptor(
             os.path.join(
-                EMBODICHAIN_DOWNLOAD_PREFIX, robot_assets, "CobotMagicArmV3.zip"
+                EMBODICHAIN_DOWNLOAD_PREFIX, robot_assets, "CobotMagicArmV4.zip"
             ),
-            "12a249e231bfc2faf0fd55f9e2646b8d",
+            "8cc54c240c2f26e84e22250c8364b0ec",
         )
         prefix = type(self).__name__
         path = EMBODICHAIN_DEFAULT_DATA_ROOT if data_root is None else data_root


### PR DESCRIPTION
## Description

This PR updates the CobotMagicArm data descriptor to download CobotMagicArmV4.zip and validate it with its published MD5 checksum.

The companion archive is available in Hugging Face PR #30: https://huggingface.co/datasets/DexForceAI/embodichain_data/discussions/30

Dependencies: Hugging Face PR #30 must merge before this PR.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which improves an existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (existing functionality will not work without user modification)
- [ ] Documentation update

## Screenshots

Not applicable.

## Checklist

- [x] I have run the Black formatting check.
- [x] Public API documentation coverage is unchanged and verified.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] The V4 archive layout, ZIP integrity, and MD5 checksum were verified.
- [x] Dependencies have been updated, if applicable.