### PR TITLE
Add atomic runtime execution for augmented PickUp collection

### DIFF
--- a/agent_context/MAP.yaml
+++ b/agent_context/MAP.yaml
@@ -435,6 +435,7 @@ topics:
       - GenerationRunner
       - FixedSceneHost
       - QposRolloutExecutor
+      - PickUpRuntimeSource
       - trajectory_generation
       - TrajectoryAugmentationCfg
       - CandidateTrajectoryBatch
@@ -489,6 +490,7 @@ topics:
       - examples/sim/motion/trajectory_generation/cube_grasp_parallel.py
       - examples/sim/motion/trajectory_generation/cube_pickup_collection.py
       - embodichain/lab/trajectory_generation/integrations/atomic.py
+      - embodichain/lab/trajectory_generation/integrations/atomic_runtime.py
       - embodichain/lab/trajectory_generation/integrations/contact.py
       - embodichain/lab/task_program/semantics/scene.py
       - embodichain/toolkits/graspkit/pose_generator.py

--- a/agent_context/topics/atomic-actions/atomic-actions.md
+++ b/agent_context/topics/atomic-actions/atomic-actions.md
@@ -296,8 +296,29 @@ mimic geometry and appends real hold commands. Only transit permits residuals.
 `cube_pickup_collection.py` uses this source with full-state/contact validation
 and confirmed LeRobot persistence across repeated full-batch restoration.
 
-This is an offline atomic source: the qpos executor owns physical validation;
-no projected `HeldObjectState` is committed as observed evidence. It does not
-consume `initial_plan_provider` or run AtomicActionRuntime tracking/recovery.
-The runtime adapter and contact-aware Gym source/host matrix remain separate
-acceptance work. Keep the existing runtime and task-state contracts intact.
+The exporter itself does not execute commands or commit projected effects.
+`integrations/atomic_runtime.py::PickUpRuntimeSource` optionally consumes those
+references through `initial_plan_provider`, using a new invocation/context/session
+after every prepared epoch. `PickUp.materialize_trajectory` shares the ordinary
+skill's command, tracking, scene-dependency and pending-held-effect construction.
+The selected transit branch and protected contact phases are retained; the
+reference's initial observation is omitted from the command sequence.
+
+`ExecutionRunner` and `SimulationExecutionAdapter` own command dispatch and arm
+feedback; the collection executor owns the only physics clock and recorder.
+The gripper endpoint has no position-tracking channels because preload prevents
+full closure. Native bilateral contact, hold stability and fresh object/TCP
+transform evidence must pass before symbolic effects are committed. Effect TCP
+uses the verifier context's measured joints through the motion endpoint FK;
+the contact profile's native TCP is a separate frame recorded in metadata. The runtime
+goal must match the qualified reference's URDF FK, not an approximate IK target.
+`ExecutionSession.attempt_generation` exposes recovery generation without copying
+plans. Generation changes, altered commands, extra settling or runtime failures
+cancel/hold and reject the full active cohort; recovery commands are not sent as
+expert data. Commands preserve float64 periods and explicit zero velocity targets
+for full/tail cohorts. Interrupted phase prefixes return unavailable path evidence
+and are audited without terminating the collection job.
+`cube_pickup_collection.py --runtime` selects this pure-sim path.
+Contact-aware Gym and the complete source/host matrix remain separate acceptance
+work. Tests: `test_atomic_runtime.py` and `test_pickup_collection.py` under
+`tests/lab/trajectory_generation/`.

--- a/agent_context/topics/motion-planning/motion-planning.md
+++ b/agent_context/topics/motion-planning/motion-planning.md
@@ -66,7 +66,8 @@ LeRobot expert qualification; the separate `cube_pickup_collection.py` performs
 that bounded collection workflow.
 
 `lab/trajectory_generation/runner.py` owns the synchronous qpos job for
-handwritten free motion and offline atomic PickUp exports. It resolves supplied host/planner/executor/sink policy identities,
+handwritten free motion and atomic PickUp references with offline or observed
+runtime execution. It resolves supplied host/planner/executor/sink policy identities,
 reserves bounded rollout capacity through `GenerationSession`, and restores the
 full batch only when ready candidates need another round. The concrete
 `QposRolloutExecutor` uses normal Gym demo/controller ports or one pure-sim
@@ -141,9 +142,18 @@ controller labels from full-joint passive target columns.
 This is CPU-physics / unscaled fixed-base URDF / cuboid-rigid support. The
 optional `trajectory-generation` dependencies supply FCL/trimesh/yourdfpy.
 It is sampled validation, not continuous collision detection. Contact-aware
-Gym, atomic runtime replay, general via points and a registry/CLI remain work.
+Gym, general via points and a registry/CLI remain work.
+`integrations/atomic_runtime.py::PickUpRuntimeSource` enables the optional
+`QposRolloutExecutor(runtime_source=...)` path. A fresh invocation/current context
+materializes the selected five-phase candidate through the existing PickUp skill;
+ExecutionRunner checks arm feedback while native contact and measured transforms
+verify the held-object effect before commit. The initial sample is an observation,
+not a command. Clock, command or recovery-generation mismatches cancel/hold and
+reject the complete active batch; recovery demonstrations are not collected.
+Use `cube_pickup_collection.py --runtime --record-video` for this pure-sim path.
 Focused tests: `test_contact.py`, `test_atomic_source.py`, `test_episode_sinks.py`,
-`test_pickup_collection.py` under `tests/lab/trajectory_generation/`.
+`test_atomic_runtime.py`, `test_pickup_collection.py` under
+`tests/lab/trajectory_generation/`.
 
 ## Planner Hierarchy
 

