### PR TITLE
Fix run task segment progress bars

### DIFF
--- a/agent_context/topics/env-framework/env-framework.md
+++ b/agent_context/topics/env-framework/env-framework.md
@@ -120,6 +120,19 @@ gym.Env
 - Environments without a Task Program keep the ordinary `BaseEnv.is_task_success()`
   behavior and task-specific overrides.
 
+### Segment terminal progress (`demo.py`, `run_env.py`)
+
+Every demo path reaches the same terminal `tqdm` wrapper through
+`execute_demo_episode()`. A `DemoSegment` can declare an exact
+`progress_total_steps` without materializing its lazy action iterable; the
+executor exposes that total through `__len__` only to the progress wrapper.
+Task Program bridges and handwritten trajectory tasks must set it only when
+the emitted action count is fixed. Dynamic recovery, feedback settling, or
+data-dependent waits retain an unknown total rather than reporting a false
+percentage. Segment metadata `program_segment_count` or `segment_count`
+selects the `segment N/M` label; legacy action-list tasks receive
+`segment_count=1` automatically.
+
 ---
 
 ## Task Registration

--- a/agent_context/topics/env-framework/env-framework.md
+++ b/agent_context/topics/env-framework/env-framework.md
@@ -129,8 +129,8 @@ executor exposes that total through `__len__` only to the progress wrapper.
 Task Program bridges and handwritten trajectory tasks must set it only when
 the emitted action count is fixed. Dynamic recovery, feedback settling, or
 data-dependent waits retain an unknown total rather than reporting a false
-percentage. Segment metadata `program_segment_count` or `segment_count`
-selects the `segment N/M` label; legacy action-list tasks receive
+percentage. Segment metadata `segment_count` selects the `segment N/M` label
+for both execution styles; legacy action-list tasks receive
 `segment_count=1` automatically.
 
 ---

--- a/agent_context/topics/task-programs/task-programs.md
+++ b/agent_context/topics/task-programs/task-programs.md
@@ -208,7 +208,9 @@ segment lifecycle completes normally.
 
 The bridge declares `progress_total_steps` only for deterministic open-loop
 Pick/Place segments with fixed interpolation samples and no recovery, runner
-holds, feedback settling, post-policies, or parallel execution. Handwritten
+holds, feedback settling, post-policies, or parallel execution. It links only
+the current segment's calls to their policy presets; progress display never
+performs full workflow analysis or downstream look-ahead. Handwritten
 trajectory tasks use the same `DemoSegment` field for a known fixed trajectory
 and settle suffix; paths whose emitted action count depends on runtime state
 remain indeterminate in both execution styles.

--- a/agent_context/topics/task-programs/task-programs.md
+++ b/agent_context/topics/task-programs/task-programs.md
@@ -206,6 +206,13 @@ Keep these boundaries separate:
 reward, reset, and persistence. Final success is published only after every
 segment lifecycle completes normally.
 
+The bridge declares `progress_total_steps` only for deterministic open-loop
+Pick/Place segments with fixed interpolation samples and no recovery, runner
+holds, feedback settling, post-policies, or parallel execution. Handwritten
+trajectory tasks use the same `DemoSegment` field for a known fixed trajectory
+and settle suffix; paths whose emitted action count depends on runtime state
+remain indeterminate in both execution styles.
+
 ## Demonstration outcome and persistence
 
 The bridge's accepted mask remains the sole segment-quality authority. The

--- a/embodichain/lab/gym/envs/demo.py
+++ b/embodichain/lab/gym/envs/demo.py
@@ -523,20 +523,20 @@ ProgressWrapper = Callable[[Iterable[Any], str], Iterable[Any]]
 StopPredicate = Callable[[], bool]
 
 
+@dataclass(frozen=True)
 class _SizedActionIterable:
     """Expose a declared action count without materializing a lazy iterable."""
 
-    def __init__(self, actions: Iterable[Any], total_steps: int) -> None:
-        self._actions = actions
-        self._total_steps = total_steps
+    actions: Iterable[Any]
+    total_steps: int
 
     def __iter__(self) -> Iterator[Any]:
         """Return the original lazy action iterator."""
-        return iter(self._actions)
+        return iter(self.actions)
 
     def __len__(self) -> int:
         """Return the exact declared number of action steps."""
-        return self._total_steps
+        return self.total_steps
 
 
 def _env_target(env: Any) -> Any:
@@ -595,27 +595,6 @@ def _has_terminal_runtime_failure_trace(segment: DemoSegment) -> bool:
     )
 
 
-def _segment_progress_description(
-    episode_index: int,
-    segment_id: int,
-    segment: DemoSegment,
-) -> str:
-    """Build the terminal label for one executing demonstration segment."""
-    segment_total = segment.metadata.get("program_segment_count")
-    if type(segment_total) is not int:
-        segment_total = segment.metadata.get("segment_count")
-
-    segment_number = segment_id + 1
-    if type(segment_total) is int and segment_total >= segment_number:
-        segment_label = f"{segment_number}/{segment_total}"
-    else:
-        segment_label = f"#{segment_number}"
-    return (
-        f"Executing episode #{episode_index}, segment {segment_label}: "
-        f"{segment.name}"
-    )
-
-
 def _dataset_instruction(env: Any) -> str:
     """Return the dataset-level instruction used for legacy demo segments."""
     metadata = getattr(_env_target(env), "metadata", {})
@@ -665,15 +644,9 @@ def resolve_demo_segments(env: Any, **kwargs: Any) -> Iterable[DemoSegment]:
             )
         actions = legacy_creator(**kwargs)
         segments = (
-            None
+            ()
             if actions is None
-            else (
-                DemoSegment(
-                    actions,
-                    name="legacy",
-                    metadata={"segment_count": 1},
-                ),
-            )
+            else (DemoSegment(actions, name="legacy", metadata={"segment_count": 1}),)
         )
 
     if segments is None:
@@ -817,12 +790,16 @@ def execute_demo_episode(
             if progress is not None:
                 if segment.progress_total_steps is not None:
                     actions = _SizedActionIterable(
-                        actions,
-                        segment.progress_total_steps,
+                        actions, segment.progress_total_steps
                     )
+                segment_total = segment.metadata.get("segment_count")
+                segment_label = f"#{segment_id + 1}"
+                if type(segment_total) is int and segment_total > segment_id:
+                    segment_label = f"{segment_id + 1}/{segment_total}"
                 actions = progress(
                     actions,
-                    _segment_progress_description(episode_index, segment_id, segment),
+                    f"Executing episode #{episode_index}, segment {segment_label}: "
+                    f"{segment.name}",
                 )
 
             action_iterator = iter(actions)

--- a/embodichain/lab/gym/envs/demo.py
+++ b/embodichain/lab/gym/envs/demo.py
@@ -664,7 +664,17 @@ def resolve_demo_segments(env: Any, **kwargs: Any) -> Iterable[DemoSegment]:
                 "create_demo_action_list()."
             )
         actions = legacy_creator(**kwargs)
