### PR TITLE
Improve run-task progress output

### DIFF
--- a/embodichain/lab/gym/envs/demo.py
+++ b/embodichain/lab/gym/envs/demo.py
@@ -798,8 +798,7 @@ def execute_demo_episode(
                     segment_label = f"{segment_id + 1}/{segment_total}"
                 actions = progress(
                     actions,
-                    f"Executing episode #{episode_index}, segment {segment_label}: "
-                    f"{segment.name}",
+                    f"Ep {episode_index} · Seg {segment_label} · {segment.name}",
                 )
 
             action_iterator = iter(actions)

--- a/embodichain/lab/scripts/run_env.py
+++ b/embodichain/lab/scripts/run_env.py
@@ -23,7 +23,7 @@ import select
 import sys
 import time
 
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Iterator, Sequence, Sized
 from typing import TYPE_CHECKING, Any
 
 import gymnasium
@@ -46,22 +46,74 @@ from embodichain.lab.gym.utils.registration import (
     discover_task_packages,
     execute_init_hooks,
 )
-from embodichain.utils.logger import log_warning, log_info, log_error
+from embodichain.utils.logger import (
+    decorate_str_color,
+    log_warning,
+    log_info,
+    log_error,
+)
 
 if TYPE_CHECKING:
     from embodichain.lab.visualization import VisualizationRuntime
 
 _REPLAY_CONTROL_POLL_INTERVAL = 0.05
+_ACTIVITY_BAR_WIDTH = 10
+
+
+def _indeterminate_progress(actions: Iterable[Any], description: str) -> Iterator[Any]:
+    """Render an activity bar for an action stream with no exact length."""
+    mode = decorate_str_color("[dynamic]", "yellow")
+
+    def label(position: int, *, done: bool = False) -> str:
+        if done:
+            cells = "━" * _ACTIVITY_BAR_WIDTH
+        else:
+            cells_list = ["·"] * _ACTIVITY_BAR_WIDTH
+            cells_list[position] = "╺"
+            cells = "".join(cells_list)
+        bar = decorate_str_color(f"│{cells}│", "cyan")
+        completion = " ✓" if done else ""
+        return f"Steps  {mode}  {description} {bar}{completion}"
+
+    progress = tqdm.tqdm(
+        total=None,
+        desc=label(0),
+        unit=" step",
+        file=sys.stdout,
+        dynamic_ncols=True,
+        bar_format="{desc} {n_fmt} steps [{elapsed}, {rate_fmt}]",
+    )
+    try:
+        for action in actions:
+            yield action
+            progress.update()
+            cycle_position = progress.n % (2 * _ACTIVITY_BAR_WIDTH - 2)
+            position = min(cycle_position, 2 * _ACTIVITY_BAR_WIDTH - 2 - cycle_position)
+            progress.set_description_str(label(position), refresh=False)
+        progress.set_description_str(label(0, done=True), refresh=False)
+    finally:
+        progress.close()
 
 
 def _progress_wrapper(actions: Iterable[Any], description: str) -> Iterable[Any]:
     """Wrap a segment action iterable in a visible terminal progress bar."""
+    total = len(actions) if isinstance(actions, Sized) else None
+    if total is None:
+        return _indeterminate_progress(actions, description)
+    mode = decorate_str_color("[fixed]", "blue")
     return tqdm.tqdm(
         actions,
+        total=total,
         desc=description,
-        unit="step",
+        unit=" step",
         file=sys.stdout,
         dynamic_ncols=True,
+        colour="cyan",
+        bar_format=(
+            f"Steps  {mode}    {{desc}} {{percentage:3.0f}}%│{{bar}}│ "
+            "{n_fmt}/{total_fmt} "
+            "[{elapsed}<{remaining}, {rate_fmt}]"
+        ),
     )
 
 
@@ -718,7 +770,6 @@ def main(args: Any, env: Any, gym_config: dict[str, Any]) -> None:
         preview(env)
         return
 
-    log_info("Start offline data generation.", color="green")
     # Prepare one clean scene. max_episodes counts persisted per-environment
     # episodes, not vector batches. Every successful generate_function call
     # commits exactly the selected rows and leaves the next batch ready to plan.
@@ -729,34 +780,66 @@ def main(args: Any, env: Any, gym_config: dict[str, Any]) -> None:
     num_envs = int(getattr(_env_target(env), "num_envs", 1))
     if num_envs < 1:
         raise ValueError(f"env.num_envs must be at least 1, got {num_envs}.")
+    max_attempts = int(gym_config.get("demo_max_attempts", 3))
+
+    environment_label = "environment" if num_envs == 1 else "environments"
+    tqdm.tqdm.write(
+        "\n".join(
+            (
+                "╭─ EmbodiChain · Run Task",
+                f"│ Task        {gym_config.get('id', 'unknown')}",
+                f"│ Episodes    {max_episodes}",
+                f"│ Parallel    {num_envs} {environment_label}",
+                f"│ Attempts    {max_attempts} per batch",
+                "╰─",
+            )
+        ),
+        file=sys.stdout,
+    )
 
     saved_episodes = 0
     generated_batches = 0
-    while saved_episodes < max_episodes:
-        batch_episode_count = min(num_envs, max_episodes - saved_episodes)
-        save_env_ids = tuple(range(batch_episode_count))
-        generated = generate_function(
-            env,
-            time_id=saved_episodes,
-            save_path=getattr(args, "save_path", ""),
-            save_video=getattr(args, "save_video", False),
-            debug_mode=getattr(args, "debug_mode", False),
-            save_env_ids=save_env_ids,
-            regenerate=getattr(args, "regenerate", False),
-            max_attempts=gym_config.get("demo_max_attempts", 3),
-            reset_before=False,
-        )
-        if not generated:
-            raise RuntimeError(
-                f"Failed to generate episode batch starting at {saved_episodes} after "
-                f"{gym_config.get('demo_max_attempts', 3)} attempts."
+    with tqdm.tqdm(
+        total=max_episodes,
+        desc="Collecting episodes",
+        unit="episode",
+        file=sys.stdout,
+        dynamic_ncols=True,
+        colour="green",
+        bar_format=(
+            "{desc:<22} {percentage:3.0f}%│{bar}│ {n_fmt}/{total_fmt} "
+            "[{elapsed}<{remaining}, {rate_fmt}]"
+        ),
+    ) as episode_progress:
+        while saved_episodes < max_episodes:
+            batch_episode_count = min(num_envs, max_episodes - saved_episodes)
+            save_env_ids = tuple(range(batch_episode_count))
+            generated = generate_function(
+                env,
+                time_id=saved_episodes,
+                save_path=getattr(args, "save_path", ""),
+                save_video=getattr(args, "save_video", False),
+                debug_mode=getattr(args, "debug_mode", False),
+                save_env_ids=save_env_ids,
+                regenerate=getattr(args, "regenerate", False),
+                max_attempts=max_attempts,
+                reset_before=False,
             )
-        saved_episodes += batch_episode_count
-        generated_batches += 1
+            if not generated:
+                raise RuntimeError(
+                    f"Failed to generate episode batch starting at {saved_episodes} "
+                    f"after {max_attempts} attempts."
+                )
+            saved_episodes += batch_episode_count
+            generated_batches += 1
+            episode_progress.update(batch_episode_count)
 
-    log_info(
-        f"Committed {saved_episodes} episode(s) in {generated_batches} vector batch(es).",
-        color="green",
+    episode_label = "episode" if saved_episodes == 1 else "episodes"
+    batch_label = "batch" if generated_batches == 1 else "batches"
+    tqdm.tqdm.write(
+        f"✓ Collection complete · {saved_episodes} {episode_label} saved in "
+        f"{generated_batches} {batch_label}",
+        file=sys.stdout,
     )
 
     # Log the trajectory save location before cli() tears down the sim and, by

--- a/tests/gym/envs/test_demo.py
+++ b/tests/gym/envs/test_demo.py
@@ -312,7 +312,7 @@ def test_execute_demo_episode_exposes_declared_progress_total_for_lazy_actions(
             )
 
     def progress(actions, description: str):
-        assert description == "Executing episode #0, segment #1: move_cube"
+        assert description == "Ep 0 · Seg #1 · move_cube"
         assert env.actions == []
         if total is None:
             with pytest.raises(TypeError):

--- a/tests/lab/scripts/test_run_env.py
+++ b/tests/lab/scripts/test_run_env.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import json
+import re
 import sys
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -125,8 +126,7 @@ def test_legacy_action_list_displays_episode_and_segment_indices(
 
     assert generated
     assert progress.call_args.kwargs["desc"] == (
-        f"Executing episode #{EPISODE_INDEX}, segment {ACTION_LIST_INDEX + 1}/1: "
-        "legacy"
+        f"Ep {EPISODE_INDEX} · Seg {ACTION_LIST_INDEX + 1}/1 · legacy"
     )
     assert len(progress.call_args.args[0]) == 1
     assert progress.call_args.kwargs["file"] is sys.stdout
@@ -145,14 +145,46 @@ def test_task_program_progress_displays_repeated_segment_position(capsys) -> Non
     )
 
     assert generated
-    output = capsys.readouterr().out
+    output = re.sub(r"\x1b\[[0-9;]*m", "", capsys.readouterr().out)
     for index in range(1, REPEATED_PICK_PLACE_SEGMENT_COUNT + 1):
         assert (
-            f"Executing episode #{EPISODE_INDEX}, segment {index}/"
-            f"{REPEATED_PICK_PLACE_SEGMENT_COUNT}: move_cube: 100%|"
+            f"Steps  [fixed]    Ep {EPISODE_INDEX} · Seg {index}/"
+            f"{REPEATED_PICK_PLACE_SEGMENT_COUNT} · move_cube 100%"
         ) in output
     total = REPEATED_PICK_PLACE_SEGMENT_STEP_COUNT
     assert output.count(f"{total}/{total}") == REPEATED_PICK_PLACE_SEGMENT_COUNT
+
+
+def test_progress_wrapper_formats_known_step_total(capsys) -> None:
+    """Sized action sequences render a complete step progress bar."""
+    actions = (object(), object())
+
+    for _ in run_env._progress_wrapper(actions, "Ep 1 · Seg 1/1 · move_cube"):
+        pass
+
+    output = re.sub(r"\x1b\[[0-9;]*m", "", capsys.readouterr().out)
+    assert "Steps  [fixed]    Ep 1 · Seg 1/1 · move_cube" in output
+    assert "100%" in output
+    assert "2/2" in output
+    assert " step/s]" in output
+
+
+def test_progress_wrapper_formats_unknown_step_total_as_activity(capsys) -> None:
+    """Lazy action streams finish an indeterminate bar without a percentage."""
+    actions = (object() for _ in range(2))
+
+    for _ in run_env._progress_wrapper(
+        actions, "Ep 1 · Seg 1/1 · pour_and_return_bottle"
+    ):
+        pass
+
+    output = re.sub(r"\x1b\[[0-9;]*m", "", capsys.readouterr().out)
+    assert (
+        "Steps  [dynamic]  Ep 1 · Seg 1/1 · pour_and_return_bottle "
+        "│━━━━━━━━━━│ ✓ 2 steps"
+    ) in output
+    assert " step/s]" in output
+    assert "0%" not in output
 
 
 def test_run_env_syncs_viser_images_each_step_by_default() -> None:
@@ -573,6 +605,58 @@ def test_main_counts_max_episodes_as_persisted_env_rows(monkeypatch) -> None:
 
     assert calls == [(0, (0, 1, 2)), (3, (0, 1))]
     assert sum(len(env_ids) for _, env_ids in calls) == 5
+
+
+def _run_successful_collection(monkeypatch) -> None:
+    """Run the collection UI around a deterministic successful generator."""
+    env = _ResetTrackingEnv(num_envs=3)
+    args = SimpleNamespace(
+        replay=False,
+        preview=False,
+        save_path="",
+        save_video=False,
+        debug_mode=False,
+        regenerate=False,
+        record_trajectory=False,
+    )
+    monkeypatch.setattr(run_env, "generate_function", lambda *args, **kwargs: True)
+    run_env.main(
+        args,
+        env,
+        {"id": GYM_ID, "max_episodes": 5, "demo_max_attempts": 2},
+    )
+
+
+def test_main_displays_total_episode_progress_for_vector_batches(
+    monkeypatch, capsys
+) -> None:
+    """Collection progress counts persisted rows rather than vector batches."""
+    _run_successful_collection(monkeypatch)
+
+    output = capsys.readouterr().out
+    assert "Collecting episodes" in output
+    assert "100%" in output
+    assert "5/5" in output
+
+
+def test_main_prints_compact_collection_summary(monkeypatch, capsys) -> None:
+    """The run header exposes the settings needed to interpret progress."""
+    _run_successful_collection(monkeypatch)
+
+    output = capsys.readouterr().out
+    assert "EmbodiChain · Run Task" in output
+    assert f"Task        {GYM_ID}" in output
+    assert "Episodes    5" in output
+    assert "Parallel    3 environments" in output
+    assert "Attempts    2 per batch" in output
+
+
+def test_main_prints_clean_collection_completion(monkeypatch, capsys) -> None:
+    """A completed run ends with one concise success line."""
+    _run_successful_collection(monkeypatch)
+
+    output = capsys.readouterr().out
+    assert "✓ Collection complete · 5 episodes saved in 2 batches" in output
 
 
 def test_generate_function_rejects_runner_owned_segment_count() -> None:


### PR DESCRIPTION
## Description

This PR improves the terminal output of `embodichain run-task`.

- Restores determinate step progress for fixed-length action sequences.
- Adds an animated activity bar for dynamic action streams whose final length is not known in advance.
- Marks step streams explicitly as `[fixed]` or `[dynamic]` and simplifies episode/segment labels.
- Adds a compact run summary, total episode collection progress, and a concise completion message.
- Counts persisted environment rows in the overall episode progress, including partial vector batches.

Dynamic Task Program segments such as `pour_water` can add data-dependent stability steps, so they intentionally avoid a misleading percentage or ETA while still reporting activity and the final step count.

Dependencies: none.

No linked issue.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which improves an existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (existing functionality will not work without user modification)
- [ ] Documentation update

## Screenshots

Before:

```text
Steps · Executing episode #0, segment 1/1: pour_and_return_bottle │━━━━━━━━━━│ done 206 step [00:05, 34.60step/s]
```

After:

```text
Steps  [fixed]    Ep 0 · Seg 1/3 · move_cube 100%│██████████│ 60/60 [00:02<00:00, 29.80 step/s]
Steps  [dynamic]  Ep 0 · Seg 1/1 · pour_and_return_bottle │━━━━━━━━━━│ ✓ 206 steps [00:05, 34.60 step/s]
```

The mode badges and progress bars are colorized in an interactive terminal.

## Validation

- `black ./`
- `python -m pytest -q -c /dev/null --noconftest tests/lab/scripts/test_run_env.py` — 38 passed
- `python docs/scripts/check_api_docs.py` — 1825/1825 exports documented
- `git diff --check`

## Checklist

- [x] I have run the `black .` command to format the code base.
- [ ] I have made corresponding changes to the documentation (not applicable; terminal-only presentation change)
- [x] Public API changes are reflected in the API docs (`python docs/scripts/check_api_docs.py`), if applicable
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Dependencies have been updated, if applicable (not applicable; no dependency changes)
