### PR TITLE
Add background texture material asset

### DIFF
--- a/embodichain/data/assets/materials.py
+++ b/embodichain/data/assets/materials.py
@@ -152,3 +152,23 @@ class CocoBackground(EmbodiChainDataset):
         path = EMBODICHAIN_DEFAULT_DATA_ROOT if data_root is None else data_root
 
         super().__init__(prefix, data_descriptor, path)
+
+
+class BackgroundTexture(EmbodiChainDataset):
+    """Download the bundled background-texture collection.
+
+    Args:
+        data_root: Optional root directory for downloaded and extracted assets.
+    """
+
+    def __init__(self, data_root: str = None):
+        data_descriptor = o3d.data.DataDescriptor(
+            os.path.join(
+                EMBODICHAIN_DOWNLOAD_PREFIX, material_assets, "BackgroundTexture.zip"
+            ),
+            "09cbde19f9e29d09c9aadf93b5dcf45d",
+        )
+        prefix = type(self).__name__
+        path = EMBODICHAIN_DEFAULT_DATA_ROOT if data_root is None else data_root
+
+        super().__init__(prefix, data_descriptor, path)

--- a/embodichain/data/dataset.py
+++ b/embodichain/data/dataset.py
@@ -14,23 +14,74 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
+from __future__ import annotations
+
 import os
 import sys
 import shutil
 import hashlib
+import time
+from contextlib import contextmanager
+from typing import Iterator
 import open3d as o3d
 
 from embodichain.utils import logger
 
 
+@contextmanager
+def _dataset_download_lock(path: str, prefix: str) -> Iterator[None]:
+    """Serialize download and extraction for one dataset cache entry.
+
+    Pytest-xdist workers and separate user processes can request the same
+    dataset simultaneously. The lock lives outside the per-dataset download
+    directory because failed-download cleanup removes that directory.
+
+    Args:
+        path: Root of the EmbodiChain data cache.
+        prefix: Dataset cache directory name.
+    """
+    lock_dir = os.path.join(path, "download", ".locks")
+    os.makedirs(lock_dir, exist_ok=True)
+    lock_path = os.path.join(lock_dir, f"{prefix}.lock")
+
+    with open(lock_path, "a+") as lock_file:
+        if os.name == "nt":
+            import msvcrt
+
+            lock_file.seek(0, os.SEEK_END)
+            if lock_file.tell() == 0:
+                lock_file.write("0")
+                lock_file.flush()
+            lock_file.seek(0)
+            while True:
+                try:
+                    msvcrt.locking(lock_file.fileno(), msvcrt.LK_NBLCK, 1)
+                    break
+                except OSError:
+                    time.sleep(0.1)
+            try:
+                yield
+            finally:
+                lock_file.seek(0)
+                msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+            return
+
+        import fcntl
+
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
 class EmbodiChainDataset(o3d.data.DownloadDataset):
     def __init__(self, prefix, data_descriptor, path):
-        # Perform the zip file and extracted contents check
-        # If the zip was not valid, the zip file would have been removed
-        # and the parent class would download and extract it again
-        self.check_zip(prefix, data_descriptor, path)
-        # Call the parent class constructor
-        super().__init__(prefix, data_descriptor, path)
+        with _dataset_download_lock(path, prefix):
+            # Perform the zip file and extracted contents check. If the zip is
+            # not valid, the parent class downloads and extracts it again.
+            self.check_zip(prefix, data_descriptor, path)
+            super().__init__(prefix, data_descriptor, path)
 
     def check_zip(self, prefix, data_descriptor, path):
         """Check the integrity of the zip file and its extracted contents."""

--- a/embodichain_tasks/configs/tasks/manipulation/tableware/pour_water/env.yaml
+++ b/embodichain_tasks/configs/tasks/manipulation/tableware/pour_water/env.yaml
@@ -96,10 +96,9 @@ env:
       params:
         entity_cfg:
           uid: bottle
-        texture_path: BackgroundTexture/100
         p_original: 0.0
-        p_library: 1.0
-        p_solid: 0.0
+        p_library: 0.0
+        p_solid: 1.0
     settle_pour_objects_on_reset:
       func: wait_for_dynamic_objects_to_settle
       mode: reset

--- a/embodichain_tasks/configs/tasks/manipulation/tableware/pour_water/env.yaml
+++ b/embodichain_tasks/configs/tasks/manipulation/tableware/pour_water/env.yaml
@@ -80,6 +80,26 @@ env:
           - [0.6, 0.6, 0.6]
           - [1, 1, 1]
         intensity_range: [50.0, 100.0]