--- a/docs/design/fixed_scene_expert_trajectory_augmentation_design.md
+++ b/docs/design/fixed_scene_expert_trajectory_augmentation_design.md
@@ -530,16 +530,16 @@ H(job_seed, source_id, source_revision, scene_case_id,
 
 ### 11.1 现有基础与待补模块
 
-以下记录当前实现与剩余设计范围。真实验证已包括初态恢复、Panda 动态障碍采样检查，以及普通重力下 UR5 自由运动的执行、实测验收、LeRobot 写入/读回。Panda 手指漂移负例被锁定关节模型检查拒绝。真实 Runner 验证为 B=1、direct-sim、20 个命令，不代表 PickUp、真实 Gym 采集或四组合 M1 已完成；详细命令和验证记录见[实施计划](fixed_scene_expert_trajectory_augmentation_implementation_plan.md)。
+以下记录当前实现与剩余设计范围。真实验证包括初态恢复、动态障碍采样检查、普通重力下 UR5 自由运动，以及四行两轮固定 cube 的 PickUp 采集。PickUp 支持离线回放与新的 Atomic Runtime 候选执行，均需物理接触验收和 LeRobot 写入/回读确认；运行时效果验证与恢复拒收已接入。当前结果覆盖 direct-sim 子集，不代表真实 Gym 采集或四组合 M1 已完成；详细命令和验证记录见[实施计划](fixed_scene_expert_trajectory_augmentation_implementation_plan.md)。
 
 | 模块 | 已有基础 | 仍需补齐 |
 |---|---|---|
-| 公共核心与来源 | qpos 模板/候选/配置、严格能力校验、demo 候选输入、原子初始计划供应入口 | EEF via-point 因子、完整原子来源导出与候选消费 |
+| 公共核心与来源 | qpos 模板/候选/配置、严格能力校验、demo 候选输入、PickUp 阶段导出及 pure-sim 运行时候选消费 | EEF via-point 因子、Gym 原子候选接线 |
 | IK 与规划 | MotionGenerator、cuRobo、真实 env_rows 分轮、EEF 显式样本 IK 与已解分支/FK 保留 | 多解枚举/去重、主动绕障路线生成与有界修复、独立候选容量桶与更广 backend 能力 |
-| 路径验证 | free/no-held qpos 加密采样、实测路径重验、运动限值与质量独立 gate | 接触/持物/夹爪变化语义、连续碰撞与任务级 PickUp 验收 |
-| SceneCase 与副本池 | 全批物理初态捕获/恢复/校验、可信 profile、独占 host/epoch、Gym 观测重播种 | 同 case 副本重绑定、接触任务 profile 与长期 settling 验收 |
+| 路径验证 | free/no-held 路径与实测重验；PickUp 完整 URDF 碰撞凸包、受限接触/持物验证、原生接触子步证据 | 更广几何与接触语义、连续碰撞、Gym 子步证据 |
+| SceneCase 与副本池 | 全批物理初态捕获/恢复/校验、可信 profile、独占 host/epoch、Gym 观测重播种 | 同 case 副本重绑定、更广接触任务 profile 与长期 settling 验收 |
 | 会话与调度 | 按 case 分区、局部 RNG、几何去重/覆盖、提议/执行/写入配额及条数/字节上限 | 依赖缓存、时长调度、有界异步 pipeline 与成本调度 |
-| sim/Gym 数据闭环 | 手写 qpos Runner、实际命令/观测冻结、同步 LeRobot 封存/读回/确认，真实 UR5 direct-sim 正例 | 真实 Gym/PickUp、原子来源、统一注册/CLI 及四组合 M1 验收 |
+| sim/Gym 数据闭环 | 手写 qpos Runner、PickUp 离线与 Atomic Runtime direct-sim 采集、T/T+1 冻结、LeRobot 封存/读回/确认 | 真实 Gym/PickUp、手写 EEF/PickUp、统一注册/CLI 及四组合 M1 验收 |
 | 逐行异步／分叉 | 部分行级接口、自然片段保存 | 全链路行隔离、独立任务上下文、完整 checkpoint 及连续性协议 |
 
 ### 11.2 交付顺序

--- a/docs/design/fixed_scene_expert_trajectory_augmentation_implementation_plan.md
+++ b/docs/design/fixed_scene_expert_trajectory_augmentation_implementation_plan.md
@@ -1,6 +1,6 @@
 # 固定场景专家轨迹扩增：实施计划
 
-- 状态：实施中；手写自由运动与离线原子 PickUp 的 direct-sim 采集闭环已落地，完整 Atomic Runtime/Gym/M1 仍待实现与验收。
+- 状态：实施中；手写自由运动、离线原子 PickUp 与受限 Atomic Runtime PickUp 的 direct-sim 采集闭环已落地；Gym、统一启动器及完整 M1 仍待实现与验收。
 - 依据：[设计文档](fixed_scene_expert_trajectory_augmentation_design.md)，2026-09-05。
 - 代码核对基线：`fb7228e2`。首批实现基于该版本，已运行 CPU 行为测试；尚未完成四组合真实仿真和性能验收。
 - 交付原则：先完成可验收、可持久化的四条执行路径，再优化吞吐，最后扩大运动覆盖。
@@ -13,13 +13,13 @@
 | PR 2 的初态基础 | 全批初态复制、恢复、验证与独占 host；Gym 准备/重播种；UR5 自由运动 profile；新增四行 PickUp profile 和抓取结束后的整批循环恢复 | 任意接触 checkpoint、逐行恢复和复杂 settling 仍不支持；Gym PickUp 待验收 |
 | PR 4 的基础算子与自由段适配 | 显式自由段 `joint_residual`、retime 与阶段索引重映射、采样速度/加速度检查；`EEFPath / EnvRowMotionPlanner` 的真实 env_rows 分轮、显式 EEF 样本 IK、已解分支保留/FK 验证、自由 qpos 分段加密碰撞检查 | EEF via-point 因子生成、接触/持物/夹爪变化的完整碰撞语义与真实 backend 任务验收；离散路径检查不代表连续碰撞证明或物理成功 |
 | PR 5 的手写 qpos/free-motion 闭环 | `GenerationRunner / MotionLimitsProfile / QposRolloutExecutor` 连接 profile 身份、全批初态、sim/Gym 实际命令/观测冻结、规划与实测验收、Session 配额和 sink 确认；真实 UR5 direct-sim 正例 committed 1，Panda 锁定关节漂移负例 committed 0 | 手写 EEF/PickUp、真实 Gym 任务采集及多行/多 episode 任务验收；当前结果不代表 PR 5 全部原定验收或 M1 完成 |
-| PR 6 的候选输入与离线模板 | 既有 `initial_plan_provider` 入口；新增 `export_pickup_templates`，从 MoveEndEffector → PickUp 离线编译导出受保护阶段、mimic 几何和实测保持段；接入 Runner 的离线 qpos 采集 | 候选到新的运行时 ActionPlan 的适配、Atomic Runtime tracking/recovery 和 Task Program/Gym 四组合接线；离线导出不代表这些完成 |
+| PR 6 的候选输入与原子运行时 | `export_pickup_templates` 导出五阶段模板；`PickUpRuntimeSource` 在当前初态物化新的 PickUp 计划，由 ExecutionRunner 执行选中分支、检查反馈、验证效果；真实四行两轮确认提交 8 条 | Task Program/Gym 接触桥、恢复数据隔离之外的恢复专家、统一启动器和完整四组合验收仍待实现 |
 | 新增 PickUp 接触闭环 | `PickUpMotionValidator`：完整 URDF 碰撞凸包、mimic 与持物几何、分阶段接触规则、CPU 物理子步接触证据、抬升到保持的相对漂移和双指接触验收；`cube_pickup_collection.py` 四行多轮采集，保存视频和确认后的 LeRobot 数据 | 仅固定基座未缩放 URDF + 盒状刚体 + CPU 物理；通用 mesh 场景、连续碰撞、Gym 子步接口另行扩展 |
 | PR 3 的同步保存基础 | `ExpertEpisode` 与 `CommitReceipt`；Session 预留/确认/失败重试；LeRobot 分片封存/真实回读；新增数值矩阵展开及原始 shape/终态保留；确认提交只读幂等核验 | 重启恢复、异步 pipeline 等后续范围；完整四组合真实采集仍需 PR 6 验收 |
 
-当前 `restore_initial` 使用显式全批物理状态适配与可信 profile，不调用普通 reset；同步 sink 只有封存并读回真实文件才确认提交。手写 qpos 的宿主证据冻结、实际控制标签、Runner/Session/sink 已接通，并通过普通重力下 UR5 自由运动真实采集。新增 direct-sim PickUp 的受限接触/持物检查和任务 profile；统一配置注册/CLI、完整原子运行时来源和 M1 四组合发布门槛仍未完成。当前示例显式构造可信服务；配置 ID 本身不代表服务已经注册。
+当前 `restore_initial` 使用显式全批物理状态适配与可信 profile，不调用普通 reset；同步 sink 只有封存并读回真实文件才确认提交。手写 qpos 的宿主证据冻结、实际控制标签、Runner/Session/sink 已接通，并通过普通重力下 UR5 自由运动真实采集。新增 direct-sim PickUp 的受限接触/持物检查和任务 profile；统一配置注册/CLI、Gym 原子运行时来源和 M1 四组合发布门槛仍未完成。当前示例显式构造可信服务；配置 ID 本身不代表服务已经注册。
 
-新增 API、测试和现有行为变更已同步对应文档及 agent context。下一步接入 Atomic Runtime 的候选消费与等价物理子步证据，再推进 Gym PickUp、via-point 因子和统一配置启动器；当前离线回放不扩大为完整原子运行时或 M1 四组合能力声明。
+新增 API、测试和现有行为变更已同步对应文档及 agent context。Atomic Runtime 的 pure-sim 候选消费已接通同一物理子步证据；下一步推进 Gym PickUp、via-point 因子和统一配置启动器。本次只完成原子 × sim 子集，不扩大为完整 M1 四组合能力声明。
 
 模块归属 review 后，`solvers`、`planners`、`workspace` 与 `trajectory_augmentation` 统一归入 `embodichain.lab.sim.motion`。公共 API、测试、示例和文档使用新路径，不提供旧路径兼容包。`motion` 父包仅按需加载子包；扩增算法保持无直接 Gym/仿真 backend 依赖，但其公共导入不再承诺绕过 `lab/sim` 初始化。该调整不改变下述 M0/M1 验收要求或未完成状态。
 
@@ -33,7 +33,7 @@ PR 5 组合回归 `1379 passed, 1 skipped, 118 deselected`；补充有界 `last_
 
 上一轮文档校验：公共导出覆盖 `1751/1751`，checker 测试 `8 passed`，Sphinx dummy 构建成功。本次新增 API/指南没有相关告警；构建仍报告其他既有文档的 46 条告警。`git diff --check -- docs` 通过。
 
-### 本轮 PickUp 实施范围
+### PR #591 的离线 PickUp 实施范围
 
 - 来源通过 `AtomicActionEngine.compile` 复用现有 MoveEndEffector/PickUp 规划；`export_pickup_templates` 保留接近/闭合/抬升边界，展开 mimic 坐标，并加入 30 个真实保持命令。只增强 transit，不改变接触时序。
 - 碰撞适配使用 URDF **碰撞**形状的保守凸包和完整关节 FK，包含指尖、mimic、随 TCP 移动的目标盒体和隐式地面；实测重验使用真实目标位姿。两条关节边以内的结构自碰撞排除沿用 cuRobo 规则。验证有界采样，不声明连续碰撞保证。
@@ -44,7 +44,26 @@ PR 5 组合回归 `1379 passed, 1 skipped, 118 deselected`；补充有界 `last_
 
 本轮同步 main 的显式物理步进 API 后，motion、原子动作、采集、Gym 初态与 demo、仿真管理器及 gizmo 组合回归为 `1542 passed, 1 skipped, 168 deselected`；真实并行采集、异常退出清理和原有视频示例为 `3 passed, 1 deselected`。四行两轮共 proposed/attempted/committed `8/8/8`，每条保持 1.5 秒、双指接触覆盖 100%，最小抬升 17.90–17.92 cm，相对位置最大漂移 0.35–0.73 mm；LeRobot 和 544 帧 H.264 视频均已真实回读。全仓 Black、`git diff --check` 通过；API 覆盖 `1761/1761`、checker 测试 `8 passed`，Sphinx dummy 构建完成，仍有文档告警。这些测试集与前述记录有重叠，不相加。
 
-当前已实现部分合并为一个 draft PR 提交 review。下文的 PR 编号保留为实施计划的工作划分，不表示这些 PR 已独立创建或全部验收。
+上述基础在 [draft PR #591](https://github.com/DexForce/EmbodiChain/pull/591) 中 review。Atomic Runtime 增量使用独立 PR，base 为 #591 的 `feat/fixed-scene-trajectory-generation` 分支。下文的 PR 编号保留为实施计划的工作划分，不表示已独立创建或全部验收。
+
+### 本轮 Atomic Runtime × sim 实施范围
+
+- `PickUpRuntimeSource` 通过 `initial_plan_provider` 使用指定候选，在每个新 `PreparedBatch` 上创建 invocation、实测 context、session 和 pending effect。`PickUp.materialize_trajectory` 复用原技能的命令/反馈/场景依赖/效果构建，不重新求解候选 IK。
+- 一个 PickUp 计划保留 transit/approach/close/lift/hold；初始样本只做观测，271 个命令对应 272 个观测。运行时与采集器使用同一物理时钟，dt 保留 float64，整批和尾批均明确下发零速度目标。
+- 机械臂保留 0.08/0.05 rad 运行中/末端反馈。手指因抓物不能达到完全闭合目标，使用独立原生双指接触和抬升/持物稳定性验收。效果验证使用当前 context 的实测关节 FK，与请求的 motion endpoint TCP 同坐标定义；原生接触 profile 的 TCP 单独记录，不把两套定义混用。
+- 全部命令执行后才请求实测效果验证，通过后提交 held-object 状态。运行时失败、额外等待、时钟/命令失配或重试/重规划均安全取消并保持整批活跃行，只保留拒绝审计。`attempt_generation` 暴露计划代数，恢复命令在 transport 边界被拒绝。
+- 示例增加 `--runtime`；`atomic_runtime` 强制 gate 和有界 episode 元数据记录命令数、计划尝试数、事件、效果误差及 TCP 定义。原离线执行仍可运行，视频在实际批次边界重置轨迹和计时。
+
+复现正例：
+
+```bash
+python examples/sim/motion/trajectory_generation/cube_pickup_collection.py \
+  --output /tmp/cube-runtime-experts --episodes 8 --runtime --record-video
+```
+
+真实四行两轮 proposed/attempted/committed 为 `8/8/8`；每条 271 个命令、272 个观测，双指保持接触覆盖 100%，最小抬升 17.90 cm；效果平移误差 3.56–5.69 mm、最大转角误差 0.0073 rad。8 个 LeRobot 分片和 544 帧 H.264 视频均已回读。完整 M1 仍需 Gym 与手写 EEF/PickUp 对应组合、统一配置启动器及其失败矩阵。
+
+本轮验证：采集与原子动作 CPU 回归 `993 passed, 1 skipped, 15 deselected`；runtime 正例、真实尾批恢复拒收、原离线采集及可视化示例共 `4 passed`。恢复负例只下发 1 个候选命令，记录 2 次计划尝试和 tracking divergence，恢复命令被拦截，安全保持且 committed 为 0；中断阶段作为不可用路径证据正常拒收，不使整个 job 异常退出。公共 API 覆盖 `1762/1762`、checker 测试 `8 passed`，全仓 Black 和差异检查通过。Sphinx dummy 构建成功并报告 744 条告警；未报告本次新增采集 API 的告警。独立只读审查发现的尾批速度目标和 float32 控制周期问题均已修复并通过复查。
 
 ## 1. 实施范围与里程碑
 
@@ -103,7 +122,8 @@ embodichain/lab/trajectory_generation/
   integrations/
     planning.py     # 已实现 free/no-held EEF/qpos 的 env_rows 适配与采样检查
     handwritten.py  # 显式模板与 DemoSegment 适配
-    atomic.py         # 已实现：离线 PickUp 阶段模板；运行时 ActionPlan 适配另行落地
+    atomic.py         # 离线 PickUp 阶段模板
+    atomic_runtime.py # 新请求/计划物化、运行时命令与效果验证、恢复拒收
     contact.py        # 已实现：PickUp 完整几何和 CPU 物理子步接触验收
     sim.py           # 已实现物理初态适配；rollout 控制/计时/观测归 execution.py
     gym.py           # Gym 初态、正常 env.step、demo/Task Program 桥
@@ -210,7 +230,7 @@ Gym 接口增加全批 generation lease，租约内拒绝普通 reset 并抑制�
 
 **当前状态：handwritten qpos/free-motion 同步闭环已落地。** `GenerationRunner` 与 `MotionLimitsProfile` 要求显式传入现有 host、planner、executor、sink 和可信限速配置，对齐 source/template/profile/validator/tolerance ID 与 control_dt/fps。运行入口接收每个物理行的固定 case 和 qpos reference，提议允许的残差/retime，规划检查后先预留配额与容量，再执行。`QposRolloutExecutor` 采集实际命令与实测观测/时间，冻结证据后由 Runner 重验实际碰撞、速度/加速度、路径/时长质量和任务成功，再提交。`generation_report.json` 记录配置、包版本、计数、audit 与目标达成状态；`last_failures` 将无完整 transition 等失败原因有界保留到 audit。Runner 为 single-use，并在退出时关闭传入的 host/sink。
 
-自由运动路径使用原 `EnvRowMotionPlanner` 的锁定关节约束。新增 PickUp 路径必须将同一个 `PickUpMotionValidator` 传入 Runner 和 executor，才能允许目标物体与 mimic 运动并采集物理子步证据。它接收离线原子模板；完整 Atomic Runtime、Gym PickUp、M1 和统一 CLI 仍未完成。
+自由运动路径使用原 `EnvRowMotionPlanner` 的锁定关节约束。新增 PickUp 路径必须将同一个 `PickUpMotionValidator` 传入 Runner 和 executor，才能允许目标物体与 mimic 运动并采集物理子步证据。它接收离线原子模板，可选通过 `PickUpRuntimeSource` 消费选中候选；Gym PickUp、M1 和统一 CLI 仍未完成。
 
 真实正例使用纯 arm UR5、普通重力、CPU physics + CUDA cuRobo、B=1：1 秒内 21 个观测/20 个命令，实际位移约 `0.078021 rad`、终点误差 `0.003212 rad`、最大跟踪误差 `0.010872 rad`，全部 gate 通过且 LeRobot 读回 confirmed，`committed=1`。Panda 默认重力负例中 task/quality/dynamics 通过，但最大手指漂移约 `3.7853e-5` 超过 locked model 的 `1e-6` 比较阈值，实测路径验收 unavailable，`committed=0`。候选不发出夹爪变化命令不能代替实测锁定关节一致性。两项真实测试均通过；未据此验收真实 Gym 采集、多行或连续多 episode。
 

--- a/docs/source/api_reference/embodichain/embodichain.lab.trajectory_generation.rst
+++ b/docs/source/api_reference/embodichain/embodichain.lab.trajectory_generation.rst
@@ -16,8 +16,9 @@ The synchronous runner supports free-motion references and an explicitly
 bounded CPU-physics PickUp integration. The latter exports an offline atomic
 compilation, checks full gripper and held-object geometry, records native
 contacts at each physics substep, and persists accepted measured episodes.
-AtomicActionRuntime recovery/feedback execution, contact-aware Gym collection,
-a configuration registry, and the unified generation CLI remain separate work.
+An optional observed atomic runner consumes those candidates with arm feedback
+and physical effect verification. Contact-aware Gym collection, a configuration
+registry, and the unified generation CLI remain separate work.
 See :doc:`/overview/trajectory_generation` for the host lifecycle and integration
 requirements.
 
@@ -358,6 +359,42 @@ commit the compilation's hypothetical symbolic effects.
 
 .. autofunction:: export_pickup_templates
 
+.. currentmodule:: embodichain.lab.trajectory_generation.integrations.atomic_runtime
+
+.. autosummary::
+   :nosignatures:
+
+   PickUpRuntimeSource
+
+Pass ``PickUpRuntimeSource`` as ``QposRolloutExecutor(runtime_source=...)`` to
+execute selected references through a fresh ``ExecutionSession`` and
+``ExecutionRunner``. The invocation factory receives the current ``PreparedBatch``;
+its explicit grasp pose must match the qualified reference's TCP FK. The source
+retains all five phase boundaries and contact coordinates, removes the initial
+observation from the command sequence, and constructs pending effects against
+the current measured scene using ``PickUp.materialize_trajectory``.
+
+Arm endpoints require in-flight and terminal feedback. Grasp endpoints use no
+position-tracking channels because contact preload prevents full closure;
+native bilateral contact and held-object stability are mandatory instead.
+The supplied contact validator, engine and pure-sim host must share the robot
+and simulator. Effect poses come from the verifier context's measured joints
+through the same motion endpoint FK as the plan; the contact profile's native
+TCP remains an independent physical check. Symbolic held state is committed only
+after both checks pass.
+
+All active rows must share reference phase boundaries and a uniform control
+clock with float64 intervals and explicit zero velocity targets, including idle
+tail batches. The executor remains the only physics owner. Replans, retries, altered
+commands, or feedback that requires additional settling cancel the active batch
+and reject its expert data. ``ExecutionSession.attempt_generation`` identifies
+recovery plans without copying plan history. Episode metadata includes bounded
+``atomic_runtime`` event counts and validation evidence. This integration does
+not collect recovery demonstrations or support contact-aware Gym execution.
+
+.. autoclass:: PickUpRuntimeSource
+   :members:
+
 .. currentmodule:: embodichain.lab.trajectory_generation.integrations.contact
 
 .. autosummary::
@@ -380,6 +417,8 @@ hold thresholds. Unknown bodies, cross-row contact, buffer overflow, forbidden
 contacts, missing finger contact, slipping and falling fail acceptance. The
 profile does not enable contact or timing augmentation. Gym and arbitrary
 mesh-shaped rigid objects are not supported by this integration.
+``validate_episode`` returns unavailable path evidence for an interrupted phase
+prefix, allowing the runner to audit rejection and continue with a fresh batch.
 
 .. autoclass:: PickUpContactProfile
    :members:

--- a/docs/source/overview/trajectory_generation.rst
+++ b/docs/source/overview/trajectory_generation.rst
@@ -13,9 +13,10 @@ The :mod:`embodichain.lab.sim.motion.trajectory_augmentation` package provides
 qpos candidates, constrained variation, coverage, and generation accounting.
 Two collection paths are available: free motion through the existing locked-joint
 planner, and a bounded CPU-physics PickUp integration with full-joint geometry
-and physical contact validation. PickUp consumes offline atomic compilations;
-AtomicActionRuntime recovery/feedback execution, contact-aware Gym collection,
-and the unified generation CLI remain unimplemented. Initial-state preparation
+and physical contact validation. PickUp can replay an offline compilation or
+consume its augmented candidates through the observed atomic runtime described
+below. Contact-aware Gym collection and the unified generation CLI remain
+unimplemented. Initial-state preparation
 alone does not certify a candidate trajectory or confirm that an episode was saved.
 
 Supported Initial States
@@ -290,7 +291,7 @@ planned feasibility alone cannot qualify the saved episode.
 counts, coverage, audit, resolved configuration, and ``target_reached`` and writes
 ``generation_report.json`` under the sink root. Reaching a proposal, rollout, or
 wall-time budget can finish without reaching the collection target. The PickUp
-adapter below adds contact-aware offline atomic replay; a unified configuration
+adapter below adds contact-aware offline and observed atomic execution; a unified configuration
 registry and generation CLI remain subsequent work.
 
 Running the Real Free-Motion Example
@@ -559,8 +560,56 @@ retain their 4x4 shape. ``preview.mp4`` includes accepted and rejected attempts;
 it is a four-panel record of actual observations, and each round restarts its
 trail and time display. Video is separate from the numeric training dataset.
 
-``source.kind=atomic`` here identifies an offline compilation source. Exporting
-its trajectory does not commit projected symbolic effects or execute the atomic
-recovery/tracking state machine. A full runtime source adapter, the four-way
-handwritten/atomic × sim/Gym qualification matrix, general via-point planning,
-and YAML-based deployment remain subsequent implementation milestones.
+``source.kind=atomic`` identifies the template's compilation source. The default
+mode replays those templates with the physical checks above. To execute them
+through the observed atomic runtime, select ``--runtime``.
+
+Observed Atomic PickUp Execution
+--------------------------------
+
+.. code-block:: bash
+
+   python examples/sim/motion/trajectory_generation/cube_pickup_collection.py \
+     --output /tmp/cube-runtime-experts --episodes 8 --runtime --record-video
+
+``PickUpRuntimeSource`` supplies the selected candidate through
+``initial_plan_provider``. Every prepared batch receives a fresh invocation,
+measured planning context, pending effect and ``ExecutionSession``. A single
+PickUp plan preserves transit/approach/close/lift/hold, including the qualified
+joint branch and protected contact coordinates. The runtime goal uses the
+reference's URDF TCP FK at grasp closure, which can differ from the nominal
+analytic IK target when the asset contains a wrist offset. The initial
+observation is omitted from the command sequence, retaining 271 commands and
+272 observations for this example.
+
+``ExecutionRunner`` sends typed commands through ``SimulationExecutionAdapter``
+and monitors arm position feedback at the existing 0.08 rad in-flight and
+0.05 rad terminal thresholds. The grasp endpoint has no position-tracking
+channels: the fingers press against the cube before full commanded closure.
+Native bilateral contact and hold stability remain mandatory. At completion,
+the verifier's measured joint context supplies FK in the same motion endpoint
+TCP frame as the plan. Together with the current object pose, it must agree with
+the pending held-object transform within the contact profile's tolerances. The
+native contact TCP has its own declared frame; both frame sources and effect
+errors are recorded in episode metadata. Only then does the session commit its
+held-object state. The usual task, geometry and persistence gates still apply.
+
+The collection executor owns every physics step and records the actual submitted
+targets. Runtime commands must match the selected candidate and fixed control
+clock. Intervals retain float64 precision; zero velocity targets are explicit
+for both full and tail batches. Phase or terminal feedback requiring extra waiting fails collection;
+replans and retries use the registered skill but their commands are blocked at
+the transport boundary. Any runtime failure cancels and holds the entire active
+batch, which is retained only as rejected audit evidence. Idle tail-batch rows
+are supported. Recovery demonstrations and independent continuation of other
+rows after a runtime failure are outside this adapter's contract.
+Interrupted phase prefixes produce unavailable path evidence so rejection does
+not prevent the runner from preparing its next batch.
+
+The ``atomic_runtime`` episode metadata contains bounded per-row event counts,
+command count, plan-attempt count, status and physical-effect result. Its
+mandatory validation check must pass before persistence. ``pickup_report.json``
+distinguishes observed runtime execution from offline replay; both modes use the
+same video and LeRobot formats. Contact-aware Gym, the complete handwritten/atomic
+× sim/Gym qualification matrix, general via-point planning, and YAML-based
+deployment remain subsequent milestones.

--- a/embodichain/lab/sim/atomic_actions/execution.py
+++ b/embodichain/lab/sim/atomic_actions/execution.py
@@ -689,6 +689,11 @@ class ExecutionSession:
         return self._plan.snapshot()
 
     @property
+    def attempt_generation(self) -> int:
+        """Current plan generation; replans and retries advance it monotonically."""
+        return self._attempt_generation
+
+    @property
     def plan_attempts(self) -> tuple[ExecutionPlanAttempt, ...]:
         """Return every installed plan in deterministic recovery order.
 

--- a/embodichain/lab/sim/atomic_actions/primitives/pick_up.py
+++ b/embodichain/lab/sim/atomic_actions/primitives/pick_up.py
@@ -512,14 +512,7 @@ class PickUp(AtomicAction[GraspGoal, PickUpOptions]):
             name="Pick-up trajectory success",
         )
 
-        object_to_eef = torch.bmm(pose_inv(object_pose), grasp_xpos)
-        held = HeldObjectState(
-            semantics=sem, object_to_eef=object_to_eef, grasp_xpos=grasp_xpos
-        )
-        coordinated_updates = {
-            key: None for key in state.coordinated_held_objects if task_state_key in key
-        }
-        return self.build_plan(
+        return self.materialize_trajectory(
             request,
             context,
             success=success_mask,
@@ -528,6 +521,65 @@ class PickUp(AtomicAction[GraspGoal, PickUpOptions]):
                 env_ids=context.env_ids,
                 step_dt=context.require_control_dt(),
             ),
+            grasp_xpos=grasp_xpos,
+            segment_lengths=segment_lengths,
+        )
+
+    def materialize_trajectory(
+        self,
+        request: ResolvedActionRequest[GraspGoal, PickUpOptions],
+        context: PlanningContext,
+        *,
+        success: torch.Tensor,
+        trajectory: TimedTrajectory,
+        grasp_xpos: torch.Tensor,
+        segment_lengths: dict[str, int],
+    ) -> ActionPlan:
+        """Bind a qualified PickUp trajectory to fresh task and scene state.
+
+        Planning and candidate integrations share this effect materialization.
+        The caller owns geometric qualification; symbolic effects remain pending
+        until the ordinary execution-session verification boundary accepts them.
+
+        Args:
+            request: Newly resolved PickUp invocation and endpoint bindings.
+            context: Current measured scene and verified symbolic state.
+            success: Per-row qualified planning mask.
+            trajectory: Full-joint command trajectory with explicit timing.
+            grasp_xpos: Qualified TCP grasp poses in the current scene frame.
+            segment_lengths: Ordered semantic command ranges, including approach.
+
+        Returns:
+            A new plan with authorized commands, tracking and pending effects.
+        """
+        if request.skill_id != self.skill_id or type(request.goal) is not GraspGoal:
+            raise ValueError("PickUp materialization requires a resolved GraspGoal")
+        if "approach" not in segment_lengths:
+            raise ValueError("PickUp materialization requires an approach segment")
+        task_state_key = require_shared_task_state_key(
+            request.binding.endpoint("primary", "motion"),
+            request.binding.endpoint("primary", "grasp"),
+            participant="PickUp primary participant",
+        )
+        sem = request.goal.semantics
+        object_pose = _resolve_object_pose(sem, context, name="pickup_object_pose")
+        grasp_xpos = resolve_pose_target(
+            grasp_xpos, num_envs=context.batch_size, device=self.device
+        )
+        object_to_eef = torch.bmm(pose_inv(object_pose), grasp_xpos)
+        held = HeldObjectState(
+            semantics=sem, object_to_eef=object_to_eef, grasp_xpos=grasp_xpos
+        )
+        coordinated_updates = {
+            key: None
+            for key in context.coordinated_held_objects
+            if task_state_key in key
+        }
+        return self.build_plan(
+            request,
+            context,
+            success=success,
+            trajectory=trajectory,
             expected_effects=StateDelta(
                 held_object_updates={task_state_key: held},
                 coordinated_held_object_updates=coordinated_updates,
@@ -539,7 +591,13 @@ class PickUp(AtomicAction[GraspGoal, PickUpOptions]):
             scene_dependency_monitor_until=(
                 {}
                 if sem.entity_id is None
-                else {sem.entity_id: segment_lengths["approach"]}
+                else {
+                    sem.entity_id: sum(
+                        length
+                        for index, length in enumerate(segment_lengths.values())
+                        if index <= tuple(segment_lengths).index("approach")
+                    )
+                }
             ),
         )
 

--- a/embodichain/lab/trajectory_generation/execution.py
+++ b/embodichain/lab/trajectory_generation/execution.py
@@ -36,6 +36,7 @@ from embodichain.lab.sim.motion.trajectory_augmentation import (
 )
 from .initial_state import FixedSceneHost, PreparedBatch
 from .integrations.contact import PickUpMotionValidator
+from .integrations.atomic_runtime import PickUpRuntimeSource
 
 __all__ = ["QposRolloutExecutor"]
 
@@ -135,6 +136,9 @@ class QposRolloutExecutor:
             robot. Adds physical-substep contact gates and measured object/TCP
             observations; permits its target and observed mimic joints to move.
             Supported only with pure simulation and the matching Runner planner.
+        runtime_source: Optional fresh PickUp plan source. Commands are dispatched
+            by ExecutionRunner; tracking, recovery or effect failures reject the
+            active batch. Requires the same pure-sim contact validator.
     """
 
     def __init__(
@@ -157,6 +161,7 @@ class QposRolloutExecutor:
         validation_profile_id: str = "verified_motion",
         max_episode_bytes: int = 256 * 1024 * 1024,
         contact_validator: PickUpMotionValidator | None = None,
+        runtime_source: PickUpRuntimeSource | None = None,
     ) -> None:
         if (
             isinstance(control_dt, bool)
@@ -179,7 +184,11 @@ class QposRolloutExecutor:
         ):
             if not isinstance(value, str) or not value or len(value.encode()) > 1024:
                 raise ValueError(f"{name} must be nonempty text of at most 1024 bytes.")
-        if validator_id in {"execution_complete", "fixed_collision_world"}:
+        if validator_id in {
+            "execution_complete",
+            "fixed_collision_world",
+            "atomic_runtime",
+        }:
             raise ValueError("validator_id cannot replace an execution check.")
         ratio = control_dt / host.profile.physics_dt
         if round(ratio) < 1 or not math.isclose(
@@ -210,6 +219,17 @@ class QposRolloutExecutor:
                 "Contact validation requires the same pure-sim host robot."
             )
         self.contact_validator = contact_validator
+        if runtime_source is not None and (
+            not isinstance(runtime_source, PickUpRuntimeSource)
+            or contact_validator is None
+            or host.env is not None
+            or runtime_source.engine.robot is not host.adapter.robot
+        ):
+            raise ValueError(
+                "Runtime source requires its own robot and pure-sim contact validation"
+            )
+        self.runtime_source = runtime_source
+        self._runtime = None
         self._substeps = round(ratio)
         self._running = False
         self._last_failures: Mapping[str, str] = MappingProxyType({})
@@ -484,6 +504,7 @@ class QposRolloutExecutor:
         if self._running:
             raise RuntimeError("QposRolloutExecutor requires serialized execution.")
         self._last_failures = MappingProxyType({})
+        self._runtime = None
         if not callable(on_started) or (
             should_stop is not None and not callable(should_stop)
         ):
@@ -658,6 +679,14 @@ class QposRolloutExecutor:
                 yield expected_command.clone()
 
         try:
+            if self.runtime_source is not None:
+                self._runtime = self.runtime_source.start(
+                    self.host,
+                    binding,
+                    candidates,
+                    contact_validator=self.contact_validator,
+                    control_dt=self.control_dt,
+                )
             if env is not None:
                 from embodichain.lab.gym.envs.demo import (
                     DemoSegment,
@@ -700,7 +729,12 @@ class QposRolloutExecutor:
                 for command in actions():
                     if stop():
                         break
-                    robot.set_qpos(command[:, joints], joint_ids=joints, target=True)
+                    if self._runtime is None:
+                        robot.set_qpos(
+                            command[:, joints], joint_ids=joints, target=True
+                        )
+                    else:
+                        self._runtime.dispatch(command, current_mask)
                     command_submitted()
                     if self.contact_validator is None:
                         sim.update(self.host.profile.physics_dt, self._substeps)
@@ -716,12 +750,16 @@ class QposRolloutExecutor:
                                 physics_dt=self.host.profile.physics_dt,
                             )
                     transition()
+                if self._runtime is not None:
+                    self._runtime.finish()
         except Exception as error:
             for row in rows:
                 if row is not None:
                     row.failure = _failure_text(error)
         finally:
             try:
+                if self._runtime is not None:
+                    self._runtime.stop()
                 self._hold(joints)
             except Exception as error:
                 self._last_failures = MappingProxyType(
@@ -808,6 +846,16 @@ class QposRolloutExecutor:
                 checks.extend(
                     self.contact_validator.rollout_validation(row_index).checks
                 )
+            if self.runtime_source is not None:
+                checks.extend(
+                    self._runtime.validation(row_index).checks
+                    if self._runtime is not None
+                    else (
+                        ValidationCheck(
+                            "atomic_runtime", "failed", "Runtime did not start"
+                        ),
+                    )
+                )
             try:
                 validation = self.validator(
                     row.candidate,
@@ -824,7 +872,8 @@ class QposRolloutExecutor:
                         f"Task validator omitted required check {self.validator_id!r}."
                     )
                 if any(
-                    check.check_id in {"execution_complete", "fixed_collision_world"}
+                    check.check_id
+                    in {"execution_complete", "fixed_collision_world", "atomic_runtime"}
                     for check in validation.checks
                 ):
                     raise ValueError("Task validator cannot replace execution checks.")
@@ -853,6 +902,8 @@ class QposRolloutExecutor:
                 metadata["collision_geometry"] = (
                     "URDF collision convex hulls; cuboid world; implicit ground"
                 )
+            if self._runtime is not None:
+                metadata["atomic_runtime"] = self._runtime.metadata(row_index)
             if (
                 _metadata_bytes(
                     (

--- a/embodichain/lab/trajectory_generation/integrations/atomic_runtime.py
+++ b/embodichain/lab/trajectory_generation/integrations/atomic_runtime.py
@@ -1,0 +1,598 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+"""Fresh PickUp action plans for physically qualified trajectory candidates."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from collections import Counter
+from dataclasses import replace
+import math
+from typing import TYPE_CHECKING
+
+import torch
+
+from embodichain.lab.sim.atomic_actions import (
+    ActionInvocation,
+    ActionPlan,
+    AtomicActionEngine,
+    GraspGoal,
+    JointPositionTarget,
+    PickUp,
+    TimedTrajectory,
+    ExecutionRunner,
+    ExecutionRunnerCfg,
+    RunnerStatus,
+    EffectVerificationResult,
+    CommandAcknowledgement,
+    CommandAckStatus,
+    SimulationExecutionAdapter,
+)
+from embodichain.lab.sim.atomic_actions.goals import resolve_pose_goal
+from embodichain.lab.sim.atomic_actions.invocation import ResolvedActionRequest
+from embodichain.lab.sim.atomic_actions.state import PlanningContext
+from embodichain.lab.sim.atomic_actions.tracking import FeedbackTerminalAcceptance
+from embodichain.lab.sim.motion.trajectory_augmentation import (
+    CandidateTrajectoryBatch,
+    TrajectoryTemplate,
+    ValidationResult,
+    ValidationCheck,
+)
+
+if TYPE_CHECKING:
+    from embodichain.lab.trajectory_generation.initial_state import (
+        PreparedBatch,
+        FixedSceneHost,
+    )
+    from .contact import PickUpMotionValidator
+
+__all__ = ["PickUpRuntimeSource"]
+
+
+class PickUpRuntimeSource:
+    """Materialize protected PickUp candidates through the registered skill.
+
+    One new invocation and session are required per prepared batch. References
+    contain transit/approach/close/lift/hold phases. Only the declared arm transit
+    may change; contact targets and timing remain identical to the references.
+    The reference's initial observation is omitted from the runtime command
+    sequence, preserving the recorder's T commands / T+1 observations convention.
+
+    Args:
+        engine: Atomic engine sharing the collection host's robot.
+        invocation_factory: Constructs a fresh PickUp invocation for a batch.
+        templates: Owned, qualified references in physical environment order.
+    """
+
+    def __init__(
+        self,
+        engine: AtomicActionEngine,
+        *,
+        invocation_factory: Callable[[PreparedBatch], ActionInvocation],
+        templates: Sequence[TrajectoryTemplate],
+    ) -> None:
+        if not isinstance(engine, AtomicActionEngine) or not callable(
+            invocation_factory
+        ):
+            raise TypeError("Provide an atomic engine and invocation factory")
+        if not isinstance(engine.actions.get("pick_up"), PickUp):
+            raise ValueError("The engine must register the PickUp implementation")
+        self.engine = engine
+        self.invocation_factory = invocation_factory
+        self.templates = tuple(replace(value) for value in templates)
+        if len(self.templates) != engine.robot.num_instances:
+            raise ValueError("References must cover the complete physical batch")
+        for template in self.templates:
+            if (
+                template.joint_names != tuple(engine.robot.joint_names)
+                or tuple(p.phase_id for p in template.phases)
+                != ("transit", "approach", "close", "lift", "hold")
+                or len(template.positions) < 3
+                or template.phases[0].start_index != 0
+                or any(p.allowed_operators for p in template.phases[1:])
+            ):
+                raise ValueError(
+                    "Provide full-joint references with protected PickUp phases"
+                )
+        if any(t.phases != self.templates[0].phases for t in self.templates[1:]):
+            raise ValueError("Runtime PickUp rows must share phase boundaries")
+
+    def materialize(
+        self,
+        request: ResolvedActionRequest,
+        context: PlanningContext,
+        candidates: Sequence[CandidateTrajectoryBatch | None],
+    ) -> ActionPlan:
+        """Build commands and pending effects against the supplied measured state.
+
+        Args:
+            request: Fresh engine-resolved PickUp request with arm tracking.
+            context: Current physical state, scene revisions and control clock.
+            candidates: One candidate per physical row, or None for idle rows.
+
+        Returns:
+            A new PickUp plan retaining the selected joint branch and phases.
+
+        Raises:
+            ValueError: If candidates differ from qualified contact references,
+                initial state, source identity, timing or endpoint layout.
+        """
+        robot = self.engine.robot
+        if request.skill_id != "pick_up" or type(request.goal) is not GraspGoal:
+            raise ValueError("Runtime source requires a PickUp GraspGoal")
+        if request.goal.grasp_xpos is None or request.goal.semantics.entity_id is None:
+            raise ValueError(
+                "Runtime PickUp requires an explicit grasp and scene entity"
+            )
+        if len(candidates) != len(self.templates) or context.batch_size != len(
+            candidates
+        ):
+            raise ValueError("Candidates must cover every physical row")
+        if not torch.equal(context.env_ids.cpu(), torch.arange(len(candidates))):
+            raise ValueError("Runtime context must preserve physical row order")
+        motion = request.binding.endpoint("primary", "motion")
+        grasp = request.binding.endpoint("primary", "grasp")
+        arm = motion.require_target(JointPositionTarget)
+        hand = grasp.require_target(JointPositionTarget)
+        if request.tracking_policy.in_flight is None or not isinstance(
+            request.tracking_policy.terminal, FeedbackTerminalAcceptance
+        ):
+            raise ValueError(
+                "Runtime collection requires in-flight and terminal feedback"
+            )
+        if not motion.tracking_channels or grasp.tracking_channels:
+            raise ValueError(
+                "Track arm feedback; qualify the grasp endpoint by physical contact"
+            )
+        if set(arm.joint_ids) & set(hand.joint_ids):
+            raise ValueError("Arm and hand endpoints must be disjoint")
+        period = context.require_control_dt()
+        reference = self.templates[0]
+        length = len(reference.positions)
+        positions = context.robot.qpos[:, None].repeat(1, length, 1)
+        active = torch.zeros(
+            context.batch_size, dtype=torch.bool, device=positions.device
+        )
+        for row, (candidate, template) in enumerate(zip(candidates, self.templates)):
+            if candidate is None:
+                continue
+            if (
+                len(candidate.identities) != 1
+                or candidate.source_row_indices is None
+                or candidate.source_row_indices.tolist() != [row]
+            ):
+                raise ValueError("Candidate does not belong to this physical row")
+            identity = candidate.identities[0]
+            if (identity.source_id, identity.source_revision, identity.template_id) != (
+                template.source_id,
+                template.source_revision,
+                template.template_id,
+            ):
+                raise ValueError(
+                    "Candidate source differs from its qualified reference"
+                )
+            if (
+                candidate.joint_names != template.joint_names
+                or candidate.phases[0] != template.phases
+                or int(candidate.valid_length[0]) != length
+            ):
+                raise ValueError("Candidate joint order or phase boundaries changed")
+            qpos = candidate.positions[0, :length].to(positions)
+            if not torch.allclose(qpos[0], context.robot.qpos[row], atol=1e-6, rtol=0):
+                raise ValueError(
+                    "Candidate initial joints differ from current observation"
+                )
+            if not torch.allclose(
+                candidate.dt[0, 1:length].double(),
+                torch.full_like(candidate.dt[0, 1:length].double(), period),
+                atol=1e-8,
+                rtol=0,
+            ):
+                raise ValueError(
+                    "Candidate timing differs from the runtime control clock"
+                )
+            protected = template.phases[1].start_index
+            other = [
+                i
+                for i in range(robot.dof)
+                if i not in arm.joint_ids and i not in robot.mimic_ids
+            ]
+            baseline = template.positions.to(qpos)
+            if (
+                not torch.equal(qpos[protected:], baseline[protected:])
+                or not torch.equal(qpos[:, other], baseline[:, other])
+                or tuple(template.controlled_joint_indices) != arm.joint_ids
+            ):
+                raise ValueError(
+                    "Candidate modified protected contact or non-arm coordinates"
+                )
+            positions[row] = qpos
+            active[row] = True
+        if not active.any():
+            raise ValueError("At least one candidate must be active")
+        grasp_poses = resolve_pose_goal(
+            request.goal.grasp_xpos, context, name="grasp_xpos"
+        ).to(positions)
+        if grasp_poses.shape == (4, 4):
+            grasp_poses = grasp_poses.repeat(context.batch_size, 1, 1)
+        close = reference.phases[2].start_index
+        actual_grasp = robot.compute_fk(
+            qpos=positions[:, close - 1, list(arm.joint_ids)],
+            name=arm.control_part,
+            to_matrix=True,
+        )
+        if not torch.allclose(
+            actual_grasp[active], grasp_poses[active], atol=1e-4, rtol=0
+        ):
+            raise ValueError(
+                "Qualified contact geometry differs from the current grasp goal"
+            )
+        segment_lengths = {
+            p.phase_id: p.stop_index - p.start_index - (1 if i == 0 else 0)
+            for i, p in enumerate(reference.phases)
+        }
+        command_positions = positions[:, 1:]
+        # Keep the host's double-precision control clock. Float32 intervals can
+        # make the runtime wait past an otherwise exact physical command tick.
+        intervals = torch.full(
+            command_positions.shape[:2],
+            period,
+            dtype=torch.float64,
+            device=positions.device,
+        )
+        intervals[:, 0] = 0
+        return self.engine.actions["pick_up"].materialize_trajectory(
+            request,
+            context,
+            success=active,
+            trajectory=TimedTrajectory(
+                positions=command_positions,
+                velocities=torch.zeros_like(command_positions),
+                accelerations=None,
+                dt=intervals,
+                env_ids=context.env_ids,
+            ),
+            grasp_xpos=grasp_poses,
+            segment_lengths=segment_lengths,
+        )
+
+    def start(
+        self,
+        host: FixedSceneHost,
+        binding: PreparedBatch,
+        candidates: Sequence[CandidateTrajectoryBatch | None],
+        *,
+        contact_validator: PickUpMotionValidator,
+        control_dt: float,
+    ) -> _PickUpRuntimeRollout:
+        """Start a fresh observed session after the host restores its batch.
+
+        Args:
+            host: Exclusive pure-simulation collection owner.
+            binding: Current prepared batch epoch.
+            candidates: Candidates in physical row order; None denotes idle rows.
+            contact_validator: The collector's native contact and grasp validator.
+            control_dt: Fixed period shared by runtime commands and observations.
+
+        Returns:
+            A serialized runtime driver borrowed by QposRolloutExecutor.
+        """
+        host.assert_current(binding)
+        if (
+            host.env is not None
+            or host.adapter.robot is not self.engine.robot
+            or contact_validator.robot is not self.engine.robot
+            or contact_validator.sim is not host.adapter.sim
+        ):
+            raise ValueError(
+                "Runtime PickUp requires the same pure-sim host and validator"
+            )
+        return _PickUpRuntimeRollout(
+            self, host, binding, candidates, contact_validator, control_dt
+        )
+
+
+class _PickUpRuntimeRollout:
+    """Strict candidate transport around the ordinary observed atomic runner.
+
+    Physics and T/T+1 recording stay with the collection executor. A replan may
+    use the registered skill but its commands never cross this transport: the
+    entire active batch is cancelled and retained only as failed audit evidence.
+    """
+
+    def __init__(self, source, host, binding, candidates, contact, control_dt):
+        self.source, self.host, self.binding, self.contact = (
+            source,
+            host,
+            binding,
+            contact,
+        )
+        self.control_dt = control_dt
+        self.started_at = float(host.adapter.sim.simulation_time)
+        self.count = 0
+        self.failure = None
+        self._expected = None
+        self._sent = False
+        self._events = [Counter() for _ in candidates]
+        self._effect_translation_error = [None for _ in candidates]
+        self._effect_rotation_error = [None for _ in candidates]
+        self._effect_passed = torch.zeros(
+            len(candidates), dtype=torch.bool, device=source.engine.device
+        )
+        self._active = torch.tensor(
+            [c is not None for c in candidates],
+            dtype=torch.bool,
+            device=source.engine.device,
+        )
+        self._transport = SimulationExecutionAdapter(
+            host.adapter.sim, source.engine.robot, control_dt=control_dt
+        )
+        invocation = source.invocation_factory(binding)
+        if (
+            not isinstance(invocation, ActionInvocation)
+            or invocation.skill_id != "pick_up"
+            or invocation.goal.semantics.entity_id != contact.profile.object_id
+        ):
+            raise ValueError(
+                "Runtime invocation must target the physically validated PickUp object"
+            )
+        context = source.engine.initial_context(
+            timestamp=self.now(), control_dt=control_dt
+        )
+        self._arm = invocation.binding.endpoint("primary", "motion").require_target(
+            JointPositionTarget
+        )
+        session = source.engine.start(
+            (invocation,),
+            context,
+            eligible_mask=self._active,
+            initial_plan_provider=lambda request, current: source.materialize(
+                request, current, candidates
+            ),
+        )
+        self._frame_count = session.active_plan.commands.frame_count
+        self.runner = ExecutionRunner(
+            session,
+            self,
+            self,
+            clock=self,
+            cfg=ExecutionRunnerCfg(
+                minimum_cycle_time=0.0,
+                hold_on_completion=False,
+                hold_during_effect_verification=False,
+            ),
+        )
+
+    def now(self):
+        return float(self.host.adapter.sim.simulation_time)
+
+    def sleep(self, duration):
+        raise RuntimeError("Collection executor owns the only physics clock")
+
+    def observe(self, task_state):
+        self.host.assert_current(self.binding)
+        return self.source.engine.initial_context(
+            task=task_state, timestamp=self.now(), control_dt=self.control_dt
+        )
+
+    def send(self, command, *, timeout):
+        session = self.runner.session
+        if session.attempt_generation != 0:
+            return CommandAcknowledgement(
+                CommandAckStatus.REJECTED,
+                "Recovery commands cannot become expert candidate data",
+            )
+        if (
+            self._expected is None
+            or self._sent
+            or not torch.equal(command.active_mask, self._active)
+        ):
+            return CommandAcknowledgement(
+                CommandAckStatus.REJECTED,
+                "Runtime command cohort differs from the candidate",
+            )
+        if not torch.allclose(
+            command.hold_duration[self._active],
+            torch.full_like(command.hold_duration[self._active], self.control_dt),
+            atol=1e-8,
+            rtol=0,
+        ):
+            return CommandAcknowledgement(
+                CommandAckStatus.REJECTED,
+                "Runtime command timing differs from the candidate",
+            )
+        for endpoint in command.commands:
+            ids = list(endpoint.target.joint_ids)
+            if not torch.allclose(
+                endpoint.payload.positions[self._active],
+                self._expected[self._active][:, ids].to(endpoint.payload.positions),
+                atol=1e-6,
+                rtol=0,
+            ):
+                return CommandAcknowledgement(
+                    CommandAckStatus.REJECTED,
+                    "Runtime attempted a different candidate command",
+                )
+        result = self._transport.send(command, timeout=timeout)
+        self._sent = result.accepted
+        return result
+
+    def hold(self, targets, context, *, timeout):
+        return self._transport.hold(targets, context=context, timeout=timeout)
+
+    def cancel(self, targets, *, timeout):
+        return self._transport.cancel(targets, timeout=timeout)
+
+    def _remember(self, result):
+        if result.tick is not None:
+            for event in result.tick.events:
+                for row, active in enumerate(event.env_mask.tolist()):
+                    if active:
+                        self._events[row][event.kind.value] += 1
+
+    def _abort(self, message):
+        self.failure = str(message)[:512]
+        self._remember(self.runner.cancel(self.failure))
+        raise RuntimeError(self.failure)
+
+    def dispatch(self, expected, active):
+        self.host.assert_current(self.binding)
+        if not math.isclose(
+            self.now(),
+            self.started_at + self.count * self.control_dt,
+            rel_tol=0,
+            abs_tol=1e-8,
+        ):
+            self._abort("Runtime collection clock differs from the candidate")
+        if (
+            tuple(self._active.tolist()) != tuple(active)
+            or self.count >= self._frame_count
+        ):
+            self._abort("Runtime requires a synchronized fixed candidate cohort")
+        self._expected, self._sent = expected.clone(), False
+        result = self.runner.step()
+        self._remember(result)
+        if not self._sent or result.status is not RunnerStatus.RUNNING:
+            self._abort(
+                "Runtime candidate execution failed: "
+                + str(result.message or self._events)
+            )
+        self.count += 1
+
+    def _verify_effect(self, context, request):
+        accepted = torch.zeros_like(request.env_mask)
+        observations = self.contact.observations()
+        key = self.runner.session.active_plan.expected_effects.held_object_updates
+        if (
+            set(request.expected_effects.held_object_updates) != set(key)
+            or len(key) != 1
+        ):
+            raise ValueError(
+                "Runtime PickUp must verify exactly its declared held-object effect"
+            )
+        held = next(iter(request.expected_effects.held_object_updates.values()))
+        expected = observations["object_pose"] @ held.object_to_eef.to(
+            observations["object_pose"]
+        )
+        # HeldObjectState uses the motion endpoint's solver TCP frame. The
+        # contact profile can deliberately declare a different native TCP.
+        # Derive pose evidence from this tick's measured joints, in the same
+        # frame used to qualify the candidate; native contacts remain mandatory.
+        measured = self.source.engine.robot.compute_fk(
+            qpos=context.robot.qpos[:, list(self._arm.joint_ids)],
+            name=self._arm.control_part,
+            to_matrix=True,
+        ).to(expected)
+        translation = (expected[:, :3, 3] - measured[:, :3, 3]).norm(dim=1)
+        rotation = expected[:, :3, :3].transpose(1, 2) @ measured[:, :3, :3]
+        angle = torch.acos(
+            ((rotation.diagonal(dim1=1, dim2=2).sum(-1) - 1) / 2).clamp(-1, 1)
+        )
+        p = self.contact.profile
+        for row, active in enumerate(request.env_mask.tolist()):
+            if active:
+                self._effect_translation_error[row] = float(translation[row])
+                self._effect_rotation_error[row] = float(angle[row])
+            accepted[row] = (
+                active
+                and self.contact.rollout_validation(row).accepted
+                and bool(
+                    translation[row] <= p.max_relative_translation
+                    and angle[row] <= p.max_relative_rotation
+                )
+            )
+        self._effect_passed |= accepted
+        return EffectVerificationResult(
+            request.verification_id,
+            accepted,
+            request.env_mask & ~accepted,
+            torch.zeros_like(accepted),
+            torch.zeros_like(accepted),
+        )
+
+    def finish(self):
+        if self.count != self._frame_count:
+            self._abort("Runtime candidate did not dispatch every command")
+        if not math.isclose(
+            self.now(),
+            self.started_at + self.count * self.control_dt,
+            rel_tol=0,
+            abs_tol=1e-8,
+        ):
+            self._abort("Runtime terminal clock differs from the candidate")
+        self._expected = None
+        # Two observation-only updates: establish the terminal boundary, then
+        # consume freshly measured evidence. They never advance physical time.
+        for _ in range(2):
+            result = self.runner.step(effect_verifier=self._verify_effect)
+            self._remember(result)
+            if result.status is not RunnerStatus.RUNNING:
+                break
+            if self.runner.session.pending_effect is None:
+                self._abort("Runtime terminal feedback or phase gate did not complete")
+        if self.runner.status is not RunnerStatus.COMPLETED or not bool(
+            self._effect_passed[self._active].all()
+        ):
+            self._abort("Runtime physical effect verification failed")
+
+    def stop(self):
+        if self.runner.status is RunnerStatus.RUNNING:
+            self.failure = self.failure or "Runtime collection interrupted"
+            self._remember(self.runner.cancel(self.failure))
+
+    def validation(self, row):
+        passed = (
+            self.failure is None
+            and self.runner.status is RunnerStatus.COMPLETED
+            and self.runner.session.attempt_generation == 0
+            and bool(self._effect_passed[row])
+        )
+        return ValidationResult(
+            (
+                ValidationCheck(
+                    "atomic_runtime",
+                    "passed" if passed else "failed",
+                    self.failure
+                    or "Observed runtime tracking and physical effect verification",
+                    {
+                        "command_count": self.count,
+                        "plan_attempts": self.runner.session.attempt_generation + 1,
+                    },
+                ),
+            )
+        )
+
+    def metadata(self, row):
+        return {
+            "command_count": self.count,
+            "plan_attempts": self.runner.session.attempt_generation + 1,
+            "events": dict(self._events[row]),
+            "status": self.runner.status.value,
+            "effect_verified": bool(self._effect_passed[row]),
+            "effect_translation_error_m": self._effect_translation_error[row],
+            "effect_rotation_error_rad": self._effect_rotation_error[row],
+            "effect_tcp_frame": {
+                "source": "robot.compute_fk",
+                "control_part": self._arm.control_part,
+            },
+            "contact_tcp_frame": {
+                "source": "robot.get_link_pose",
+                "link": self.contact.profile.tcp_link,
+                "offset": self.contact.profile.tcp_offset,
+            },
+            "failure": self.failure,
+        }

--- a/embodichain/lab/trajectory_generation/integrations/contact.py
+++ b/embodichain/lab/trajectory_generation/integrations/contact.py
@@ -447,7 +447,21 @@ class PickUpMotionValidator:
 
         Returns:
             The measured path's joint-limit and collision validation result.
+            An interrupted or malformed phase sequence returns unavailable
+            evidence so the runner can audit rejection and continue collection.
         """
+        try:
+            self._phases(episode.phases, len(episode.observations["joint_positions"]))
+        except ValueError as error:
+            return ValidationResult(
+                (
+                    ValidationCheck(
+                        "path_collision",
+                        "unavailable",
+                        f"Incomplete or invalid PickUp phases: {error}",
+                    ),
+                )
+            )
         return self._validate_path(
             episode.observations["joint_positions"],
             episode.phases,

--- a/examples/sim/motion/trajectory_generation/README.md
+++ b/examples/sim/motion/trajectory_generation/README.md
@@ -56,7 +56,22 @@ python examples/sim/motion/trajectory_generation/cube_pickup_collection.py \
 
 输出 `preview.mp4`（开启视频时）、`generation_report.json`、`pickup_report.json`、`manifest.json` 和逐 episode 的 LeRobot 分片。每条数据含 T 个真实控制目标及 T+1 个实测观测/时间戳。cube/TCP 位姿在 LeRobot 中按行优先展开为 16 维，`episode.json` 的 `observation_shapes` 保留 `[4, 4]`；终态 `terminal.npz` 保持矩阵形状。`commanded_joint_indices` 标识完整关节向量中真正下发的关节列。
 
-范围：单个固定基座 URDF 机器人、盒状刚体、CPU 物理。碰撞验证是有界采样，未提供连续碰撞保证。`source.kind=atomic` 表示来源是 `AtomicActionEngine.compile` 的离线计划；执行采用单独验收的 qpos 回放，不提交编译时预测的符号效果。Atomic Runtime 的 tracking/recovery 接入、Gym 接触采集与通用 YAML 启动器仍是后续工作。
+范围：单个固定基座 URDF 机器人、盒状刚体、CPU 物理。碰撞验证是有界采样，未提供连续碰撞保证。默认执行离线编译模板的 qpos 回放，不提交编译时预测的符号效果。加上 `--runtime` 可切换到下方的原子运行时执行；Gym 接触采集与通用 YAML 启动器仍是后续工作。
+
+## 通过 Atomic Runtime 采集
+
+```bash
+python examples/sim/motion/trajectory_generation/cube_pickup_collection.py \
+  --output /tmp/cube-runtime-experts --episodes 8 --runtime --record-video
+```
+
+场景、增强因子和物理验收与上面的采集示例相同。`PickUpRuntimeSource` 在每次全批恢复后创建新的 invocation 和 `ExecutionSession`，通过 `initial_plan_provider` 将选中的五阶段候选物化为一个 PickUp 计划。执行直接使用候选关节分支；运行时抓取目标取模板闭合前的 URDF FK 姿态，避免将分析 IK 目标与资产几何之间的腕部偏移带入持物效果。
+
+`ExecutionRunner` 通过 `SimulationExecutionAdapter` 下发命令并检查机械臂反馈，阈值为运行中 0.08 rad、末端 0.05 rad。手指依靠真实双侧接触及持物稳定性验收。全部命令执行后，使用当前观测关节的 FK 和实测物体位姿，在计划使用的 motion endpoint TCP 坐标系中验证持物效果；原生接触 TCP 仍单独检查，成功后才提交新的 held-object 状态。
+
+运行时与采集器共用 20 Hz 控制时钟；每条数据仍是 271 个实际命令和 272 个观测。计划重试/重规划、命令或时钟不匹配、额外等待及效果验证失败都会停止整批活跃行、保持当前关节状态并拒收数据。恢复命令不进入专家轨迹。尾批可保留空闲行，单行运行时失败会保守拒收同批其他活跃行。
+
+每条 episode 的 `atomic_runtime` 元数据记录命令数、计划尝试数、事件计数、完成状态、效果误差及计划/接触 TCP 定义；同名强制验收项必须通过。`pickup_report.json` 标识本次执行来源。视频与 LeRobot 文件的保存格式保持一致，完整的手写/原子 × sim/Gym 四组合验收仍待后续完成。
 
 ## 自由运动采集
 

--- a/examples/sim/motion/trajectory_generation/cube_grasp_parallel.py
+++ b/examples/sim/motion/trajectory_generation/cube_grasp_parallel.py
@@ -247,8 +247,8 @@ def _prepare_cube_scene(
     return robot, cube, camera, initial_qpos, grasps, hand_open, hand_close
 
 
-def _compile_cube_pickup(robot, cube, grasps, hand_open, hand_close):
-    """Compile the same atomic transit and PickUp for preview and collection."""
+def _cube_pickup_program(robot, cube, grasps, hand_open, hand_close):
+    """Build reusable atomic transit and PickUp requests for the fixed scene."""
     generator = create_toppra_motion_generator(robot)
     engine = create_simulation_atomic_action_engine(
         motion_generator=generator,
@@ -261,31 +261,39 @@ def _compile_cube_pickup(robot, cube, grasps, hand_open, hand_close):
     )
     pregrasp = grasps.clone()
     pregrasp[:, 2, 3] += 0.16
-    compiled = engine.compile(
-        (
-            engine.make_invocation(
-                "move_end_effector",
-                EndEffectorPoseGoal(pregrasp),
-                control_parts={"primary": {"motion": "arm"}},
-                motion_policy=MotionPolicy(strategy="ik_interp", sample_count=81),
+    invocations = (
+        engine.make_invocation(
+            "move_end_effector",
+            EndEffectorPoseGoal(pregrasp),
+            control_parts={"primary": {"motion": "arm"}},
+            motion_policy=MotionPolicy(strategy="ik_interp", sample_count=81),
+        ),
+        engine.make_invocation(
+            "pick_up",
+            GraspGoal(
+                create_antipodal_semantics(cube, label="cube"),
+                grasp_xpos=grasps,
             ),
-            engine.make_invocation(
-                "pick_up",
-                GraspGoal(
-                    create_antipodal_semantics(cube, label="cube"),
-                    grasp_xpos=grasps,
-                ),
-                control_parts={"primary": {"motion": "arm", "grasp": "hand"}},
-                motion_policy=MotionPolicy(strategy="ik_interp", sample_count=141),
-                skill_options=PickUpOptions(
-                    pre_grasp_distance=0.16,
-                    lift_height=0.18,
-                    hand_interp_steps=30,
-                    grasp_settle_steps=20,
-                ),
+            control_parts={"primary": {"motion": "arm", "grasp": "hand"}},
+            motion_policy=MotionPolicy(strategy="ik_interp", sample_count=141),
+            skill_options=PickUpOptions(
+                pre_grasp_distance=0.16,
+                lift_height=0.18,
+                hand_interp_steps=30,
+                grasp_settle_steps=20,
             ),
         ),
-        engine.initial_context(control_dt=_CONTROL_DT),
+    )
+    return generator, engine, invocations
+
+
+def _compile_cube_pickup(robot, cube, grasps, hand_open, hand_close):
+    """Compile the same atomic transit and PickUp for preview and collection."""
+    generator, engine, invocations = _cube_pickup_program(
+        robot, cube, grasps, hand_open, hand_close
+    )
+    compiled = engine.compile(
+        invocations, engine.initial_context(control_dt=_CONTROL_DT)
     )
     return generator, compiled
 

--- a/examples/sim/motion/trajectory_generation/cube_pickup_collection.py
+++ b/examples/sim/motion/trajectory_generation/cube_pickup_collection.py
@@ -30,6 +30,7 @@ count towards the requested target. The video also shows rejected attempts.
 from __future__ import annotations
 
 import argparse
+from dataclasses import replace
 import json
 from pathlib import Path
 import sys
@@ -43,6 +44,11 @@ if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
 from embodichain.lab.sim import SimulationManager, SimulationManagerCfg
+from embodichain.lab.sim.atomic_actions import (
+    ActionBinding,
+    RecoveryPolicy,
+    TrackingPolicy,
+)
 from embodichain.lab.sim.motion.trajectory_augmentation import (
     SceneCase,
     TrajectoryGenerationJobCfg,
@@ -60,6 +66,9 @@ from embodichain.lab.trajectory_generation.integrations.sim import (
 from embodichain.lab.trajectory_generation.integrations.atomic import (
     export_pickup_templates,
 )
+from embodichain.lab.trajectory_generation.integrations.atomic_runtime import (
+    PickUpRuntimeSource,
+)
 from embodichain.lab.trajectory_generation.integrations.contact import (
     PickUpContactProfile,
     PickUpMotionValidator,
@@ -72,7 +81,7 @@ from embodichain.lab.trajectory_generation.sinks import LeRobotEpisodeSink
 from embodichain.utils.math import look_at_to_pose
 from examples.sim.motion.trajectory_generation.cube_grasp_parallel import (
     _prepare_cube_scene,
-    _compile_cube_pickup,
+    _cube_pickup_program,
     _preview_frame,
     _YAW,
     _EYE,
@@ -92,6 +101,7 @@ def run_cube_pickup_collection(
     seed: int = 13,
     cuda_device: int = 0,
     record_video: bool = False,
+    runtime: bool = False,
 ) -> dict[str, object]:
     """Run a bounded four-row PickUp collection with real contact acceptance.
 
@@ -101,6 +111,8 @@ def run_cube_pickup_collection(
         seed: Local augmentation random seed.
         cuda_device: GPU used by the simulator renderer.
         record_video: Stream synchronized four-panel observations to preview.mp4.
+        runtime: Execute candidates through observed Atomic ExecutionRunner
+            tracking and effect verification before accepting expert data.
 
     Returns:
         The persisted generation audit with committed count and target outcome.
@@ -147,8 +159,11 @@ def run_cube_pickup_collection(
         robot, cube, camera, initial, grasps, hand_open, hand_close = (
             _prepare_cube_scene(sim, arm_stiffness=2e5, hand_open_margin=0.001)
         )
-        generator, compiled = _compile_cube_pickup(
+        generator, engine, invocations = _cube_pickup_program(
             robot, cube, grasps, hand_open, hand_close
+        )
+        compiled = engine.compile(
+            invocations, engine.initial_context(control_dt=_CONTROL_DT)
         )
         templates = export_pickup_templates(compiled, robot, control_dt=_CONTROL_DT)
         initial_objects = {
@@ -224,6 +239,7 @@ def run_cube_pickup_collection(
             sim, robot, profile=PickUpContactProfile(approach_contact_distance=0.06)
         )
         frames = 0
+        preview_round, round_frame = 0, 0
         trails = [[] for _ in range(4)]
         view = torch.linalg.inv(look_at_to_pose(_EYE, _TARGET)).squeeze(0).numpy()
         if record_video:
@@ -235,11 +251,12 @@ def run_cube_pickup_collection(
                 font = ImageFont.load_default()
 
         def observe() -> dict[str, torch.Tensor]:
-            nonlocal frames, trails
+            nonlocal frames, trails, preview_round, round_frame
             if record_video:
-                index = frames % len(templates[0].positions)
-                if index == 0:
+                if preview_round != prepares:
+                    preview_round, round_frame = prepares, 0
                     trails = [[] for _ in range(4)]
+                index = round_frame
                 observations = planner.observations()
                 tcp = observations["tcp_pose"].cpu().numpy()
                 for row in range(4):
@@ -275,6 +292,7 @@ def run_cube_pickup_collection(
                 )
                 writer.append_data(frame)
                 frames += 1
+                round_frame += 1
             return {
                 "joint_positions": robot.get_qpos(),
                 "joint_velocities": robot.get_qvel(),
@@ -308,6 +326,51 @@ def run_cube_pickup_collection(
             )
 
         budget = 1024 * 1024
+        # Ground the runtime request in the selected reference's full-URDF TCP.
+        # The analytic IK target can differ from that geometry (the UR5 asset
+        # includes a wrist offset); pending effects must describe the qualified
+        # joint branch that will actually execute.
+        qualified_grasps = robot.compute_fk(
+            qpos=torch.stack(
+                [t.positions[t.phases[2].start_index - 1, arm_ids] for t in templates]
+            ),
+            name="arm",
+            to_matrix=True,
+        )
+
+        def runtime_invocation(binding):
+            reference = invocations[1]
+            invocation = engine.make_invocation(
+                "pick_up",
+                replace(reference.goal, grasp_xpos=qualified_grasps),
+                control_parts={"primary": {"motion": "arm", "grasp": "hand"}},
+                motion_policy=reference.motion_policy,
+                skill_options=reference.skill_options,
+                tracking_policy=TrackingPolicy.joint_position(
+                    in_flight_max_abs_error=0.08,
+                    terminal_max_abs_error=0.05,
+                ),
+                recovery_policy=RecoveryPolicy(max_replans=1, max_action_retries=0),
+                invocation_id=f"pickup_batch_{prepares}",
+            )
+            # The closing hand presses into the cube. Its physical contract is
+            # bilateral contact and held-object stability, while arm positions
+            # retain the ordinary runtime feedback thresholds.
+            return replace(
+                invocation,
+                binding=ActionBinding(
+                    invocation.binding.owner_id,
+                    tuple(
+                        (
+                            replace(endpoint, tracking_channels={})
+                            if endpoint.endpoint_id == "grasp"
+                            else endpoint
+                        )
+                        for endpoint in invocation.binding.endpoints
+                    ),
+                ),
+            )
+
         executor = QposRolloutExecutor(
             host,
             control_dt=_CONTROL_DT,
@@ -315,6 +378,15 @@ def run_cube_pickup_collection(
             validator=task_validator,
             max_episode_bytes=budget,
             contact_validator=planner,
+            runtime_source=(
+                PickUpRuntimeSource(
+                    engine,
+                    invocation_factory=runtime_invocation,
+                    templates=templates,
+                )
+                if runtime
+                else None
+            ),
         )
         sink = LeRobotEpisodeSink(output_dir, fps=20, max_episode_bytes=budget)
         if record_video:
@@ -354,7 +426,11 @@ def run_cube_pickup_collection(
                     "target_reached": report["target_reached"],
                     "prepared_batches": prepares,
                     "video_frames": frames,
-                    "source": "offline AtomicActionEngine MoveEndEffector + PickUp export",
+                    "source": (
+                        "Atomic ExecutionRunner with fresh PickUp candidate plans"
+                        if runtime
+                        else "offline AtomicActionEngine MoveEndEffector + PickUp export"
+                    ),
                     "contact_profile": planner.profile.to_dict(),
                 },
                 indent=2,
@@ -382,6 +458,11 @@ def main() -> None:
     parser.add_argument("--seed", type=int, default=13)
     parser.add_argument("--cuda-device", type=int, default=0)
     parser.add_argument("--record-video", action="store_true")
+    parser.add_argument(
+        "--runtime",
+        action="store_true",
+        help="Use observed atomic candidate execution and effect verification",
+    )
     args = parser.parse_args()
     report = None
     try:
@@ -391,6 +472,7 @@ def main() -> None:
             seed=args.seed,
             cuda_device=args.cuda_device,
             record_video=args.record_video,
+            runtime=args.runtime,
         )
     except Exception as error:
         diagnostic = traceback.TracebackException.from_exception(error)

--- a/tests/lab/trajectory_generation/test_atomic_runtime.py
+++ b/tests/lab/trajectory_generation/test_atomic_runtime.py
@@ -1,0 +1,459 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+"""Candidate materialization and observed atomic execution contracts."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from embodichain.lab.sim.atomic_actions import (
+    ActionBinding,
+    AtomicActionEngine,
+    ControlPartCommandProfile,
+    GraspGoal,
+    ObjectSemantics,
+    RecoveryPolicy,
+    EntityState,
+    SceneSnapshot,
+    TrackingPolicy,
+)
+from embodichain.lab.sim.motion.trajectory_augmentation import (
+    CandidateIdentity,
+    CandidateTrajectoryBatch,
+    TrajectoryPhase,
+    TrajectoryTemplate,
+)
+from embodichain.lab.sim.atomic_actions.affordance import Affordance
+
+CONTROL_DT = 0.05
+
+
+class _Robot:
+    device = torch.device("cpu")
+    dof = 3
+    num_instances = 2
+    joint_names = ("vertical", "yaw", "finger")
+    control_parts = {"arm": object(), "hand": object()}
+    mimic_ids = ()
+    mimic_parents = ()
+    mimic_multipliers = ()
+    mimic_offsets = ()
+
+    def __init__(self):
+        self.qpos = torch.zeros(2, 3)
+        self.targets = self.qpos.clone()
+        self.qvel = torch.zeros_like(self.qpos)
+        self.velocity_targets = torch.zeros_like(self.qpos)
+
+    def get_qpos(self, name=None, *, target=False):
+        value = self.targets if target else self.qpos
+        return value[:, self.get_joint_ids(name)].clone()
+
+    def get_qvel(self, name=None, *, target=False):
+        value = self.velocity_targets if target else self.qvel
+        return value[:, self.get_joint_ids(name)].clone()
+
+    def get_qf(self):
+        return torch.zeros_like(self.qpos)
+
+    def get_joint_ids(self, name=None):
+        return {None: (0, 1, 2), "arm": (0, 1), "hand": (2,)}[name]
+
+    def compute_fk(self, qpos=None, name=None, to_matrix=True):
+        value = self.qpos if qpos is None else qpos
+        pose = torch.eye(4).repeat(len(value), 1, 1)
+        pose[:, 2, 3] = value[:, 0]
+        return pose
+
+    def compute_ik(self, **kwargs):
+        raise AssertionError("Candidate execution must not recompute IK")
+
+    def set_qpos(self, value, *, joint_ids, env_ids=None, target=True):
+        assert target
+        self.targets[:, joint_ids] = value
+
+    def set_qvel(self, value, *, joint_ids, **kwargs):
+        self.velocity_targets[:, joint_ids] = value
+
+    def set_qf(self, value, **kwargs):
+        pass
+
+
+def _fixture(*, control_dt=CONTROL_DT):
+    from embodichain.lab.trajectory_generation.integrations.atomic_runtime import (
+        PickUpRuntimeSource,
+    )
+
+    robot = _Robot()
+    generator = Mock(robot=robot, device=robot.device)
+    generator.planner.cfg.planner_type = "fixture"
+    engine = AtomicActionEngine(
+        generator,
+        control_profiles={
+            "hand": ControlPartCommandProfile.joint_positions(
+                open=torch.zeros(2, 1), grasp=torch.full((2, 1), 0.03)
+            )
+        },
+    )
+    scene = SceneSnapshot(
+        timestamp=0.0,
+        version=1,
+        entities={"cube": EntityState(torch.eye(4).repeat(2, 1, 1))},
+    )
+    context = engine.initial_context(scene=scene, control_dt=control_dt)
+    phases = (
+        TrajectoryPhase("transit", 0, 3, allowed_operators=("joint_residual",)),
+        TrajectoryPhase("approach", 3, 5, kind="contact"),
+        TrajectoryPhase("close", 5, 7, kind="contact"),
+        TrajectoryPhase("lift", 7, 9, kind="contact"),
+        TrajectoryPhase("hold", 9, 12, kind="hold"),
+    )
+    qpos = torch.zeros(12, 3)
+    qpos[:, 0] = torch.tensor(
+        [0.0, 0.05, 0.1, 0.05, 0.0, 0.0, 0.0, 0.09, 0.18, 0.18, 0.18, 0.18]
+    )
+    qpos[5:, 2] = 0.03
+    dt = torch.full((12,), control_dt, dtype=torch.float64)
+    dt[0] = 0
+    templates = tuple(
+        TrajectoryTemplate(
+            source_id="atomic_pickup",
+            source_revision="v1",
+            template_id="reference_0",
+            joint_names=robot.joint_names,
+            positions=qpos,
+            dt=dt,
+            phases=phases,
+            validator_id="task_success",
+            controlled_joint_indices=(0, 1),
+        )
+        for _ in range(2)
+    )
+    candidates = tuple(
+        CandidateTrajectoryBatch(
+            identities=(
+                CandidateIdentity(
+                    f"case_{i}",
+                    "initial",
+                    f"candidate_{i}",
+                    f"geometry_{i}",
+                    "atomic_pickup",
+                    "v1",
+                    "reference_0",
+                ),
+            ),
+            positions=qpos[None],
+            dt=templates[i].dt[None],
+            valid_length=torch.tensor([12]),
+            phases=(phases,),
+            joint_names=robot.joint_names,
+            source_row_indices=torch.tensor([i]),
+        )
+        for i in range(2)
+    )
+
+    def invocation(_binding):
+        result = engine.make_invocation(
+            "pick_up",
+            GraspGoal(
+                ObjectSemantics(affordance=Affordance(), geometry={}, entity_id="cube"),
+                grasp_xpos=torch.eye(4).repeat(2, 1, 1),
+            ),
+            control_parts={"primary": {"motion": "arm", "grasp": "hand"}},
+            tracking_policy=TrackingPolicy.joint_position(
+                in_flight_max_abs_error=0.08, terminal_max_abs_error=0.05
+            ),
+            recovery_policy=RecoveryPolicy(max_replans=1, max_action_retries=0),
+            invocation_id="fixture-pickup",
+        )
+        # A closing gripper intentionally presses against the cube. Native
+        # contact verifies this endpoint; arm joints retain feedback tracking.
+        return replace(
+            result,
+            binding=ActionBinding(
+                result.binding.owner_id,
+                tuple(
+                    replace(e, tracking_channels={}) if e.endpoint_id == "grasp" else e
+                    for e in result.binding.endpoints
+                ),
+            ),
+        )
+
+    source = PickUpRuntimeSource(
+        engine, invocation_factory=invocation, templates=templates
+    )
+    return robot, engine, context, candidates, source, invocation
+
+
+def test_materialize_preserves_candidate_commands_and_rebuilds_symbolic_effect():
+    robot, engine, context, candidates, source, invocation = _fixture()
+    qpos = candidates[0].positions.clone()
+    qpos[0, 1, 1] = 0.025
+    candidates = (replace(candidates[0], positions=qpos), candidates[1])
+    plan = source.materialize(engine.resolve(invocation(None)), context, candidates)
+    assert plan.commands.frame_count == 11
+    assert plan.segment("transit").stop == 2
+    assert plan.segment("hold").stop == 11
+    torch.testing.assert_close(plan.joint_trajectory.positions[0], qpos[0, 1:])
+    assert not context.task.held_objects
+    held = plan.expected_effects.held_object_updates["arm"]
+    torch.testing.assert_close(held.object_to_eef, torch.eye(4).repeat(2, 1, 1))
+    assert plan.tracking is not None
+    assert {s.endpoint_key for s in plan.tracking.frames[0].setpoints} == {
+        ("primary", "motion")
+    }
+    assert plan.planned_scene_version == context.scene.version
+
+
+@pytest.mark.parametrize(
+    "change", ["protected", "clock", "row", "initial", "source", "phase"]
+)
+def test_materialize_rejects_unqualified_candidate_before_commands(change):
+    _, engine, context, candidates, source, invocation = _fixture()
+    candidate = candidates[0]
+    if change in {"protected", "initial"}:
+        q = candidate.positions.clone()
+        q[0, 5 if change == "protected" else 0, 0] += 0.01
+        candidate = replace(candidate, positions=q)
+    elif change == "clock":
+        dt = candidate.dt.clone()
+        dt[0, 1] += 0.01
+        candidate = replace(candidate, dt=dt)
+    elif change == "row":
+        candidate = replace(candidate, source_row_indices=torch.tensor([1]))
+    elif change == "source":
+        candidate = replace(
+            candidate,
+            identities=(replace(candidate.identities[0], source_revision="other"),),
+        )
+    elif change == "phase":
+        phases = list(candidate.phases[0])
+        phases[0] = replace(phases[0], allowed_operators=())
+        candidate = replace(candidate, phases=(tuple(phases),))
+    with pytest.raises(ValueError):
+        source.materialize(
+            engine.resolve(invocation(None)), context, (candidate, candidates[1])
+        )
+
+
+def test_materialize_tail_batch_keeps_idle_rows_ineligible():
+    robot, engine, context, candidates, source, invocation = _fixture()
+    plan = source.materialize(
+        engine.resolve(invocation(None)), context, (candidates[0], None)
+    )
+    assert plan.plan_success.tolist() == [True, False]
+    assert all(
+        frame.active_mask.tolist() == [True, False] for frame in plan.commands.frames
+    )
+    assert plan.joint_trajectory.positions[1].count_nonzero() == 0
+
+
+def _runtime_fixture(*, contact_passed=True, control_dt=CONTROL_DT, idle_row=False):
+    from embodichain.lab.trajectory_generation.integrations.contact import (
+        PickUpContactProfile,
+    )
+    from embodichain.lab.sim.motion.trajectory_augmentation import (
+        ValidationCheck,
+        ValidationResult,
+    )
+
+    robot, engine, context, candidates, source, invocation = _fixture(
+        control_dt=control_dt
+    )
+    if idle_row:
+        candidates = (candidates[0], None)
+    sim = SimpleNamespace(
+        simulation_time=0.0, sim_config=SimpleNamespace(physics_dt=0.005)
+    )
+    engine._scene_provider = SimpleNamespace(
+        snapshot=lambda **kwargs: replace(context.scene, timestamp=kwargs["timestamp"])
+    )
+    host = SimpleNamespace(
+        adapter=SimpleNamespace(robot=robot, sim=sim), env=None, assert_current=Mock()
+    )
+    contact = SimpleNamespace(
+        robot=robot,
+        sim=sim,
+        profile=PickUpContactProfile(),
+        observations=lambda: {
+            "tcp_pose": robot.compute_fk(),
+            "object_pose": robot.compute_fk(),
+        },
+        rollout_validation=lambda row: ValidationResult(
+            (
+                ValidationCheck(
+                    "physical_contacts", "passed" if contact_passed else "failed"
+                ),
+                ValidationCheck(
+                    "held_object_stability", "passed" if contact_passed else "failed"
+                ),
+            )
+        ),
+    )
+    runtime = source.start(
+        host, object(), candidates, contact_validator=contact, control_dt=control_dt
+    )
+    return robot, sim, engine, candidates, runtime
+
+
+def test_runtime_executes_candidate_and_commits_effect_only_after_verification():
+    robot, sim, engine, candidates, runtime = _runtime_fixture()
+    assert not runtime.runner.session.task_state.held_objects
+    assert runtime.runner.session.attempt_generation == 0
+    for index in range(1, 12):
+        expected = torch.cat([c.positions[:, index] for c in candidates])
+        runtime.dispatch(expected, (True, True))
+        torch.testing.assert_close(robot.targets, expected)
+        robot.qpos.copy_(robot.targets)
+        sim.simulation_time += CONTROL_DT
+        assert not runtime.runner.session.task_state.held_objects
+    runtime.finish()
+    assert runtime.validation(0).accepted
+    assert runtime.runner.session.task_state.held_objects["arm"].env_mask.tolist() == [
+        True,
+        True,
+    ]
+    assert runtime.metadata(0)["command_count"] == 11
+    assert runtime.metadata(0)["plan_attempts"] == 1
+
+
+def test_runtime_never_accepts_missing_physical_effect_evidence():
+    robot, sim, engine, candidates, runtime = _runtime_fixture(contact_passed=False)
+    for index in range(1, 12):
+        runtime.dispatch(
+            torch.cat([c.positions[:, index] for c in candidates]), (True, True)
+        )
+        robot.qpos.copy_(robot.targets)
+        sim.simulation_time += CONTROL_DT
+    with pytest.raises(RuntimeError, match="Runtime"):
+        runtime.finish()
+    assert not runtime.validation(0).accepted
+    assert not runtime.runner.session.task_state.held_objects
+
+
+def test_recovery_uses_registered_planner_but_never_dispatches_its_candidate(
+    monkeypatch,
+):
+    from embodichain.lab.sim.atomic_actions import TimedTrajectory
+
+    robot, sim, engine, candidates, runtime = _runtime_fixture()
+    calls = []
+
+    def fallback(request, context):
+        calls.append(context.robot.qpos.clone())
+        return engine.actions["pick_up"].build_plan(
+            request,
+            context,
+            success=True,
+            trajectory=TimedTrajectory.from_uniform_step(
+                context.robot.qpos[:, None].repeat(1, 2, 1),
+                env_ids=context.env_ids,
+                step_dt=CONTROL_DT,
+            ),
+        )
+
+    monkeypatch.setattr(engine.actions["pick_up"], "_plan", fallback)
+    expected = torch.cat([c.positions[:, 1] for c in candidates])
+    runtime.dispatch(expected, (True, True))
+    robot.qpos[:, 0] = 0.5
+    sim.simulation_time += CONTROL_DT
+    with pytest.raises(RuntimeError, match="Runtime"):
+        runtime.dispatch(
+            torch.cat([c.positions[:, 2] for c in candidates]), (True, True)
+        )
+    assert len(calls) == 1
+    assert runtime.runner.session.attempt_generation == 1
+    assert not runtime.validation(0).accepted
+    assert runtime.metadata(0)["command_count"] == 1
+    assert runtime.metadata(0)["events"]["tracking_diverged"] == 1
+    # The recovery plan cannot be sent; ordinary cancellation installs measured hold.
+    torch.testing.assert_close(robot.targets, robot.qpos)
+
+
+def test_runtime_rejects_unexpected_clock_advance():
+    robot, sim, engine, candidates, runtime = _runtime_fixture()
+    sim.simulation_time += 0.01
+    with pytest.raises(RuntimeError, match="clock"):
+        runtime.dispatch(
+            torch.cat([c.positions[:, 1] for c in candidates]), (True, True)
+        )
+    assert robot.targets.count_nonzero() == 0
+
+
+@pytest.mark.parametrize("period", [0.04, 0.05, 0.1, 0.15, 0.2])
+def test_runtime_uses_exact_control_period(period):
+    robot, sim, engine, candidates, runtime = _runtime_fixture(control_dt=period)
+    for index in range(1, 12):
+        runtime.dispatch(
+            torch.cat([c.positions[:, index] for c in candidates]), (True, True)
+        )
+        robot.qpos.copy_(robot.targets)
+        sim.simulation_time += period
+    runtime.finish()
+    assert runtime.validation(0).accepted
+
+
+@pytest.mark.parametrize("idle_row", [False, True])
+def test_runtime_commands_zero_velocity_independent_of_batch_occupancy(idle_row):
+    robot, sim, engine, candidates, runtime = _runtime_fixture(idle_row=idle_row)
+    robot.qvel.fill_(0.2)
+    robot.velocity_targets.fill_(0.3)
+    expected = robot.qpos.clone()
+    for row, candidate in enumerate(candidates):
+        if candidate is not None:
+            expected[row] = candidate.positions[0, 1]
+    runtime.dispatch(expected, (True, not idle_row))
+    assert robot.velocity_targets.count_nonzero() == 0
+
+
+@pytest.mark.parametrize(
+    "mismatch", [False, True], ids=["contact_frame", "effect_error"]
+)
+def test_runtime_verifies_effect_in_the_motion_endpoints_tcp_frame(mismatch):
+    robot, sim, engine, candidates, runtime = _runtime_fixture()
+    for index in range(1, 12):
+        runtime.dispatch(
+            torch.cat([c.positions[:, index] for c in candidates]), (True, True)
+        )
+        robot.qpos.copy_(robot.targets)
+        sim.simulation_time += CONTROL_DT
+    # The native contact profile can use a different calibrated TCP. The
+    # symbolic effect belongs to the motion endpoint's FK frame.
+    native_tcp = robot.compute_fk()
+    native_tcp[:, 0, 3] += 0.04
+    object_pose = robot.compute_fk()
+    if mismatch:
+        object_pose[:, 2, 3] -= 0.1
+    runtime.contact.observations = lambda: {
+        "tcp_pose": native_tcp,
+        "object_pose": object_pose,
+    }
+    if mismatch:
+        with pytest.raises(RuntimeError, match="effect verification"):
+            runtime.finish()
+        assert not runtime.validation(0).accepted
+        assert not runtime.runner.session.task_state.held_objects
+    else:
+        runtime.finish()
+        assert runtime.validation(0).accepted
+    error = runtime.metadata(0)["effect_translation_error_m"]
+    assert error == pytest.approx(0.1 if mismatch else 0.0)

--- a/tests/lab/trajectory_generation/test_contact.py
+++ b/tests/lab/trajectory_generation/test_contact.py
@@ -196,6 +196,22 @@ def test_unobserved_hold_cannot_pass():
     assert not validator.rollout_validation(0).accepted
 
 
+def test_interrupted_pickup_returns_rejected_path_evidence():
+    validator, _, _ = _monitor()
+    episode = SimpleNamespace(
+        observations={
+            "joint_positions": torch.zeros(2, 1),
+            "object_pose": torch.eye(4).repeat(2, 1, 1),
+        },
+        phases=(TrajectoryPhase("transit", 0, 2),),
+    )
+    result = validator.validate_episode(episode, None, row=0)
+    assert not result.accepted
+    assert result.checks[0].check_id == "path_collision"
+    assert result.checks[0].status == "unavailable"
+    assert "incomplete" in result.checks[0].detail.lower()
+
+
 def test_full_state_collision_uses_collision_shapes_and_moving_fingers(tmp_path):
     pytest.importorskip("fcl")
     pytest.importorskip("yourdfpy")

--- a/tests/lab/trajectory_generation/test_pickup_collection.py
+++ b/tests/lab/trajectory_generation/test_pickup_collection.py
@@ -31,7 +31,8 @@ import pytest
 @pytest.mark.slow
 @pytest.mark.requires_sim
 @pytest.mark.subprocess_sim
-def test_pickup_collection(tmp_path: Path) -> None:
+@pytest.mark.parametrize("runtime", [False, True], ids=["offline", "runtime"])
+def test_pickup_collection(tmp_path: Path, runtime: bool) -> None:
     av = pytest.importorskip("av")
     import pyarrow.parquet as pq
 
@@ -46,6 +47,7 @@ def test_pickup_collection(tmp_path: Path) -> None:
             "--episodes",
             "8",
             "--record-video",
+            *(["--runtime"] if runtime else []),
         ],
         cwd=root,
         capture_output=True,
@@ -93,6 +95,19 @@ def test_pickup_collection(tmp_path: Path) -> None:
         assert evidence["observation_shapes"]["object_pose"] == [4, 4]
         assert len(evidence["metadata"]["commanded_joint_indices"]) == 7
         assert len(evidence["metadata"]["joint_names"]) == 8
+        if runtime:
+            assert checks["atomic_runtime"]["status"] == "passed"
+            audit = evidence["metadata"]["atomic_runtime"]
+            assert audit["status"] == "completed"
+            assert audit["command_count"] == 271
+            assert audit["plan_attempts"] == 1
+            assert audit["effect_verified"]
+            assert audit["events"]["effect_verification_required"] == 1
+            assert audit["events"]["action_completed"] == 1
+            assert audit["effect_translation_error_m"] <= 0.01
+            assert audit["effect_rotation_error_rad"] <= 0.15
+            assert audit["effect_tcp_frame"]["source"] == "robot.compute_fk"
+            assert audit["contact_tcp_frame"]["source"] == "robot.get_link_pose"
         files = sorted((shard / "dataset" / "data").rglob("*.parquet"))
         table = pq.read_table(files)
         assert table.num_rows == 271
@@ -142,6 +157,74 @@ def test_pickup_collection(tmp_path: Path) -> None:
         assert float(stream.average_rate) == 20.0
         frames = sum(1 for _ in video.decode(stream))
         assert frames == pickup["video_frames"] == pickup["prepared_batches"] * 272
+
+
+@pytest.mark.gpu
+@pytest.mark.slow
+@pytest.mark.requires_sim
+@pytest.mark.subprocess_sim
+def test_runtime_recovery_rejects_physical_tail_batch_without_committing(
+    tmp_path: Path,
+) -> None:
+    root = Path(__file__).resolve().parents[3]
+    output = tmp_path / "recovery"
+    script = """
+import json
+import sys
+from dataclasses import replace
+from pathlib import Path
+import torch
+from examples.sim.motion.trajectory_generation.cube_pickup_collection import main
+from embodichain.lab.sim.atomic_actions import TrackingPolicy
+from embodichain.lab.sim.motion.trajectory_augmentation import TrajectoryGenerationJobCfg
+from embodichain.lab.trajectory_generation.execution import QposRolloutExecutor
+from embodichain.lab.trajectory_generation.integrations.atomic_runtime import PickUpRuntimeSource
+
+original_cfg = TrajectoryGenerationJobCfg.from_mapping
+def bounded(raw):
+    raw['collection'].update(max_proposals=1, max_rollout_attempts=1)
+    return original_cfg(raw)
+TrajectoryGenerationJobCfg.from_mapping = staticmethod(bounded)
+
+original_init = PickUpRuntimeSource.__init__
+def strict(self, engine, *, invocation_factory, templates):
+    def factory(binding):
+        return replace(invocation_factory(binding), tracking_policy=TrackingPolicy.joint_position(
+            in_flight_max_abs_error=1e-8, terminal_max_abs_error=0.05))
+    original_init(self, engine, invocation_factory=factory, templates=templates)
+PickUpRuntimeSource.__init__ = strict
+
+original_execute = QposRolloutExecutor.execute
+def audited(self, *args, **kwargs):
+    result = original_execute(self, *args, **kwargs)
+    robot = self.host.adapter.robot
+    ids = robot.active_joint_ids
+    torch.testing.assert_close(robot.get_qpos(target=True)[:, ids], robot.get_qpos()[:, ids])
+    torch.testing.assert_close(robot.get_qvel(target=True)[:, ids], torch.zeros_like(robot.get_qvel()[:, ids]))
+    (Path(sys.argv[2]) / 'runtime_audit.json').write_text(json.dumps(self._runtime.metadata(0)))
+    return result
+QposRolloutExecutor.execute = audited
+sys.argv = ['cube_pickup_collection.py', '--output', sys.argv[1], '--episodes', '1', '--runtime']
+main()
+"""
+    process = subprocess.run(
+        [sys.executable, "-c", script, str(output)],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert process.returncode == 1, process.stdout[-2000:] + process.stderr[-2000:]
+    report = json.loads((output / "generation_report.json").read_text())
+    assert report["error"] is None and not report["target_reached"]
+    assert report["counts"]["rollout_attempted"] == 1
+    assert report["counts"]["committed"] == 0
+    assert not (output / "manifest.json").exists()
+    audit = json.loads((output / "runtime_audit.json").read_text())
+    assert audit["command_count"] == 1
+    assert audit["plan_attempts"] == 2
+    assert audit["events"]["tracking_diverged"] == 1
+    assert not audit["effect_verified"]
 
 
 @pytest.mark.gpu


### PR DESCRIPTION
## Description

Execute selected augmented PickUp candidates through a fresh `ExecutionSession` and `ExecutionRunner`, with measured arm feedback and verified held-object effects before expert-data acceptance. The existing collector previously replayed offline atomic templates; `cube_pickup_collection.py --runtime` now exercises the observed runtime while preserving its physical contact checks and confirmed LeRobot persistence.

Depends on #591. This is a separate increment based on `feat/fixed-scene-trajectory-generation`; review only the changes above that branch.

- Add `PickUpRuntimeSource` and share plan/effect construction through `PickUp.materialize_trajectory`. Preserve the chosen joint branch and transit/approach/close/lift/hold phases after every full-batch initial-state restoration.
- Keep one physics clock, float64 command periods, explicit zero velocity targets, and T commands / T+1 observations. Arm feedback remains mandatory; gripper preload is verified by native bilateral contact and hold stability.
- Verify symbolic effects using the current observed joint context in the motion endpoint's TCP frame. Record both this frame and the contact profile's native TCP frame, with effect errors and bounded runtime event counts.
- Block recovery commands at the transport boundary, cancel/hold the active batch, and reject its expert data. Interrupted phase prefixes return unavailable path evidence so rejection does not abort the collection job.
- Update the API reference, guide, examples, design status and agent context. Offline collection remains available.

This layer covers Atomic PickUp × pure simulation with the existing fixed-base URDF / cuboid / CPU-physics contact profile. Contact-aware Gym, general via-point factors, the unified YAML launcher and the complete M1 qualification matrix remain subsequent work.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Validation

- Affected collection and atomic-action CPU tests: **993 passed, 1 skipped, 15 deselected**. Includes candidate ownership/protected phases, idle rows, five control periods, velocity-target consistency, effect-frame mismatch and recovery rejection.
- Real headless simulation: **4 passed** across observed runtime collection, recovery rejection, offline collection and the original four-panel preview. Runtime collected **8/8/8 proposed/attempted/committed**, with 271 actual commands and 272 observations per episode; all eight LeRobot shards and the 544-frame H.264 video were read back. Minimum lift was 17.90 cm and bilateral hold-contact coverage was 100%.
- Real recovery negative case: one tail-batch attempt, one candidate command, two plan attempts, measured safe hold, **zero commits**, no manifest and no job error.
- `black .`, `black --check .`, `git diff --check`, API coverage **1762/1762**, and docs checker **8 passed**. Sphinx dummy build succeeded with 744 warnings; none referenced the added generation APIs. Independent read-only review findings were fixed and rechecked.

## Screenshots

Reproduce the synchronized four-panel video and numeric dataset:

```bash
python examples/sim/motion/trajectory_generation/cube_pickup_collection.py \
  --output /tmp/cube-runtime-experts --episodes 8 --runtime --record-video
```

The output directory must be new or empty. `preview.mp4` shows two grasp orientations and independent augmented transit paths; `generation_report.json` and per-episode metadata carry acceptance evidence. Video is separate from the numeric LeRobot dataset.

## Checklist

- [x] I have run the `black .` command to format the code base.
- [x] I have made corresponding changes to the documentation.
- [x] Public API changes are reflected in the API docs.
- [x] I have added tests that prove the feature works.
- [x] Dependencies have been reviewed; no dependency changes are needed beyond #591.
