### PR TITLE
Support post-release versions and release branch CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
     tags:
       - 'v*'
   pull_request:
-    branches: [main]
+    branches: [main, 'release/**']
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -222,6 +222,7 @@ jobs:
         shell: bash
         run: |
           python - <<'PY'
+          from email.parser import Parser
           from pathlib import Path
           from zipfile import ZipFile
 
@@ -235,11 +236,18 @@ jobs:
               "embodichain/VERSION",
               "embodichain/gen_sim/simready_pipeline/configs/gen_config.json",
               "embodichain_tasks/__init__.py",
-              "embodichain_tasks/configs/tasks/manipulation/tableware/pour_water/env.json",
+              "embodichain_tasks/configs/tasks/manipulation/tableware/pour_water/env.yaml",
           }
           with ZipFile(wheels[0]) as wheel:
               members = set(wheel.namelist())
               entry_points = wheel.read(f"{dist_info}entry_points.txt").decode()
+              metadata = Parser().parsestr(wheel.read(f"{dist_info}METADATA").decode())
+              runtime_version = wheel.read("embodichain/VERSION").decode().strip()
+              if metadata["Version"] != version or runtime_version != version:
+                  raise SystemExit(
+                      f"Wheel version mismatch: expected={version}, "
+                      f"metadata={metadata['Version']}, runtime={runtime_version}"
+                  )
 
           source_task_configs = {
               path.as_posix()

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,3 +9,4 @@ sphinxcontrib-bibtex==2.6.5
 sphinx-design==0.6.1
 sphinx-autodoc-typehints==2.3.0
 pypandoc-binary==1.17
+packaging>=23.0

--- a/docs/scripts/generate_versions_json.py
+++ b/docs/scripts/generate_versions_json.py
@@ -20,16 +20,17 @@ from __future__ import annotations
 
 import argparse
 import json
-import re
 from pathlib import Path
 
+from packaging.version import InvalidVersion, Version
 
-def parse_version(tag: str) -> tuple[int, int, int]:
-    """Parse a version tag like 'v1.2.3' into a tuple (1, 2, 3)."""
-    match = re.match(r"^v(\d+)\.(\d+)\.(\d+)$", tag)
-    if not match:
-        return (0, 0, 0)
-    return (int(match.group(1)), int(match.group(2)), int(match.group(3)))
+
+def parse_version(tag: str) -> Version:
+    """Parse release tags, including PEP 440 post-release suffixes."""
+    try:
+        return Version(tag)
+    except InvalidVersion:
+        return Version("0")
 
 
 def main() -> None:
@@ -62,7 +63,7 @@ def main() -> None:
 
     versions: list[dict[str, str]] = []
 
-    # Collect tag versions (vX.Y.Z directories), sorted newest-first
+    # Collect tag versions (including vX.Y.Z.postN directories), sorted newest-first
     tag_dirs = sorted(
         [d for d in html_dir.glob("v*") if d.is_dir()],
         key=lambda d: parse_version(d.name),

--- a/setup.py
+++ b/setup.py
@@ -101,11 +101,9 @@ def get_package_dir() -> dict[str, str]:
 
 
 def get_version() -> str:
-    """Read the normalized package version from the repository version file."""
+    """Read the complete package version from the repository version file."""
     with open(os.path.join(os.path.dirname(__file__), "VERSION")) as f:
-        full_version = f.read().strip()
-        version = ".".join(full_version.split(".")[:3])
-    return version
+        return f.read().strip()
 
 
 def main():

--- a/tests/docs/test_generate_versions_json.py
+++ b/tests/docs/test_generate_versions_json.py
@@ -1,0 +1,54 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "docs/scripts/generate_versions_json.py"
+
+
+@pytest.mark.parametrize(
+    ("tags", "expected"),
+    [
+        (["v0.2.4", "v0.2.4.post1"], ["v0.2.4.post1", "v0.2.4"]),
+        (
+            ["v0.2.4.post2", "v0.2.5", "v0.2.4.post10"],
+            ["v0.2.5", "v0.2.4.post10", "v0.2.4.post2"],
+        ),
+        (["v0.2.3", "v0.2.4"], ["v0.2.4", "v0.2.3"]),
+        ([], []),
+    ],
+)
+def test_manifest_and_redirect_use_newest_version(
+    tmp_path: Path, tags: list[str], expected: list[str]
+) -> None:
+    for tag in [*tags, "main"]:
+        (tmp_path / tag).mkdir()
+    subprocess.run(
+        [sys.executable, str(_SCRIPT), "--build-dir", str(tmp_path)], check=True
+    )
+
+    manifest = json.loads((tmp_path / "versions.json").read_text())
+    latest = expected[0] if expected else "main"
+    assert manifest["latest"] == latest
+    assert [entry["name"] for entry in manifest["versions"]] == [*expected, "main"]
+    assert f"url=./{latest}/index.html" in (tmp_path / "index.html").read_text()

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -23,6 +23,7 @@ from zipfile import ZipFile
 import pytest
 from packaging.requirements import Requirement
 
+import setup as package_setup
 from scripts.validate_wheel_metadata import WheelMetadataError, validate_wheel
 from setup import get_package_dir, get_packages
 
@@ -115,3 +116,13 @@ def test_wheel_metadata_rejects_direct_dependencies(tmp_path: Path) -> None:
 
     with pytest.raises(WheelMetadataError, match="nvidia-curobo"):
         validate_wheel(wheel_path)
+
+
+@pytest.mark.parametrize("version", ["0.2.4", "0.2.4.post1", "0.2.4.post10"])
+def test_setup_preserves_full_version(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, version: str
+) -> None:
+    (tmp_path / "VERSION").write_text(f"{version}\n", encoding="utf-8")
+    monkeypatch.setattr(package_setup, "__file__", str(tmp_path / "setup.py"))
+
+    assert package_setup.get_version() == version


### PR DESCRIPTION
# Description

Synchronize post-release support onto `main` so later docs deployments continue selecting `v0.2.4.post1` over `v0.2.4`. VERSION remains unchanged.

Supports post-release versions in docs sorting and redirects, preserves the complete VERSION in setup.py, enables pull-request CI for release/**, and checks both wheel metadata and the bundled runtime version against VERSION. Adds focused regressions for post-release ordering and version preservation. Declares packaging explicitly in docs requirements.

## Type of change

- Bug fix
- Enhancement

## Validation

- Black 26.3.1: `black .`
- `actionlint -shellcheck= .github/workflows/main.yml`
- Focused packaging tests and docs tooling tests (isolated from simulation fixtures)
- `python -m build`, `twine check`, dependency metadata validator, and the exact workflow wheel-content/version validation code
- Builds performed locally with Python 3.13; CI uses Python 3.11. Full simulation tests and live PyPI/Pages publishing were not run locally.

## Checklist

- [x] I have run `black .` to format the code base.
- [x] I have added tests that prove the fixes.
- [x] Dependencies have been updated where required.
- Documentation: executable docs tooling updated; no Sphinx content or package public API changes.

Also corrects the release wheel check's stale `pour_water/env.json` path to the existing `env.yaml`; the old path failed against an actual build from main.

Main validation: 32 focused tests passed, API docs coverage 1857/1857, wheel/sdist build and exact CI artifact checks passed. Project context reports no affected topics.

This is the main counterpart of release/v0.2.4 preparation PR #608; #579 remains a separate functional change on the release branch.