+    random_table_material:
+      func: randomize_visual_material
+      mode: reset
+      params:
+        entity_cfg:
+          uid: table
+        texture_path: BackgroundTexture/100
+        p_original: 0.0
+        p_library: 1.0
+        p_solid: 0.0
+    random_bottle_material:
+      func: randomize_visual_material
+      mode: reset
+      params:
+        entity_cfg:
+          uid: bottle
+        texture_path: BackgroundTexture/100
+        p_original: 0.0
+        p_library: 1.0
+        p_solid: 0.0
     settle_pour_objects_on_reset:
       func: wait_for_dynamic_objects_to_settle
       mode: reset

--- a/tests/data/test_dataset.py
+++ b/tests/data/test_dataset.py
@@ -1,0 +1,90 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+"""Regression tests for data-cache synchronization."""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+import time
+
+import pytest
+
+from embodichain.data.dataset import _dataset_download_lock
+
+LOCK_HOLD_SECONDS = 0.2
+PROCESS_JOIN_TIMEOUT_SECONDS = 5.0
+
+
+def _hold_dataset_download_lock(
+    data_root: str,
+    start_event,
+    active_initializers,
+    maximum_active_initializers,
+) -> None:
+    """Enter the same dataset lock and hold it long enough to detect overlap."""
+    start_event.wait()
+    with _dataset_download_lock(data_root, "ConcurrentDataset"):
+        with active_initializers.get_lock():
+            active_initializers.value += 1
+            with maximum_active_initializers.get_lock():
+                maximum_active_initializers.value = max(
+                    maximum_active_initializers.value,
+                    active_initializers.value,
+                )
+        try:
+            time.sleep(LOCK_HOLD_SECONDS)
+        finally:
+            with active_initializers.get_lock():
+                active_initializers.value -= 1
+
+
+@pytest.mark.no_sim
+def test_dataset_initialization_is_serialized_across_processes(tmp_path) -> None:
+    """One worker completes cache preparation before another enters it."""
+    context = mp.get_context("spawn")
+    active_initializers = context.Value("i", 0)
+    maximum_active_initializers = context.Value("i", 0)
+    start_event = context.Event()
+
+    workers = [
+        context.Process(
+            target=_hold_dataset_download_lock,
+            args=(
+                str(tmp_path),
+                start_event,
+                active_initializers,
+                maximum_active_initializers,
+            ),
+        )
+        for _ in range(2)
+    ]
+    for worker in workers:
+        worker.start()
+    start_event.set()
+
+    try:
+        for worker in workers:
+            worker.join(PROCESS_JOIN_TIMEOUT_SECONDS)
+    finally:
+        start_event.set()
+        for worker in workers:
+            if worker.is_alive():
+                worker.terminate()
+            worker.join(PROCESS_JOIN_TIMEOUT_SECONDS)
+
+    assert [worker.exitcode for worker in workers] == [0, 0]
+    assert maximum_active_initializers.value == 1


### PR DESCRIPTION
## Description

This PR registers the BackgroundTexture material archive and configures the CobotMagic pour-water task to randomize the table from its 100-image texture library at reset.

The bottle deliberately does not declare a texture_path. Its material tier is configured as p_solid: 1.0, so it receives a random pure color instead of a background texture.

It also fixes the failed CI run by serializing each data-cache entry across processes. Pytest-xdist workers can no longer concurrently clean, download, or extract CobotMagicArmV4.zip, which previously produced transient MD5 mismatches and missing URDF files.

The archive is supplied by the related [Hugging Face data PR #31](https://huggingface.co/datasets/DexForceAI/embodichain_data/discussions/31). That asset PR must merge before a fresh EmbodiChain installation can download BackgroundTexture from main.

Dependencies: Hugging Face data PR #31.

No linked issue.

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

A one-episode LeRobot capture was generated for CobotMagic pour-water with the solid-color bottle configuration. It contains 308 frames at 25 FPS, and the saved dataset preview passed its structure and segment checks.

## Checklist

- [x] I have run the `black .` command to format the code base.
- [ ] I have made corresponding changes to the documentation.
- [x] Public API documentation coverage was checked with `python docs/scripts/check_api_docs.py`.
- [x] I have added a regression test that proves concurrent cache initialization is serialized.
- [ ] Dependencies have been updated; the external data asset is tracked in Hugging Face data PR #31.

## Validation

- `black --check --diff --color ./`
- `python docs/scripts/check_api_docs.py`
- `BackgroundTexture` archive extraction and `get_data_path(BackgroundTexture/100)` resolution: 100 PNG files
- Production `config_to_cfg` parsing of `task.cobotmagic.yaml`: table uses the background library and bottle is solid-only
- One CobotMagic pour-water episode recorded to LeRobot after the solid-color change; 308 frames at 25 FPS; `preview_lerobot_data --expect-segments 1` passed
- The data-cache concurrency regression test plus the five CobotMagic tests that failed in [CI job #101037393071](https://github.com/DexForce/EmbodiChain/actions/runs/33877275416/job/101037393071?pr=583): 6 passed