-        segments = None if actions is None else (DemoSegment(actions, name="legacy"),)
+        segments = (
+            None
+            if actions is None
+            else (
+                DemoSegment(
+                    actions,
+                    name="legacy",
+                    metadata={"segment_count": 1},
+                ),
+            )
+        )
 
     if segments is None:
         return ()

--- a/embodichain/lab/gym/envs/demo.py
+++ b/embodichain/lab/gym/envs/demo.py
@@ -18,7 +18,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Callable, Iterable, Iterator, Mapping
 from dataclasses import dataclass, field, replace
 from types import MappingProxyType
 from typing import Any, Literal
@@ -197,6 +197,10 @@ class DemoSegment:
             behavior. ``"row_independent"`` permanently freezes only failed
             environment rows while peers continue through the shared segment
             and later lazy segments.
+        progress_total_steps: Optional exact action count used by terminal
+            progress wrappers. Leave this as ``None`` when the segment can
+            replan, retry, or otherwise emit a data-dependent number of
+            actions.
     """
 
     actions: Iterable[Any]
@@ -211,6 +215,7 @@ class DemoSegment:
         compare=False,
     )
     failure_policy: Literal["batch_abort", "row_independent"] = "batch_abort"
+    progress_total_steps: int | None = None
 
     def __post_init__(self) -> None:
         if self.abort_actions is not None and not callable(self.abort_actions):
@@ -219,6 +224,10 @@ class DemoSegment:
             raise ValueError(
                 "failure_policy must be 'batch_abort' or 'row_independent'."
             )
+        if self.progress_total_steps is not None and (
+            type(self.progress_total_steps) is not int or self.progress_total_steps < 1
+        ):
+            raise ValueError("progress_total_steps must be a positive integer or None.")
 
 
 @dataclass(frozen=True)
@@ -514,6 +523,22 @@ ProgressWrapper = Callable[[Iterable[Any], str], Iterable[Any]]
 StopPredicate = Callable[[], bool]
 
 
+class _SizedActionIterable:
+    """Expose a declared action count without materializing a lazy iterable."""
+
+    def __init__(self, actions: Iterable[Any], total_steps: int) -> None:
+        self._actions = actions
+        self._total_steps = total_steps
+
+    def __iter__(self) -> Iterator[Any]:
+        """Return the original lazy action iterator."""
+        return iter(self._actions)
+
+    def __len__(self) -> int:
+        """Return the exact declared number of action steps."""
+        return self._total_steps
+
+
 def _env_target(env: Any) -> Any:
     """Return the unwrapped environment when available."""
     return getattr(env, "unwrapped", env)
@@ -567,6 +592,27 @@ def _has_terminal_runtime_failure_trace(segment: DemoSegment) -> bool:
             "parallel_skill_result",
         }
         and runtime.get("status") == "failed"
+    )
+
+
+def _segment_progress_description(
+    episode_index: int,
+    segment_id: int,
+    segment: DemoSegment,
+) -> str:
+    """Build the terminal label for one executing demonstration segment."""
+    segment_total = segment.metadata.get("program_segment_count")
+    if type(segment_total) is not int:
+        segment_total = segment.metadata.get("segment_count")
+
+    segment_number = segment_id + 1
+    if type(segment_total) is int and segment_total >= segment_number:
+        segment_label = f"{segment_number}/{segment_total}"
+    else:
+        segment_label = f"#{segment_number}"
+    return (
+        f"Executing episode #{episode_index}, segment {segment_label}: "
+        f"{segment.name}"
     )
 
 
@@ -759,10 +805,14 @@ def execute_demo_episode(
             if actions is None:
                 actions = ()
             if progress is not None:
+                if segment.progress_total_steps is not None:
+                    actions = _SizedActionIterable(
+                        actions,
+                        segment.progress_total_steps,
+                    )
                 actions = progress(
                     actions,
-                    f"Executing episode #{episode_index}, segment #{segment_id}: "
-                    f"{segment.name}",
+                    _segment_progress_description(episode_index, segment_id, segment),
                 )
 
             action_iterator = iter(actions)

--- a/embodichain/lab/gym/envs/task_program/bridge.py
+++ b/embodichain/lab/gym/envs/task_program/bridge.py
@@ -41,6 +41,8 @@ from embodichain.lab.sim.atomic_actions.bindings import (
     JointPositionTarget,
     RuntimeEndpointTarget,
 )
+from embodichain.lab.sim.atomic_actions.primitives.pick_up import PickUpOptions
+from embodichain.lab.sim.atomic_actions.primitives.place import PlaceOptions
 from embodichain.lab.sim.atomic_actions.runner import (
     CommandAcknowledgement,
     ExecutionClock,
@@ -64,6 +66,7 @@ from embodichain.lab.task_program.runtime.results import (
     SemanticExecutionResult,
     SemanticExecutionStatus,
 )
+from embodichain.lab.task_program.semantics.profiles import EffectAssurance
 from embodichain.lab.sim.types import EnvAction
 
 _SAFE_HOLD_ACTION_KINDS = frozenset(
@@ -1003,6 +1006,7 @@ class TaskProgramDemoBridge:
                 validator=validator,
                 abort_actions=self._segment_abort_actions(segment, lifecycle),
                 failure_policy="row_independent",
+                progress_total_steps=self._segment_progress_total_steps(segment),
             )
             self._require_consumed_segment_lifecycle(segment, lifecycle)
         if self._eligible_mask is None:
@@ -1037,9 +1041,95 @@ class TaskProgramDemoBridge:
                 "compiled segment."
             )
 
+    def _segment_progress_total_steps(self, segment: Any) -> int | None:
+        """Return an exact static action count when one is safe to expose.
+
+        A Task Program normally grounds and plans calls just in time, so a
+        generic segment cannot promise its final number of Gym actions.  The
+        open-loop Pick/Place path is different: no retry, no runner hold, no
+        feedback settlement, and each primitive constructs exactly its policy
+        sample count plus its explicit settle frames.  Expose a total only for
+        that deterministic subset; all other segments retain tqdm's unknown
+        total rather than showing a misleading percentage.
+        """
+        if getattr(segment, "parallel_block", None) is not None or getattr(
+            segment, "post_policies", ()
+        ):
+            return None
+
+        compiler = getattr(self._runtime, "compiler", None)
+        analyze = getattr(compiler, "analyze", None)
+        if not callable(analyze):
+            return None
+
+        try:
+            analysis = self._program.sequential_execution_analysis(
+                segment.segment_index
+            )
+            workflow = analyze(
+                analysis.calls,
+                workflow_id=(
+                    f"{self._program.program_id}/{segment.segment_id}:progress"
+                ),
+            )
+            prefix_length = analysis.execution_prefix_length
+            analyzed_calls = tuple(getattr(workflow, "calls", ()))[:prefix_length]
+            if len(analyzed_calls) != prefix_length:
+                return None
+            totals = [
+                self._deterministic_call_progress_steps(call) for call in analyzed_calls
+            ]
+        except Exception:  # Optional terminal display must not alter execution.
+            return None
+
+        if any(total is None for total in totals):
+            return None
+        return sum(total for total in totals if total is not None)
+
+    def _deterministic_call_progress_steps(
+        self,
+        analyzed_call: Any,
+    ) -> int | None:
+        """Return an exact command count for one deterministic Pick/Place call."""
+        bound = getattr(analyzed_call, "bound", None)
+        preset = getattr(bound, "preset", None)
+        call = getattr(analyzed_call, "call", None)
+        semantic_id = getattr(call, "semantic_id", None)
+        if preset is None or type(semantic_id) is not str:
+            return None
+        if preset.effect_assurance is not EffectAssurance.PROJECTED:
+            return None
+
+        motion_policy = preset.motion_policy
+        recovery_policy = preset.recovery_policy
+        workflow_recovery_policy = preset.workflow_recovery_policy
+        tracking_policy = preset.tracking_policy
+        sample_count = getattr(motion_policy, "sample_count", None)
+        if (
+            getattr(motion_policy, "strategy", None) != "ik_interp"
+            or type(sample_count) is not int
+            or sample_count < 1
+            or recovery_policy.max_replans != 0
+            or recovery_policy.max_action_retries != 0
+            or workflow_recovery_policy.max_recovery_attempts != 0
+            or self._runner_cfg.minimum_cycle_time != 0.0
+            or self._runner_cfg.hold_on_completion
+            or self._runner_cfg.hold_during_effect_verification
+            or tracking_policy.in_flight is not None
+            or getattr(tracking_policy.terminal, "settle_duration", None) != 0.0
+        ):
+            return None
+
+        options = preset.action_option_template(semantic_id)
+        if type(options) is PickUpOptions:
+            return sample_count + options.grasp_settle_steps
+        if type(options) is PlaceOptions:
+            return sample_count + options.release_settle_steps
+        return None
+
     def _segment_metadata(self, segment: Any) -> dict[str, Any]:
         """Build mutable JSON-safe metadata completed at lifecycle boundaries."""
-        return {
+        metadata: dict[str, Any] = {
             "task_program_id": self._program.program_id,
             "program_segment_id": segment.segment_id,
             "program_segment_index": segment.segment_index,
@@ -1053,6 +1143,10 @@ class TaskProgramDemoBridge:
             "post_policies": [],
             "validation": None,
         }
+        program_segment_count = getattr(self._program, "segment_count", None)
+        if type(program_segment_count) is int and program_segment_count > 0:
+            metadata["program_segment_count"] = program_segment_count
+        return metadata
 
     @staticmethod
     def _record_runtime_result(

--- a/embodichain/lab/gym/envs/task_program/bridge.py
+++ b/embodichain/lab/gym/envs/task_program/bridge.py
@@ -66,6 +66,8 @@ from embodichain.lab.task_program.runtime.results import (
     SemanticExecutionResult,
     SemanticExecutionStatus,
 )
+from embodichain.lab.task_program.semantics.calls import Pick, Place
+from embodichain.lab.task_program.semantics.integration import SemanticValidationError
 from embodichain.lab.task_program.semantics.profiles import EffectAssurance
 from embodichain.lab.sim.types import EnvAction
 
@@ -1042,97 +1044,61 @@ class TaskProgramDemoBridge:
             )
 
     def _segment_progress_total_steps(self, segment: Any) -> int | None:
-        """Return an exact static action count when one is safe to expose.
-
-        A Task Program normally grounds and plans calls just in time, so a
-        generic segment cannot promise its final number of Gym actions.  The
-        open-loop Pick/Place path is different: no retry, no runner hold, no
-        feedback settlement, and each primitive constructs exactly its policy
-        sample count plus its explicit settle frames.  Expose a total only for
-        that deterministic subset; all other segments retain tqdm's unknown
-        total rather than showing a misleading percentage.
-        """
-        if getattr(segment, "parallel_block", None) is not None or getattr(
-            segment, "post_policies", ()
+        """Count fixed Pick/Place samples without analyzing downstream calls."""
+        if (
+            getattr(segment, "parallel_block", None) is not None
+            or segment.post_policies
+            or self._runner_cfg.minimum_cycle_time != 0.0
+            or self._runner_cfg.hold_on_completion
+            or self._runner_cfg.hold_during_effect_verification
         ):
             return None
 
         compiler = getattr(self._runtime, "compiler", None)
-        analyze = getattr(compiler, "analyze", None)
-        if not callable(analyze):
+        integration = getattr(compiler, "integration", None)
+        if integration is None:
             return None
 
+        total = 0
         try:
-            analysis = self._program.sequential_execution_analysis(
-                segment.segment_index
-            )
-            workflow = analyze(
-                analysis.calls,
-                workflow_id=(
-                    f"{self._program.program_id}/{segment.segment_id}:progress"
-                ),
-            )
-            prefix_length = analysis.execution_prefix_length
-            analyzed_calls = tuple(getattr(workflow, "calls", ()))[:prefix_length]
-            if len(analyzed_calls) != prefix_length:
-                return None
-            totals = [
-                self._deterministic_call_progress_steps(call) for call in analyzed_calls
-            ]
-        except Exception:  # Optional terminal display must not alter execution.
+            for compiled_call in segment.calls:
+                call = compiled_call.call
+                if type(call) not in (Pick, Place):
+                    return None
+                preset = integration.link_call(call).preset
+                motion = preset.motion_policy
+                recovery = preset.recovery_policy
+                tracking = preset.tracking_policy
+                if (
+                    preset.effect_assurance is not EffectAssurance.PROJECTED
+                    or motion.strategy != "ik_interp"
+                    or type(motion.sample_count) is not int
+                    or recovery.max_replans != 0
+                    or recovery.max_action_retries != 0
+                    or preset.workflow_recovery_policy.max_recovery_attempts != 0
+                    or tracking.in_flight is not None
+                    or getattr(tracking.terminal, "settle_duration", None) != 0.0
+                ):
+                    return None
+                options = preset.action_option_template(call.semantic_id)
+                if type(options) is PickUpOptions:
+                    total += motion.sample_count + options.grasp_settle_steps
+                elif type(options) is PlaceOptions:
+                    total += motion.sample_count + options.release_settle_steps
+                else:
+                    return None
+        except SemanticValidationError:
+            # Let ordinary execution report linking failures through its lifecycle.
             return None
-
-        if any(total is None for total in totals):
-            return None
-        return sum(total for total in totals if total is not None)
-
-    def _deterministic_call_progress_steps(
-        self,
-        analyzed_call: Any,
-    ) -> int | None:
-        """Return an exact command count for one deterministic Pick/Place call."""
-        bound = getattr(analyzed_call, "bound", None)
-        preset = getattr(bound, "preset", None)
-        call = getattr(analyzed_call, "call", None)
-        semantic_id = getattr(call, "semantic_id", None)
-        if preset is None or type(semantic_id) is not str:
-            return None
-        if preset.effect_assurance is not EffectAssurance.PROJECTED:
-            return None
-
-        motion_policy = preset.motion_policy
-        recovery_policy = preset.recovery_policy
-        workflow_recovery_policy = preset.workflow_recovery_policy
-        tracking_policy = preset.tracking_policy
-        sample_count = getattr(motion_policy, "sample_count", None)
-        if (
-            getattr(motion_policy, "strategy", None) != "ik_interp"
-            or type(sample_count) is not int
-            or sample_count < 1
-            or recovery_policy.max_replans != 0
-            or recovery_policy.max_action_retries != 0
-            or workflow_recovery_policy.max_recovery_attempts != 0
-            or self._runner_cfg.minimum_cycle_time != 0.0
-            or self._runner_cfg.hold_on_completion
-            or self._runner_cfg.hold_during_effect_verification
-            or tracking_policy.in_flight is not None
-            or getattr(tracking_policy.terminal, "settle_duration", None) != 0.0
-        ):
-            return None
-
-        options = preset.action_option_template(semantic_id)
-        if type(options) is PickUpOptions:
-            return sample_count + options.grasp_settle_steps
-        if type(options) is PlaceOptions:
-            return sample_count + options.release_settle_steps
-        return None
+        return total or None
 
     def _segment_metadata(self, segment: Any) -> dict[str, Any]:
         """Build mutable JSON-safe metadata completed at lifecycle boundaries."""
-        metadata: dict[str, Any] = {
+        return {
             "task_program_id": self._program.program_id,
             "program_segment_id": segment.segment_id,
             "program_segment_index": segment.segment_index,
+            "segment_count": getattr(self._program, "segment_count", None),
             "program_segment_source_path": list(segment.source_path),
             "program_segment_implicit": bool(segment.implicit),
             "semantic_call_indices": [call.call_index for call in segment.calls],
@@ -1143,10 +1109,6 @@ class TaskProgramDemoBridge:
             "post_policies": [],
             "validation": None,
         }
-        program_segment_count = getattr(self._program, "segment_count", None)
-        if type(program_segment_count) is int and program_segment_count > 0:
-            metadata["program_segment_count"] = program_segment_count
-        return metadata
 
     @staticmethod
     def _record_runtime_result(

--- a/embodichain/lab/scripts/run_env.py
+++ b/embodichain/lab/scripts/run_env.py
@@ -62,8 +62,6 @@ def _progress_wrapper(actions: Iterable[Any], description: str) -> Iterable[Any]
         unit="step",
         file=sys.stdout,
         dynamic_ncols=True,
-        leave=True,
-        disable=False,
     )
 
 

--- a/embodichain/lab/scripts/run_env.py
+++ b/embodichain/lab/scripts/run_env.py
@@ -55,8 +55,16 @@ _REPLAY_CONTROL_POLL_INTERVAL = 0.05
 
 
 def _progress_wrapper(actions: Iterable[Any], description: str) -> Iterable[Any]:
-    """Wrap a segment action iterable in the run-env progress bar."""
-    return tqdm.tqdm(actions, desc=description, unit="step")
+    """Wrap a segment action iterable in a visible terminal progress bar."""
+    return tqdm.tqdm(
+        actions,
+        desc=description,
+        unit="step",
+        file=sys.stdout,
+        dynamic_ncols=True,
+        leave=True,
+        disable=False,
+    )
 
 
 def _env_target(env: Any) -> Any:

--- a/embodichain_tasks/embodichain_tasks/manipulation/tableware/stack_blocks_two.py
+++ b/embodichain_tasks/embodichain_tasks/manipulation/tableware/stack_blocks_two.py
@@ -116,6 +116,7 @@ class StackBlocksTwoEnv(EmbodiedEnv):
                 name="stack_block_2_on_block_1",
                 target_uid=STACK_BLOCK_UID,
                 instruction="Pick up block 2 and place it on top of block 1.",
+                progress_total_steps=int(trajectory.shape[1]) + SETTLE_STEPS,
                 metadata={
                     "segment_index": 0,
                     "segment_count": 1,

--- a/tests/gym/envs/task_program/test_bridge.py
+++ b/tests/gym/envs/task_program/test_bridge.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import json
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -44,6 +45,8 @@ from embodichain.lab.sim.atomic_actions.execution import (
     ExecutionEvent,
     ExecutionEventKind,
 )
+from embodichain.lab.sim.atomic_actions.primitives.pick_up import PickUpOptions
+from embodichain.lab.sim.atomic_actions.primitives.place import PlaceOptions
 from embodichain.lab.sim.atomic_actions.runner import ExecutionRunnerCfg
 from embodichain.lab.sim.atomic_actions.runtime_commands import (
     EndpointCommand,
@@ -69,7 +72,10 @@ from embodichain.lab.task_program.runtime.parallel_executor import (
     ParallelSemanticExecutionResult,
     ParallelSemanticExecutor,
 )
-from embodichain.lab.task_program.semantics.profiles import ResourceClaim
+from embodichain.lab.task_program.semantics.profiles import (
+    EffectAssurance,
+    ResourceClaim,
+)
 
 STEP_DT = 0.02
 BATCH_SIZE = 2
@@ -287,6 +293,60 @@ class _FakeProgram:
                 break
             calls.extend(compiled.call for compiled in segment.calls)
         return _FakeProgramAnalysis(tuple(calls), len(current.calls))
+
+
+class _DeterministicProgressCompiler:
+    """Return static policy bindings for the terminal-progress contract."""
+
+    def __init__(self) -> None:
+        runner_cfg = ExecutionRunnerCfg(
+            minimum_cycle_time=0.0,
+            hold_on_completion=False,
+            hold_during_effect_verification=False,
+        )
+        common = {
+            "effect_assurance": EffectAssurance.PROJECTED,
+            "motion_policy": SimpleNamespace(
+                strategy="ik_interp",
+                sample_count=40,
+            ),
+            "recovery_policy": SimpleNamespace(
+                max_replans=0,
+                max_action_retries=0,
+            ),
+            "workflow_recovery_policy": SimpleNamespace(max_recovery_attempts=0),
+            "runner_cfg": runner_cfg,
+            "tracking_policy": SimpleNamespace(
+                in_flight=None,
+                terminal=SimpleNamespace(settle_duration=0.0),
+            ),
+        }
+        self._calls = (
+            SimpleNamespace(
+                bound=SimpleNamespace(
+                    preset=SimpleNamespace(
+                        **common,
+                        action_option_template=lambda _: PickUpOptions(),
+                    )
+                ),
+                call=SimpleNamespace(semantic_id="pick"),
+            ),
+            SimpleNamespace(
+                bound=SimpleNamespace(
+                    preset=SimpleNamespace(
+                        **common,
+                        action_option_template=lambda _: PlaceOptions(),
+                    )
+                ),
+                call=SimpleNamespace(semantic_id="place"),
+            ),
+        )
+        self.seen_calls: tuple[object, ...] = ()
+
+    def analyze(self, calls: object, *, workflow_id: str) -> SimpleNamespace:
+        del workflow_id
+        self.seen_calls = tuple(calls)
+        return SimpleNamespace(calls=self._calls)
 
 
 def _skill_result(
@@ -894,6 +954,26 @@ def _bridge(
         parallel_safety_validator=parallel_safety_validator,
     )
     return bridge, runtime, clock
+
+
+def test_bridge_declares_repeat_pick_place_progress_total_before_execution() -> None:
+    """Deterministic open-loop Pick/Place exposes the 80-step tqdm total."""
+    bridge, runtime, _ = _bridge(
+        duration=STEP_DT,
+        runner_cfg=ExecutionRunnerCfg(
+            minimum_cycle_time=0.0,
+            hold_on_completion=False,
+            hold_during_effect_verification=False,
+        ),
+    )
+    compiler = _DeterministicProgressCompiler()
+    runtime.compiler = compiler
+
+    demo_segment = next(bridge.iter_segments())
+
+    assert demo_segment.progress_total_steps == 80
+    assert compiler.seen_calls == ("pick", "place")
+    assert runtime.start_count == 0
 
 
 def test_bridge_snapshots_runner_cfg_before_lazy_parallel_creation() -> None:

--- a/tests/gym/envs/task_program/test_bridge.py
+++ b/tests/gym/envs/task_program/test_bridge.py
@@ -18,8 +18,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import json
-from types import SimpleNamespace
 from typing import Any
+from unittest.mock import Mock
 
 import pytest
 import torch
@@ -45,6 +45,7 @@ from embodichain.lab.sim.atomic_actions.execution import (
     ExecutionEvent,
     ExecutionEventKind,
 )
+from embodichain.lab.sim.atomic_actions.policies import MotionPolicy, RecoveryPolicy
 from embodichain.lab.sim.atomic_actions.primitives.pick_up import PickUpOptions
 from embodichain.lab.sim.atomic_actions.primitives.place import PlaceOptions
 from embodichain.lab.sim.atomic_actions.runner import ExecutionRunnerCfg
@@ -60,7 +61,13 @@ from embodichain.lab.sim.atomic_actions.state import (
     SceneSnapshot,
     TaskState,
 )
-from embodichain.lab.task_program.semantics.calls import RegisteredSemanticCall
+from embodichain.lab.sim.atomic_actions.tracking import TrackingPolicy
+from embodichain.lab.task_program.semantics.calls import (
+    Pick,
+    Place,
+    RegisteredSemanticCall,
+)
+from embodichain.lab.task_program.semantics.scene import SceneObjectRef
 from embodichain.lab.task_program.runtime.parallel import ParallelTimingPolicy
 from embodichain.lab.task_program.runtime.results import (
     SemanticExecutionResult,
@@ -75,11 +82,13 @@ from embodichain.lab.task_program.runtime.parallel_executor import (
 from embodichain.lab.task_program.semantics.profiles import (
     EffectAssurance,
     ResourceClaim,
+    SkillPolicyPreset,
 )
 
 STEP_DT = 0.02
 BATCH_SIZE = 2
 ROBOT_DOF = 5
+PROGRESS_SAMPLE_COUNT = 40
 
 
 class _QposProvider:
@@ -293,60 +302,6 @@ class _FakeProgram:
                 break
             calls.extend(compiled.call for compiled in segment.calls)
         return _FakeProgramAnalysis(tuple(calls), len(current.calls))
-
-
-class _DeterministicProgressCompiler:
-    """Return static policy bindings for the terminal-progress contract."""
-
-    def __init__(self) -> None:
-        runner_cfg = ExecutionRunnerCfg(
-            minimum_cycle_time=0.0,
-            hold_on_completion=False,
-            hold_during_effect_verification=False,
-        )
-        common = {
-            "effect_assurance": EffectAssurance.PROJECTED,
-            "motion_policy": SimpleNamespace(
-                strategy="ik_interp",
-                sample_count=40,
-            ),
-            "recovery_policy": SimpleNamespace(
-                max_replans=0,
-                max_action_retries=0,
-            ),
-            "workflow_recovery_policy": SimpleNamespace(max_recovery_attempts=0),
-            "runner_cfg": runner_cfg,
-            "tracking_policy": SimpleNamespace(
-                in_flight=None,
-                terminal=SimpleNamespace(settle_duration=0.0),
-            ),
-        }
-        self._calls = (
-            SimpleNamespace(
-                bound=SimpleNamespace(
-                    preset=SimpleNamespace(
-                        **common,
-                        action_option_template=lambda _: PickUpOptions(),
-                    )
-                ),
-                call=SimpleNamespace(semantic_id="pick"),
-            ),
-            SimpleNamespace(
-                bound=SimpleNamespace(
-                    preset=SimpleNamespace(
-                        **common,
-                        action_option_template=lambda _: PlaceOptions(),
-                    )
-                ),
-                call=SimpleNamespace(semantic_id="place"),
-            ),
-        )
-        self.seen_calls: tuple[object, ...] = ()
-
-    def analyze(self, calls: object, *, workflow_id: str) -> SimpleNamespace:
-        del workflow_id
-        self.seen_calls = tuple(calls)
-        return SimpleNamespace(calls=self._calls)
 
 
 def _skill_result(
@@ -956,23 +911,52 @@ def _bridge(
     return bridge, runtime, clock
 
 
-def test_bridge_declares_repeat_pick_place_progress_total_before_execution() -> None:
-    """Deterministic open-loop Pick/Place exposes the 80-step tqdm total."""
+@pytest.mark.parametrize(
+    "overrides, expected_total",
+    [
+        ({}, 2 * PROGRESS_SAMPLE_COUNT),
+        ({"motion_policy": MotionPolicy(strategy="motion_gen")}, None),
+        ({"recovery_policy": RecoveryPolicy()}, None),
+        ({"tracking_policy": TrackingPolicy.joint_position()}, None),
+        ({"tracking_policy": TrackingPolicy.timed(settle_duration=STEP_DT)}, None),
+    ],
+)
+def test_bridge_progress_counts_only_fixed_pick_place_calls(
+    overrides, expected_total
+) -> None:
+    """Only fixed paths expose a total, without starting or analyzing a workflow."""
+    cube = SceneObjectRef("cube")
+    calls = (Pick(cube), Place(cube, on=SceneObjectRef("table")))
     bridge, runtime, _ = _bridge(
         duration=STEP_DT,
+        segment=_FakeSegment(
+            calls=tuple(_FakeCompiledCall(i, call) for i, call in enumerate(calls))
+        ),
         runner_cfg=ExecutionRunnerCfg(
             minimum_cycle_time=0.0,
             hold_on_completion=False,
             hold_during_effect_verification=False,
         ),
     )
-    compiler = _DeterministicProgressCompiler()
+    policies = {
+        "motion_policy": MotionPolicy(sample_count=PROGRESS_SAMPLE_COUNT),
+        "recovery_policy": RecoveryPolicy(max_replans=0, max_action_retries=0),
+        "tracking_policy": TrackingPolicy.timed(),
+        **overrides,
+    }
+    compiler = Mock()
+    compiler.integration.link_call.return_value.preset = SkillPolicyPreset(
+        "progress",
+        effect_assurance=EffectAssurance.PROJECTED,
+        action_option_templates={"pick": PickUpOptions(), "place": PlaceOptions()},
+        **policies,
+    )
     runtime.compiler = compiler
 
     demo_segment = next(bridge.iter_segments())
 
-    assert demo_segment.progress_total_steps == 80
-    assert compiler.seen_calls == ("pick", "place")
+    assert demo_segment.progress_total_steps == expected_total
+    compiler.analyze.assert_not_called()
     assert runtime.start_count == 0
 
 

--- a/tests/gym/envs/task_program/test_task_vertical_slices.py
+++ b/tests/gym/envs/task_program/test_task_vertical_slices.py
@@ -476,7 +476,7 @@ def test_packaged_repeated_cube_runs_three_lazy_bridge_lifecycles() -> None:
     for segment_index, metadata in enumerate(segment_metadata):
         assert metadata["task_program_id"] == compiled.program_id
         assert metadata["program_segment_index"] == segment_index
-        assert metadata["program_segment_count"] == 3
+        assert metadata["segment_count"] == 3
         assert metadata["semantic_call_indices"] == [
             2 * segment_index,
             2 * segment_index + 1,

--- a/tests/gym/envs/task_program/test_task_vertical_slices.py
+++ b/tests/gym/envs/task_program/test_task_vertical_slices.py
@@ -476,6 +476,7 @@ def test_packaged_repeated_cube_runs_three_lazy_bridge_lifecycles() -> None:
     for segment_index, metadata in enumerate(segment_metadata):
         assert metadata["task_program_id"] == compiled.program_id
         assert metadata["program_segment_index"] == segment_index
+        assert metadata["program_segment_count"] == 3
         assert metadata["semantic_call_indices"] == [
             2 * segment_index,
             2 * segment_index + 1,

--- a/tests/gym/envs/test_demo.py
+++ b/tests/gym/envs/test_demo.py
@@ -283,6 +283,37 @@ def test_execute_demo_episode_runs_lazy_segments_as_one_episode() -> None:
     assert not env._demo_no_auto_reset
 
 
+def test_execute_demo_episode_exposes_declared_progress_total_for_lazy_actions() -> (
+    None
+):
+    """A progress wrapper can render a total without consuming a generator."""
+
+    class _ProgressTotalEnv(_SegmentedEnv):
+        def create_demo_segments(self):
+            def actions():
+                yield from (1, 2, 3)
+
+            return (
+                DemoSegment(
+                    actions=actions(),
+                    name="move_cube",
+                    progress_total_steps=3,
+                ),
+            )
+
+    totals: list[int] = []
+
+    def progress(actions, description: str):
+        del description
+        totals.append(len(actions))
+        return actions
+
+    result = execute_demo_episode(_ProgressTotalEnv(), progress=progress)
+
+    assert result.all_success
+    assert totals == [3]
+
+
 class _LifecycleMetadataEnv:
     """Populate one shared metadata mapping at lazy lifecycle boundaries."""
 

--- a/tests/gym/envs/test_demo.py
+++ b/tests/gym/envs/test_demo.py
@@ -34,9 +34,6 @@ from embodichain.lab.gym.envs.demo import (
 )
 from embodichain.lab.gym.envs.embodied_env import EmbodiedEnv
 from embodichain.lab.gym.envs.types import ControllerAction
-from embodichain_tasks.manipulation.tableware.blocks_ranking_rgb import (
-    BlocksRankingRGBEnv,
-)
 from embodichain_tasks.manipulation.tableware.stack_blocks_two import (
     SETTLE_STEPS,
     StackBlocksTwoEnv,
@@ -293,108 +290,61 @@ def test_execute_demo_episode_runs_lazy_segments_as_one_episode() -> None:
     assert not env._demo_no_auto_reset
 
 
-def test_execute_demo_episode_exposes_declared_progress_total_for_lazy_actions() -> (
-    None
-):
+@pytest.mark.parametrize("total", [None, 3])
+def test_execute_demo_episode_exposes_declared_progress_total_for_lazy_actions(
+    total,
+) -> None:
     """A progress wrapper can render a total without consuming a generator."""
 
     class _ProgressTotalEnv(_SegmentedEnv):
         def create_demo_segments(self):
             def actions():
-                yield from (1, 2, 3)
+                for action in (1, 2, 3):
+                    assert self.state == action - 1
+                    yield action
 
             return (
                 DemoSegment(
                     actions=actions(),
                     name="move_cube",
-                    progress_total_steps=3,
+                    progress_total_steps=total,
                 ),
             )
 
-    totals: list[int] = []
-
     def progress(actions, description: str):
-        del description
-        totals.append(len(actions))
+        assert description == "Executing episode #0, segment #1: move_cube"
+        assert env.actions == []
+        if total is None:
+            with pytest.raises(TypeError):
+                len(actions)
+        else:
+            assert len(actions) == total
         return actions
 
-    result = execute_demo_episode(_ProgressTotalEnv(), progress=progress)
+    env = _ProgressTotalEnv()
+    result = execute_demo_episode(env, progress=progress)
 
     assert result.all_success
-    assert totals == [3]
 
 
 def test_handwritten_motion_generator_segment_declares_exact_progress_total() -> None:
     """A fixed trajectory and fixed settle phase share the tqdm total contract."""
 
-    class _HandwrittenStackEnv:
-        _iter_segment_actions = StackBlocksTwoEnv._iter_segment_actions
-
-        def __init__(self) -> None:
-            self._stack_block = Mock()
-            self._trajectory = torch.zeros(
-                1,
-                HANDWRITTEN_TRAJECTORY_STEPS,
-                HANDWRITTEN_TRAJECTORY_DOF,
-            )
-
-        def _plan_stack(
-            self,
-        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-            plan_success = torch.tensor([True])
-            pose = torch.eye(4).unsqueeze(0)
-            return plan_success, self._trajectory, pose, pose
-
-        @staticmethod
-        def _validate_stack(plan_success: torch.Tensor) -> torch.Tensor:
-            return plan_success
-
-    env = _HandwrittenStackEnv()
-
+    trajectory = torch.zeros(
+        1, HANDWRITTEN_TRAJECTORY_STEPS, HANDWRITTEN_TRAJECTORY_DOF
+    )
+    pose = torch.eye(4).unsqueeze(0)
+    env = Mock(spec=StackBlocksTwoEnv)
+    env._stack_block = Mock()
+    env._plan_stack.return_value = torch.tensor([True]), trajectory, pose, pose
+    env._iter_segment_actions.side_effect = (
+        lambda value: StackBlocksTwoEnv._iter_segment_actions(env, value)
+    )
     segment = StackBlocksTwoEnv.create_demo_segments(env)[0]
 
     assert segment.progress_total_steps == HANDWRITTEN_TRAJECTORY_STEPS + SETTLE_STEPS
     assert len(tuple(segment.actions)) == segment.progress_total_steps
     env._stack_block.clear_dynamics.assert_called_once()
-
-
-def test_dynamic_handwritten_settling_keeps_progress_indeterminate() -> None:
-    """A runtime-dependent settle phase must not claim a fixed tqdm total."""
-
-    class _DynamicHandwrittenEnv:
-        @staticmethod
-        def _target_position(x_offset: float) -> torch.Tensor:
-            del x_offset
-            return torch.zeros(1, HANDWRITTEN_TRAJECTORY_DOF)
-
-        @staticmethod
-        def _plan_block_segment(
-            *,
-            uid: str,
-            arm: str,
-            hand: str,
-            target_position: torch.Tensor,
-        ) -> tuple[torch.Tensor, Any, torch.Tensor]:
-            del uid, arm, hand, target_position
-
-            def actions():
-                yield torch.zeros(1, HANDWRITTEN_TRAJECTORY_DOF)
-
-            return torch.tensor([True]), actions(), torch.eye(4).unsqueeze(0)
-
-        @staticmethod
-        def _validate_block_placement(
-            uid: str,
-            plan_success: torch.Tensor,
-            target_position: torch.Tensor,
-        ) -> torch.Tensor:
-            del uid, target_position
-            return plan_success
-
-    segments = tuple(BlocksRankingRGBEnv.create_demo_segments(_DynamicHandwrittenEnv()))
-
-    assert segments
-    assert all(segment.progress_total_steps is None for segment in segments)
 
 
 class _LifecycleMetadataEnv:

--- a/tests/gym/envs/test_demo.py
+++ b/tests/gym/envs/test_demo.py
@@ -34,6 +34,16 @@ from embodichain.lab.gym.envs.demo import (
 )
 from embodichain.lab.gym.envs.embodied_env import EmbodiedEnv
 from embodichain.lab.gym.envs.types import ControllerAction
+from embodichain_tasks.manipulation.tableware.blocks_ranking_rgb import (
+    BlocksRankingRGBEnv,
+)
+from embodichain_tasks.manipulation.tableware.stack_blocks_two import (
+    SETTLE_STEPS,
+    StackBlocksTwoEnv,
+)
+
+HANDWRITTEN_TRAJECTORY_STEPS = 7
+HANDWRITTEN_TRAJECTORY_DOF = 3
 
 
 def test_demo_segment_result_owns_json_safe_lifecycle_metadata() -> None:
@@ -312,6 +322,79 @@ def test_execute_demo_episode_exposes_declared_progress_total_for_lazy_actions()
 
     assert result.all_success
     assert totals == [3]
+
+
+def test_handwritten_motion_generator_segment_declares_exact_progress_total() -> None:
+    """A fixed trajectory and fixed settle phase share the tqdm total contract."""
+
+    class _HandwrittenStackEnv:
+        _iter_segment_actions = StackBlocksTwoEnv._iter_segment_actions
+
+        def __init__(self) -> None:
+            self._stack_block = Mock()
+            self._trajectory = torch.zeros(
+                1,
+                HANDWRITTEN_TRAJECTORY_STEPS,
+                HANDWRITTEN_TRAJECTORY_DOF,
+            )
+
+        def _plan_stack(
+            self,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+            plan_success = torch.tensor([True])
+            pose = torch.eye(4).unsqueeze(0)
+            return plan_success, self._trajectory, pose, pose
+
+        @staticmethod
+        def _validate_stack(plan_success: torch.Tensor) -> torch.Tensor:
+            return plan_success
+
+    env = _HandwrittenStackEnv()
+
+    segment = StackBlocksTwoEnv.create_demo_segments(env)[0]
+
+    assert segment.progress_total_steps == HANDWRITTEN_TRAJECTORY_STEPS + SETTLE_STEPS
+    assert len(tuple(segment.actions)) == segment.progress_total_steps
+    env._stack_block.clear_dynamics.assert_called_once()
+
+
+def test_dynamic_handwritten_settling_keeps_progress_indeterminate() -> None:
+    """A runtime-dependent settle phase must not claim a fixed tqdm total."""
+
+    class _DynamicHandwrittenEnv:
+        @staticmethod
+        def _target_position(x_offset: float) -> torch.Tensor:
+            del x_offset
+            return torch.zeros(1, HANDWRITTEN_TRAJECTORY_DOF)
+
+        @staticmethod
+        def _plan_block_segment(
+            *,
+            uid: str,
+            arm: str,
+            hand: str,
+            target_position: torch.Tensor,
+        ) -> tuple[torch.Tensor, Any, torch.Tensor]:
+            del uid, arm, hand, target_position
+
+            def actions():
+                yield torch.zeros(1, HANDWRITTEN_TRAJECTORY_DOF)
+
+            return torch.tensor([True]), actions(), torch.eye(4).unsqueeze(0)
+
+        @staticmethod
+        def _validate_block_placement(
+            uid: str,
+            plan_success: torch.Tensor,
+            target_position: torch.Tensor,
+        ) -> torch.Tensor:
+            del uid, target_position
+            return plan_success
+
+    segments = tuple(BlocksRankingRGBEnv.create_demo_segments(_DynamicHandwrittenEnv()))
+
+    assert segments
+    assert all(segment.progress_total_steps is None for segment in segments)
 
 
 class _LifecycleMetadataEnv:

--- a/tests/lab/scripts/test_run_env.py
+++ b/tests/lab/scripts/test_run_env.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -26,6 +27,7 @@ import torch
 from embodichain.lab.gym.envs.demo import (
     DemoEpisodeResult,
     DemoExecutionCfg,
+    DemoSegment,
     DemoSegmentResult,
 )
 from embodichain.lab.task_program.language.loader import (
@@ -46,6 +48,8 @@ ACTION_LIST_INDEX = 0
 REPLAY_NUM_STEPS = 5
 REPLAY_TARGET_STEP = 3
 VISER_POLL_INTERVAL = 0.05
+REPEATED_PICK_PLACE_SEGMENT_COUNT = 3
+REPEATED_PICK_PLACE_SEGMENT_STEP_COUNT = 80
 
 
 def _task_program_payload() -> dict[str, object]:
@@ -84,6 +88,29 @@ class _LegacyProgressEnv:
         return True
 
 
+class _TaskProgramProgressEnv(_LegacyProgressEnv):
+    """Three-segment Task Program stand-in matching repeated pick/place."""
+
+    def get_wrapper_attr(self, name: str):
+        if name == "create_demo_segments":
+            return self.create_demo_segments
+        return super().get_wrapper_attr(name)
+
+    def create_demo_segments(self, **kwargs):
+        del kwargs
+        return tuple(
+            DemoSegment(
+                actions=(object(),),
+                name="move_cube",
+                metadata={
+                    "program_segment_count": REPEATED_PICK_PLACE_SEGMENT_COUNT,
+                },
+                progress_total_steps=REPEATED_PICK_PLACE_SEGMENT_STEP_COUNT,
+            )
+            for _ in range(REPEATED_PICK_PLACE_SEGMENT_COUNT)
+        )
+
+
 def test_legacy_action_list_displays_episode_and_segment_indices(
     monkeypatch,
 ) -> None:
@@ -101,8 +128,35 @@ def test_legacy_action_list_displays_episode_and_segment_indices(
 
     assert generated
     assert progress.call_args.kwargs["desc"] == (
-        f"Executing episode #{EPISODE_INDEX}, segment #{ACTION_LIST_INDEX}: legacy"
+        f"Executing episode #{EPISODE_INDEX}, segment #{ACTION_LIST_INDEX + 1}: legacy"
     )
+    assert progress.call_args.kwargs["file"] is sys.stdout
+    assert progress.call_args.kwargs["dynamic_ncols"] is True
+    assert progress.call_args.kwargs["disable"] is False
+
+
+def test_task_program_progress_displays_repeated_segment_position(monkeypatch) -> None:
+    """Repeated pick/place progress labels identify each segment out of three."""
+    env = _TaskProgramProgressEnv()
+    progress = MagicMock(side_effect=lambda actions, **kwargs: actions)
+    monkeypatch.setattr(run_env.tqdm, "tqdm", progress)
+
+    generated = run_env.generate_and_execute_action_list(
+        env,
+        ACTION_LIST_INDEX,
+        debug_mode=False,
+        episode_idx=EPISODE_INDEX,
+    )
+
+    assert generated
+    assert [call.kwargs["desc"] for call in progress.call_args_list] == [
+        f"Executing episode #{EPISODE_INDEX}, segment {index}/"
+        f"{REPEATED_PICK_PLACE_SEGMENT_COUNT}: move_cube"
+        for index in range(1, REPEATED_PICK_PLACE_SEGMENT_COUNT + 1)
+    ]
+    assert [len(call.args[0]) for call in progress.call_args_list] == [
+        REPEATED_PICK_PLACE_SEGMENT_STEP_COUNT
+    ] * REPEATED_PICK_PLACE_SEGMENT_COUNT
 
 
 def test_run_env_syncs_viser_images_each_step_by_default() -> None:

--- a/tests/lab/scripts/test_run_env.py
+++ b/tests/lab/scripts/test_run_env.py
@@ -128,8 +128,10 @@ def test_legacy_action_list_displays_episode_and_segment_indices(
 
     assert generated
     assert progress.call_args.kwargs["desc"] == (
-        f"Executing episode #{EPISODE_INDEX}, segment #{ACTION_LIST_INDEX + 1}: legacy"
+        f"Executing episode #{EPISODE_INDEX}, segment {ACTION_LIST_INDEX + 1}/1: "
+        "legacy"
     )
+    assert len(progress.call_args.args[0]) == 1
     assert progress.call_args.kwargs["file"] is sys.stdout
     assert progress.call_args.kwargs["dynamic_ncols"] is True
     assert progress.call_args.kwargs["disable"] is False

--- a/tests/lab/scripts/test_run_env.py
+++ b/tests/lab/scripts/test_run_env.py
@@ -91,19 +91,16 @@ class _LegacyProgressEnv:
 class _TaskProgramProgressEnv(_LegacyProgressEnv):
     """Three-segment Task Program stand-in matching repeated pick/place."""
 
-    def get_wrapper_attr(self, name: str):
-        if name == "create_demo_segments":
-            return self.create_demo_segments
-        return super().get_wrapper_attr(name)
-
     def create_demo_segments(self, **kwargs):
         del kwargs
         return tuple(
             DemoSegment(
-                actions=(object(),),
+                actions=(
+                    object() for _ in range(REPEATED_PICK_PLACE_SEGMENT_STEP_COUNT)
+                ),
                 name="move_cube",
                 metadata={
-                    "program_segment_count": REPEATED_PICK_PLACE_SEGMENT_COUNT,
+                    "segment_count": REPEATED_PICK_PLACE_SEGMENT_COUNT,
                 },
                 progress_total_steps=REPEATED_PICK_PLACE_SEGMENT_STEP_COUNT,
             )
@@ -134,14 +131,11 @@ def test_legacy_action_list_displays_episode_and_segment_indices(
     assert len(progress.call_args.args[0]) == 1
     assert progress.call_args.kwargs["file"] is sys.stdout
     assert progress.call_args.kwargs["dynamic_ncols"] is True
-    assert progress.call_args.kwargs["disable"] is False
 
 
-def test_task_program_progress_displays_repeated_segment_position(monkeypatch) -> None:
-    """Repeated pick/place progress labels identify each segment out of three."""
+def test_task_program_progress_displays_repeated_segment_position(capsys) -> None:
+    """Each lazy segment renders its position, percentage, and exact step count."""
     env = _TaskProgramProgressEnv()
-    progress = MagicMock(side_effect=lambda actions, **kwargs: actions)
-    monkeypatch.setattr(run_env.tqdm, "tqdm", progress)
 
     generated = run_env.generate_and_execute_action_list(
         env,
@@ -151,14 +145,14 @@ def test_task_program_progress_displays_repeated_segment_position(monkeypatch) -
     )
 
     assert generated
-    assert [call.kwargs["desc"] for call in progress.call_args_list] == [
-        f"Executing episode #{EPISODE_INDEX}, segment {index}/"
-        f"{REPEATED_PICK_PLACE_SEGMENT_COUNT}: move_cube"
-        for index in range(1, REPEATED_PICK_PLACE_SEGMENT_COUNT + 1)
-    ]
-    assert [len(call.args[0]) for call in progress.call_args_list] == [
-        REPEATED_PICK_PLACE_SEGMENT_STEP_COUNT
-    ] * REPEATED_PICK_PLACE_SEGMENT_COUNT
+    output = capsys.readouterr().out
+    for index in range(1, REPEATED_PICK_PLACE_SEGMENT_COUNT + 1):
+        assert (
+            f"Executing episode #{EPISODE_INDEX}, segment {index}/"
+            f"{REPEATED_PICK_PLACE_SEGMENT_COUNT}: move_cube: 100%|"
+        ) in output
+    total = REPEATED_PICK_PLACE_SEGMENT_STEP_COUNT
+    assert output.count(f"{total}/{total}") == REPEATED_PICK_PLACE_SEGMENT_COUNT
 
 
 def test_run_env_syncs_viser_images_each_step_by_default() -> None:


### PR DESCRIPTION
## Description

Lazy demo action generators previously displayed only elapsed steps, such as `80step`, because tqdm had no total. `DemoSegment.progress_total_steps` now supplies an exact length without consuming the generator or changing the existing progress callback interface. Both execution styles use `segment_count` for the `segment N/M` label.

- Repeated Pick/Place shows three segments with `0%` to `100%` progress over 80 steps each. The bridge links only the current segment's calls to their policy presets; it does not repeat full workflow analysis for display.
- `StackBlocksTwo` uses its planned trajectory length plus the fixed settle suffix. Legacy action lists retain their native length and display `segment 1/1`.
- Recovery, feedback settling, variable-length motion generation, post-policies, and parallel execution retain an unknown total.

Dependencies: None. Issue reference: None provided.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Validation

- 154 focused tests passed across demo execution, run-task output, task layout, the Task Program bridge, completion metadata, and packaged task vertical slices.
- Actual tqdm output is checked for all three segment labels, `100%`, and `80/80`; policy tests verify that variable-length paths stay indeterminate.
- 4 progress smoke tests also passed in the user's active checkout.
- Black formatting and API documentation coverage passed (1680/1680 exports).
- No live simulation or GPU execution was run for this display-only change.

## Screenshots

Terminal output is covered by the rendering test; no screenshot attached.

## Checklist

- [x] I have run the `black .` command to format the code base.
- [x] I have updated the relevant agent-context documentation.
- [x] Public API documentation coverage passes (`python docs/scripts/check_api_docs.py`).
- [x] Tests cover the fix and relevant fallback behavior.
- [ ] Dependencies have been updated, if applicable (not applicable).
