### PR TITLE
fix(gym/utils): is_pose_flip raises UnboundLocalError on every call

### DIFF
--- a/embodichain/lab/gym/utils/misc.py
+++ b/embodichain/lab/gym/utils/misc.py
@@ -138,10 +138,10 @@ def is_pose_flip(
 ):
     pose = np.asarray(pose)
     ref_pose = np.asarray(ref_pose)
-    axis_idx = axis_idx(axis_str)
-    if axis_idx is None:
+    axis_id = axis_idx(axis_str)
+    if axis_id is None:
         log_error(f'Axis {axis_str} is not among ["x", "y", "z"]')
-    relative_angle = np.abs(np.arccos(pose[:3, axis_idx].dot(ref_pose[:3, axis_idx])))
+    relative_angle = np.abs(np.arccos(pose[:3, axis_id].dot(ref_pose[:3, axis_id])))
     valid_ret = relative_angle > np.pi / 2
 
     if return_inverse:


### PR DESCRIPTION
### Problem

`is_pose_flip` in `embodichain/lab/gym/utils/misc.py` raises `UnboundLocalError` on **every** call:

```python
def is_pose_flip(pose, ref_pose, axis_str="y", return_inverse=False):
    ...
    axis_idx = axis_idx(axis_str)   # <-- UnboundLocalError
```

Because `axis_idx` is assigned inside the function, Python treats it as a local for the whole scope, so the `axis_idx(axis_str)` call on the right-hand side references the local *before* it is assigned:

```
UnboundLocalError: cannot access local variable 'axis_idx' where it is not associated with a value
```

The name `axis_idx` is also the module-level helper `def axis_idx(k)` that the line is trying to call, which is what gets shadowed.

### Fix

Rename the local to `axis_id`, exactly as the sibling function `is_pose_axis_align` in the same file already does (`axis_id = axis_idx(axis_str)`). No behavior change other than removing the crash.

### Verification

```python
pose = np.eye(4); ref = np.eye(4); ref[:3, 1] = [0, -1, 0]
is_pose_flip(pose, ref, axis_str="y")
# before: UnboundLocalError
# after:  True
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
