### PR TITLE
Improve PPO training stability

### DIFF
--- a/agent_context/topics/rl-learning/rl-learning.md
+++ b/agent_context/topics/rl-learning/rl-learning.md
@@ -127,6 +127,7 @@ how many environment steps contribute to one optimizer update.
 | Standard rollout storage and views | `buffer/` |
 | Standard and differentiable collection | `collector/` |
 | Policy interface, actor-critic, actor-only, MLP builder | `models/` |
+| Actor and critic observation statistics | `models/normalizer.py` |
 | Standard collect/update loop | `utils/trainer.py` |
 | Differentiable TBPTT/update loop | `differentiable_trainer.py` |
 | Shared completed-episode evaluation | `evaluation.py` |
@@ -137,6 +138,12 @@ Rollout payloads on the standard path are `TensorDict` objects. Policies
 consume observations and write action, log-probability, entropy, and value
 fields needed by their algorithm. Differentiable policies must expose
 graph-preserving action sampling.
+
+For actor-critic policies, `policy.obs_groups.actor` and `.critic` select ordered
+observation groups. The collector and standard buffer preserve separate
+`critic_obs` when configured; evaluation applies the same selection. The PPO
+collector also records the old Gaussian mean and standard deviation for KL
+measurement. These rollout fields have explicit dimensions in the buffer.
 
 Read [training and extension](training.md) for evaluation, checkpoints,
 distributed ownership, official examples and adding algorithms/policies/envs.

--- a/agent_context/topics/rl-learning/training.md
+++ b/agent_context/topics/rl-learning/training.md
@@ -17,8 +17,24 @@ Evaluation uses an independent environment and
 terminal metrics, temporarily switches the policy to evaluation mode, and
 restores its prior mode.
 
+PPO supports adaptive learning rates from Gaussian KL, clipped value loss,
+configurable minibatch counts, and optional action-mean bounds. Adaptive KL
+scheduling cannot be combined with `algorithm.cfg.lr_scheduler`. The actor and
+critic can maintain independent observation statistics in
+`models/normalizer.py`; collection updates these buffers and evaluation keeps
+them frozen. A restored policy must use the original normalization settings.
+Time-limit truncations bootstrap rewards with the value stored for the
+transition before GAE masks the episode boundary.
+See the [PPO configuration options](../../../docs/source/overview/rl/config.md)
+for the public configuration fields.
+
+`Trainer` increments `num_updates` after each algorithm update.
+`trainer.save_frequency_updates` enables saving at update intervals. An
+explicit positive `save_freq` additionally enables saving by environment steps.
+
 Checkpoints include policy parameters, trainer counters, best-evaluation
-state, and optimizer or LR-scheduler state when present.
+state, observation-normalizer state when enabled, and optimizer or LR-scheduler
+state when present.
 
 On the simulator path, distributed mode initializes NCCL, assigns one CUDA
 device per local rank, wraps the policy in

--- a/docs/source/api_reference/embodichain/embodichain.learning.rl.models.rst
+++ b/docs/source/api_reference/embodichain/embodichain.learning.rl.models.rst
@@ -21,6 +21,7 @@ through :func:`register_policy` / :func:`get_policy_class`.
       ActorCritic
       ActorOnly
       MLP
+      EmpiricalNormalizer
 
    .. rubric:: Functions
 
@@ -31,9 +32,24 @@ through :func:`register_policy` / :func:`get_policy_class`.
       get_policy_class
       get_registered_policy_names
       register_policy
+      resolve_policy_obs_groups
 
 .. automodule:: embodichain.learning.rl.models
    :members:
    :undoc-members:
    :show-inheritance:
-   
+
+Observation normalization
+-------------------------
+
+``ActorCritic`` can maintain independent actor and critic observation moments.
+The statistics are stored in policy buffers and restored with its checkpoint.
+
+.. currentmodule:: embodichain.learning.rl.models.normalizer
+
+.. autosummary::
+
+   EmpiricalNormalizer
+
+.. autoclass:: EmpiricalNormalizer
+   :no-index:

--- a/docs/source/api_reference/embodichain/embodichain.learning.rl.rst
+++ b/docs/source/api_reference/embodichain/embodichain.learning.rl.rst
@@ -97,6 +97,7 @@ Policy Models
    :members:
    :undoc-members:
    :show-inheritance:
+   :no-index:
 
 Training
 --------

--- a/docs/source/overview/rl/config.md
+++ b/docs/source/overview/rl/config.md
@@ -78,3 +78,52 @@ GRPO example (for Embodied AI / from-scratch training):
 ## Practical Tips
 - It is recommended to manage all experiment parameters via JSON or YAML config files for reproducibility and tuning.
 - Supports multi-algorithm config for easy comparison and automation.
+
+## PPO training options
+
+PPO accepts the following optional settings under `algorithm.cfg`:
+
+| Setting | Default | Effect |
+|---|---|---|
+| `num_mini_batches` | `null` | Split a rollout into this many minibatches; otherwise use `batch_size`. |
+| `use_clipped_value_loss` | `false` | Clip value updates around the values stored during collection. |
+| `schedule` / `desired_kl` | `fixed` / `null` | Select `adaptive` with a positive target KL to adjust the learning rate. |
+| `minimum_learning_rate` / `maximum_learning_rate` | `1e-5` / `1e-2` | Bound the adaptive learning rate. |
+| `normalize_advantage_per_mini_batch` | `false` | Normalize advantages within each minibatch. |
+| `action_bound_coef` | `0.0` | Weight the squared penalty on action means outside `[-1, 1]`; use this for tasks with normalized actions. |
+
+Adaptive KL scheduling controls the optimizer learning rate directly and cannot
+be combined with `algorithm.cfg.lr_scheduler`.
+
+Time-limit truncations bootstrap rewards with the value stored for the
+transition.
+
+For `actor_critic`, `policy.actor_obs_normalization` and
+`policy.critic_obs_normalization` enable separate running statistics. Both
+are disabled by default. These statistics are included in the policy checkpoint;
+recreate the policy with the same normalization settings before loading it.
+`policy.initial_action_std` sets exploration scale, and `policy.action_std_range`
+bounds the standard deviation. `policy.initial_log_std`, when supplied, takes
+precedence over the initial standard deviation.
+
+An environment can expose different actor and critic observation groups:
+
+```yaml
+policy:
+  name: actor_critic
+  obs_groups:
+    actor: [policy]
+    critic: [critic]
+  actor_obs_normalization: true
+  critic_obs_normalization: true
+```
+
+Keep the actor and critic network definitions alongside these settings. The
+collector, rollout buffer, and evaluator preserve the selected groups. Omit
+`obs_groups` to flatten all observations as before.
+
+`trainer.save_frequency_updates` saves a checkpoint after each specified number
+of PPO updates. Its default is `0` (disabled). If it is supplied, the Gym training
+entry defaults `save_freq` to `0`; an explicit `save_freq` also enables saving by
+environment steps. Checkpoints include `global_step` and `num_updates`.
+Evaluation reports terminal scalar metrics under `eval/metrics/`.

--- a/embodichain/learning/rl/algo/common.py
+++ b/embodichain/learning/rl/algo/common.py
@@ -37,9 +37,14 @@ def compute_gae(
     Returns:
         Tuple of `(advantages, returns)`, both shaped `[num_envs, time]`.
     """
+    values = rollout["value"].float()
     rewards = rollout["reward"][:, :-1].float()
     dones = rollout["done"][:, :-1].bool()
-    values = rollout["value"].float()
+    truncated = rollout["truncated"][:, :-1].bool()
+
+    # Bootstrap time-limit truncations with the value stored for the
+    # transition before the done mask cuts GAE recursion.
+    rewards = rewards + gamma * values[:, :-1] * truncated
 
     if rewards.ndim != 2:
         raise ValueError(

--- a/embodichain/learning/rl/algo/ppo.py
+++ b/embodichain/learning/rl/algo/ppo.py
@@ -21,8 +21,8 @@ from typing import Dict
 import torch
 from tensordict import TensorDict
 
-from embodichain.learning.rl.buffer import iterate_minibatches, transition_view
-from embodichain.learning.rl.utils import AlgorithmCfg
+from embodichain.learning.rl.buffer import transition_view
+from embodichain.learning.rl.utils import AlgorithmCfg, coerce_lr_scheduler_cfg
 from embodichain.utils import configclass
 from .common import compute_gae
 from .base import BaseAlgorithm
@@ -38,12 +38,44 @@ class PPOCfg(AlgorithmCfg):
     clip_coef: float = 0.2
     ent_coef: float = 0.01
     vf_coef: float = 0.5
+    action_bound_coef: float = 0.0
+    use_clipped_value_loss: bool = False
+    schedule: str = "fixed"
+    desired_kl: float | None = None
+    minimum_learning_rate: float = 1e-5
+    maximum_learning_rate: float = 1e-2
+    num_mini_batches: int | None = None
+    normalize_advantage_per_mini_batch: bool = False
 
 
 class PPO(BaseAlgorithm[TensorDict]):
     """PPO algorithm consuming TensorDict rollouts."""
 
     def __init__(self, cfg: PPOCfg, policy):
+        if cfg.schedule not in {"fixed", "adaptive"}:
+            raise ValueError("PPO schedule must be 'fixed' or 'adaptive'.")
+        if cfg.schedule == "adaptive" and (
+            cfg.desired_kl is None or cfg.desired_kl <= 0.0
+        ):
+            raise ValueError("Adaptive PPO requires a positive desired_kl.")
+        if (
+            cfg.schedule == "adaptive"
+            and coerce_lr_scheduler_cfg(cfg.lr_scheduler).name is not None
+        ):
+            raise ValueError(
+                "Adaptive PPO cannot be combined with algorithm.cfg.lr_scheduler."
+            )
+        if cfg.minimum_learning_rate <= 0.0:
+            raise ValueError("minimum_learning_rate must be positive.")
+        if cfg.maximum_learning_rate < cfg.minimum_learning_rate:
+            raise ValueError(
+                "maximum_learning_rate must be greater than or equal to "
+                "minimum_learning_rate."
+            )
+        if cfg.num_mini_batches is not None and cfg.num_mini_batches <= 0:
+            raise ValueError("num_mini_batches must be positive when provided.")
+        if cfg.action_bound_coef < 0.0:
+            raise ValueError("action_bound_coef must be non-negative.")
         self.cfg = cfg
         self.policy = policy
         self.device = torch.device(cfg.device)
@@ -55,28 +87,37 @@ class PPO(BaseAlgorithm[TensorDict]):
         compute_gae(rollout, gamma=self.cfg.gamma, gae_lambda=self.cfg.gae_lambda)
         flat_rollout = transition_view(rollout, flatten=True)
 
-        advantages = flat_rollout["advantage"]
-        adv_mean = advantages.mean()
-        adv_std = advantages.std().clamp_min(1e-8)
+        if not self.cfg.normalize_advantage_per_mini_batch:
+            advantages = flat_rollout["advantage"]
+            flat_rollout["advantage"] = (advantages - advantages.mean()) / (
+                advantages.std() + 1e-8
+            )
 
         total_actor_loss = 0.0
         total_value_loss = 0.0
+        total_action_bound_loss = 0.0
         total_entropy = 0.0
+        total_kl = 0.0
         total_steps = 0
 
         for _ in range(self.cfg.n_epochs):
-            for batch in iterate_minibatches(
-                flat_rollout, self.cfg.batch_size, self.device
-            ):
+            for indices in self._minibatch_indices(flat_rollout.batch_size[0]):
+                batch = flat_rollout[indices]
                 old_logprobs = batch["sample_log_prob"].clone()
                 returns = batch["return"].clone()
-                batch_advantages = ((batch["advantage"] - adv_mean) / adv_std).detach()
+                batch_advantages = batch["advantage"]
+                if self.cfg.normalize_advantage_per_mini_batch:
+                    batch_advantages = (batch_advantages - batch_advantages.mean()) / (
+                        batch_advantages.std() + 1e-8
+                    )
+                batch_advantages = batch_advantages.detach()
 
                 policy_module = getattr(self.policy, "module", self.policy)
                 eval_batch = policy_module.evaluate_actions(batch)
                 logprobs = eval_batch["sample_log_prob"]
                 entropy = eval_batch["entropy"]
                 values = eval_batch["value"]
+                kl = self._update_adaptive_learning_rate(batch, eval_batch)
                 ratio = (logprobs - old_logprobs).exp()
                 surr1 = ratio * batch_advantages
                 surr2 = (
@@ -86,32 +127,141 @@ class PPO(BaseAlgorithm[TensorDict]):
                     * batch_advantages
                 )
                 actor_loss = -torch.min(surr1, surr2).mean()
-                value_loss = torch.nn.functional.mse_loss(values, returns)
+                value_loss = self._value_loss(values, returns, batch["value"])
+                action_bound_loss = self._action_bound_loss(eval_batch["action_mean"])
                 entropy_loss = -entropy.mean()
 
                 loss = (
                     actor_loss
                     + self.cfg.vf_coef * value_loss
+                    + self.cfg.action_bound_coef * action_bound_loss
                     + self.cfg.ent_coef * entropy_loss
                 )
 
                 self.optimizer.zero_grad(set_to_none=True)
                 loss.backward()
-                torch.nn.utils.clip_grad_norm_(
-                    self.policy.parameters(), self.cfg.max_grad_norm
-                )
+                self._clip_gradients()
                 self.optimizer.step()
 
                 bs = batch.batch_size[0]
                 total_actor_loss += actor_loss.item() * bs
                 total_value_loss += value_loss.item() * bs
+                total_action_bound_loss += action_bound_loss.item() * bs
                 total_entropy += (-entropy_loss.item()) * bs
+                total_kl += kl * bs
                 total_steps += bs
 
         self._step_scheduler()
         return {
             "actor_loss": total_actor_loss / max(1, total_steps),
             "value_loss": total_value_loss / max(1, total_steps),
+            "action_bound_loss": total_action_bound_loss / max(1, total_steps),
             "entropy": total_entropy / max(1, total_steps),
+            "kl": total_kl / max(1, total_steps),
             "learning_rate": self.current_learning_rate(),
         }
+
+    def _minibatch_indices(self, total: int) -> tuple[torch.Tensor, ...]:
+        """Build a shuffled mini-batch partition without dropping transitions."""
+        if self.cfg.num_mini_batches is not None:
+            if self.cfg.num_mini_batches > total:
+                raise ValueError(
+                    "num_mini_batches cannot exceed the rollout transition count."
+                )
+            permutation = torch.randperm(total, device=self.device)
+            return permutation.chunk(self.cfg.num_mini_batches)
+        if self.cfg.batch_size <= 0:
+            raise ValueError("batch_size must be positive.")
+        permutation = torch.randperm(total, device=self.device)
+        return tuple(
+            permutation[start : start + self.cfg.batch_size]
+            for start in range(0, total, self.cfg.batch_size)
+        )
+
+    def _value_loss(
+        self,
+        values: torch.Tensor,
+        returns: torch.Tensor,
+        old_values: torch.Tensor,
+    ) -> torch.Tensor:
+        """Compute the configured PPO value objective."""
+        if not self.cfg.use_clipped_value_loss:
+            return torch.nn.functional.mse_loss(values, returns)
+        value_delta = (values - old_values).clamp(
+            -self.cfg.clip_coef,
+            self.cfg.clip_coef,
+        )
+        clipped_values = old_values + value_delta
+        value_losses = (values - returns).square()
+        clipped_value_losses = (clipped_values - returns).square()
+        return torch.maximum(value_losses, clipped_value_losses).mean()
+
+    @staticmethod
+    def _action_bound_loss(action_mean: torch.Tensor) -> torch.Tensor:
+        """Penalize policy means outside the normalized action range."""
+        above = torch.clamp(action_mean - 1.0, min=0.0).square().mean()
+        below = torch.clamp(action_mean + 1.0, max=0.0).square().mean()
+        return above + below
+
+    @torch.no_grad()
+    def _update_adaptive_learning_rate(
+        self,
+        batch: TensorDict,
+        eval_batch: TensorDict,
+    ) -> float:
+        """Apply exact diagonal-Gaussian KL scheduling and return mean KL."""
+        if self.cfg.schedule != "adaptive":
+            return 0.0
+        desired_kl = self.cfg.desired_kl
+        if desired_kl is None:
+            raise RuntimeError("adaptive PPO requires desired_kl")
+        for name in ("action_mean", "action_std"):
+            if name not in batch.keys():
+                raise KeyError(f"adaptive PPO requires rollout field '{name}'")
+        old_mean = batch["action_mean"]
+        old_std = batch["action_std"].clamp_min(1e-8)
+        new_mean = eval_batch["action_mean"]
+        new_std = eval_batch["action_std"].clamp_min(1e-8)
+        kl = torch.sum(
+            torch.log(new_std / old_std)
+            + (old_std.square() + (old_mean - new_mean).square())
+            / (2.0 * new_std.square())
+            - 0.5,
+            dim=-1,
+        ).mean()
+        mean_kl = float(kl)
+        learning_rate = self.current_learning_rate()
+        if mean_kl > desired_kl * 2.0:
+            learning_rate = max(
+                self.cfg.minimum_learning_rate,
+                learning_rate / 1.5,
+            )
+        elif 0.0 < mean_kl < desired_kl * 0.5:
+            learning_rate = min(
+                self.cfg.maximum_learning_rate,
+                learning_rate * 1.5,
+            )
+        for param_group in self.optimizer.param_groups:
+            param_group["lr"] = learning_rate
+        return mean_kl
+
+    def _clip_gradients(self) -> None:
+        """Clip actor and critic gradients and reject non-finite updates."""
+        policy_module = getattr(self.policy, "module", self.policy)
+        parameter_groups = getattr(policy_module, "optimization_parameter_groups", None)
+        groups = (
+            parameter_groups()
+            if parameter_groups is not None
+            else (tuple(self.policy.parameters()),)
+        )
+        try:
+            for parameters in groups:
+                torch.nn.utils.clip_grad_norm_(
+                    parameters,
+                    self.cfg.max_grad_norm,
+                    error_if_nonfinite=True,
+                )
+        except RuntimeError as exc:
+            raise FloatingPointError(
+                "PPO update produced non-finite gradients; optimizer step skipped."
+            ) from exc

--- a/embodichain/learning/rl/buffer/standard_buffer.py
+++ b/embodichain/learning/rl/buffer/standard_buffer.py
@@ -40,10 +40,14 @@ class RolloutBuffer:
         obs_dim: int,
         action_dim: int,
         device: torch.device,
+        critic_obs_dim: int | None = None,
+        distribution_param_dim: int | None = None,
     ) -> None:
         self.num_envs = num_envs
         self.rollout_len = rollout_len
         self.obs_dim = obs_dim
+        self.critic_obs_dim = critic_obs_dim
+        self.distribution_param_dim = distribution_param_dim
         self.action_dim = action_dim
         self.device = device
         self._rollout = self._allocate_rollout()
@@ -97,59 +101,77 @@ class RolloutBuffer:
 
     def _allocate_rollout(self) -> TensorDict:
         """Preallocate rollout storage with uniform `[num_envs, time + 1]` shape."""
+        fields = {
+            "obs": torch.empty(
+                self.num_envs,
+                self.rollout_len + 1,
+                self.obs_dim,
+                dtype=torch.float32,
+                device=self.device,
+            ),
+            "action": torch.empty(
+                self.num_envs,
+                self.rollout_len + 1,
+                self.action_dim,
+                dtype=torch.float32,
+                device=self.device,
+            ),
+            "sample_log_prob": torch.empty(
+                self.num_envs,
+                self.rollout_len + 1,
+                dtype=torch.float32,
+                device=self.device,
+            ),
+            "value": torch.empty(
+                self.num_envs,
+                self.rollout_len + 1,
+                dtype=torch.float32,
+                device=self.device,
+            ),
+            "reward": torch.empty(
+                self.num_envs,
+                self.rollout_len + 1,
+                dtype=torch.float32,
+                device=self.device,
+            ),
+            "done": torch.empty(
+                self.num_envs,
+                self.rollout_len + 1,
+                dtype=torch.bool,
+                device=self.device,
+            ),
+            "terminated": torch.empty(
+                self.num_envs,
+                self.rollout_len + 1,
+                dtype=torch.bool,
+                device=self.device,
+            ),
+            "truncated": torch.empty(
+                self.num_envs,
+                self.rollout_len + 1,
+                dtype=torch.bool,
+                device=self.device,
+            ),
+        }
+        if self.critic_obs_dim is not None:
+            fields["critic_obs"] = torch.empty(
+                self.num_envs,
+                self.rollout_len + 1,
+                self.critic_obs_dim,
+                dtype=torch.float32,
+                device=self.device,
+            )
+        if self.distribution_param_dim is not None:
+            for name in ("action_mean", "action_std"):
+                fields[name] = torch.empty(
+                    self.num_envs,
+                    self.rollout_len + 1,
+                    self.distribution_param_dim,
+                    dtype=torch.float32,
+                    device=self.device,
+                )
         return TensorDict(
-            {
-                "obs": torch.empty(
-                    self.num_envs,
-                    self.rollout_len + 1,
-                    self.obs_dim,
-                    dtype=torch.float32,
-                    device=self.device,
-                ),
-                "action": torch.empty(
-                    self.num_envs,
-                    self.rollout_len + 1,
-                    self.action_dim,
-                    dtype=torch.float32,
-                    device=self.device,
-                ),
-                "sample_log_prob": torch.empty(
-                    self.num_envs,
-                    self.rollout_len + 1,
-                    dtype=torch.float32,
-                    device=self.device,
-                ),
-                "value": torch.empty(
-                    self.num_envs,
-                    self.rollout_len + 1,
-                    dtype=torch.float32,
-                    device=self.device,
-                ),
-                "reward": torch.empty(
-                    self.num_envs,
-                    self.rollout_len + 1,
-                    dtype=torch.float32,
-                    device=self.device,
-                ),
-                "done": torch.empty(
-                    self.num_envs,
-                    self.rollout_len + 1,
-                    dtype=torch.bool,
-                    device=self.device,
-                ),
-                "terminated": torch.empty(
-                    self.num_envs,
-                    self.rollout_len + 1,
-                    dtype=torch.bool,
-                    device=self.device,
-                ),
-                "truncated": torch.empty(
-                    self.num_envs,
-                    self.rollout_len + 1,
-                    dtype=torch.bool,
-                    device=self.device,
-                ),
-            },
+            fields,
             batch_size=[self.num_envs, self.rollout_len + 1],
             device=self.device,
         )
@@ -170,6 +192,9 @@ class RolloutBuffer:
         self._rollout["done"][:, last_idx].fill_(False)
         self._rollout["terminated"][:, last_idx].fill_(False)
         self._rollout["truncated"][:, last_idx].fill_(False)
+        for name in ("action_mean", "action_std"):
+            if name in self._rollout.keys():
+                self._rollout[name][:, last_idx].zero_()
 
     def _validate_rollout_layout(self, rollout: TensorDict) -> None:
         """Validate the expected tensor shapes for the shared rollout."""
@@ -183,6 +208,19 @@ class RolloutBuffer:
             "terminated": (self.num_envs, self.rollout_len + 1),
             "truncated": (self.num_envs, self.rollout_len + 1),
         }
+        if self.critic_obs_dim is not None:
+            expected_shapes["critic_obs"] = (
+                self.num_envs,
+                self.rollout_len + 1,
+                self.critic_obs_dim,
+            )
+        if self.distribution_param_dim is not None:
+            for name in ("action_mean", "action_std"):
+                expected_shapes[name] = (
+                    self.num_envs,
+                    self.rollout_len + 1,
+                    self.distribution_param_dim,
+                )
         for key, expected_shape in expected_shapes.items():
             actual_shape = tuple(rollout[key].shape)
             if actual_shape != expected_shape:

--- a/embodichain/learning/rl/buffer/utils.py
+++ b/embodichain/learning/rl/buffer/utils.py
@@ -58,6 +58,12 @@ def transition_view(rollout: TensorDict, flatten: bool = False) -> TensorDict:
         device=rollout.device,
     )
 
+    if "critic_obs" in rollout.keys():
+        td["critic_obs"] = rollout["critic_obs"][:, :-1]
+    for key in ("action_mean", "action_std"):
+        if key in rollout.keys():
+            td[key] = rollout[key][:, :-1]
+
     for key in ("advantage", "return", "seq_mask", "seq_return", "entropy"):
         if key in rollout.keys():
             td[key] = rollout[key][:, :-1]

--- a/embodichain/learning/rl/collector/sync_collector.py
+++ b/embodichain/learning/rl/collector/sync_collector.py
@@ -21,7 +21,10 @@ from typing import Callable
 import torch
 from tensordict import TensorDict
 
-from embodichain.learning.rl.utils import dict_to_tensordict, flatten_dict_observation
+from embodichain.learning.rl.utils import (
+    dict_to_tensordict,
+    flatten_observation_groups,
+)
 from .base import BaseCollector
 
 __all__ = ["SyncCollector"]
@@ -41,6 +44,18 @@ class SyncCollector(BaseCollector):
         self.policy = policy
         self.device = device
         self.reset_every_rollout = reset_every_rollout
+        policy_module = getattr(policy, "module", policy)
+        self.actor_obs_groups = getattr(policy_module, "actor_obs_groups", None)
+        self.critic_obs_groups = getattr(policy_module, "critic_obs_groups", None)
+        self.uses_separate_critic_obs = bool(
+            getattr(policy_module, "uses_separate_critic_obs", False)
+        )
+        self.critic_obs_dim = getattr(policy_module, "critic_obs_dim", None)
+        self.obs_dim = getattr(policy_module, "obs_dim", None)
+        self.action_dim = getattr(policy_module, "action_dim", None)
+        self.distribution_param_dim = getattr(
+            policy_module, "distribution_param_dim", None
+        )
         self._supports_shared_rollout = hasattr(self.env, "set_rollout_buffer")
         self.obs_td = self._reset_env()
 
@@ -68,11 +83,16 @@ class SyncCollector(BaseCollector):
         if self._supports_shared_rollout:
             self.env.set_rollout_buffer(rollout)
 
-        initial_obs = flatten_dict_observation(self.obs_td)
+        initial_obs, initial_critic_obs = self._model_observations(self.obs_td)
         rollout["obs"][:, 0] = initial_obs
+        if initial_critic_obs is not None:
+            rollout["critic_obs"][:, 0] = initial_critic_obs
         for step_idx in range(num_steps):
+            step_fields = {"obs": rollout["obs"][:, step_idx]}
+            if self.uses_separate_critic_obs:
+                step_fields["critic_obs"] = rollout["critic_obs"][:, step_idx]
             step_td = TensorDict(
-                {"obs": rollout["obs"][:, step_idx]},
+                step_fields,
                 batch_size=[rollout.batch_size[0]],
                 device=self.device,
             )
@@ -95,7 +115,11 @@ class SyncCollector(BaseCollector):
                     terminated=terminated,
                     truncated=truncated,
                 )
-            rollout["obs"][:, step_idx + 1] = flatten_dict_observation(next_obs_td)
+            actor_obs, critic_obs = self._model_observations(next_obs_td)
+            rollout["obs"][:, step_idx + 1] = actor_obs
+            if critic_obs is not None:
+                rollout["critic_obs"][:, step_idx + 1] = critic_obs
+            self._update_policy_normalization(actor_obs, critic_obs)
 
             if on_step_callback is not None:
                 on_step_callback(rollout[:, step_idx], env_info)
@@ -107,9 +131,11 @@ class SyncCollector(BaseCollector):
 
     def _attach_final_value(self, rollout: TensorDict) -> None:
         """Populate the bootstrap value for the final observed state."""
-        final_obs = rollout["obs"][:, -1]
+        final_fields = {"obs": rollout["obs"][:, -1]}
+        if self.uses_separate_critic_obs:
+            final_fields["critic_obs"] = rollout["critic_obs"][:, -1]
         last_next_td = TensorDict(
-            {"obs": final_obs},
+            final_fields,
             batch_size=[rollout.batch_size[0]],
             device=self.device,
         )
@@ -120,12 +146,50 @@ class SyncCollector(BaseCollector):
         obs, _ = self.env.reset()
         return dict_to_tensordict(obs, self.device)
 
+    def _model_observations(
+        self,
+        observation: TensorDict,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        """Build actor and optional privileged critic observations."""
+        actor_obs = flatten_observation_groups(
+            observation,
+            self.actor_obs_groups,
+        )
+        if not self.uses_separate_critic_obs:
+            return actor_obs, None
+        critic_obs = flatten_observation_groups(
+            observation,
+            self.critic_obs_groups,
+        )
+        return actor_obs, critic_obs
+
     def _to_action_dict(self, action: torch.Tensor) -> TensorDict | torch.Tensor:
         am = getattr(self.env, "action_manager", None)
         if am is None:
             return action
         else:
             return am.convert_policy_action_to_env_action(action)
+
+    def _update_policy_normalization(
+        self,
+        actor_obs: torch.Tensor,
+        critic_obs: torch.Tensor | None,
+    ) -> None:
+        """Update optional policy observation normalizers from the next state."""
+        policy_module = getattr(self.policy, "module", self.policy)
+        update = getattr(policy_module, "update_normalization", None)
+        if update is None:
+            return
+        fields = {"obs": actor_obs}
+        if critic_obs is not None:
+            fields["critic_obs"] = critic_obs
+        update(
+            TensorDict(
+                fields,
+                batch_size=[actor_obs.shape[0]],
+                device=self.device,
+            )
+        )
 
     def _write_step(
         self,
@@ -137,6 +201,13 @@ class SyncCollector(BaseCollector):
         rollout["action"][:, step_idx] = step_td["action"]
         rollout["sample_log_prob"][:, step_idx] = step_td["sample_log_prob"]
         rollout["value"][:, step_idx] = step_td["value"]
+        for name in ("action_mean", "action_std"):
+            if name in rollout.keys():
+                if name not in step_td.keys():
+                    raise KeyError(
+                        f"policy must return '{name}' for adaptive PPO scheduling"
+                    )
+                rollout[name][:, step_idx] = step_td[name]
 
     def _write_env_step(
         self,
@@ -156,8 +227,8 @@ class SyncCollector(BaseCollector):
     def _validate_rollout(self, rollout: TensorDict, num_steps: int) -> None:
         """Validate rollout layout expected by the collector."""
         expected_shapes = {
-            "obs": (self.env.num_envs, num_steps + 1, self.policy.obs_dim),
-            "action": (self.env.num_envs, num_steps + 1, self.policy.action_dim),
+            "obs": (self.env.num_envs, num_steps + 1, self.obs_dim),
+            "action": (self.env.num_envs, num_steps + 1, self.action_dim),
             "sample_log_prob": (self.env.num_envs, num_steps + 1),
             "value": (self.env.num_envs, num_steps + 1),
             "reward": (self.env.num_envs, num_steps + 1),
@@ -165,6 +236,19 @@ class SyncCollector(BaseCollector):
             "terminated": (self.env.num_envs, num_steps + 1),
             "truncated": (self.env.num_envs, num_steps + 1),
         }
+        if self.uses_separate_critic_obs:
+            expected_shapes["critic_obs"] = (
+                self.env.num_envs,
+                num_steps + 1,
+                self.critic_obs_dim,
+            )
+        if all(name in rollout.keys() for name in ("action_mean", "action_std")):
+            for name in ("action_mean", "action_std"):
+                expected_shapes[name] = (
+                    self.env.num_envs,
+                    num_steps + 1,
+                    self.distribution_param_dim,
+                )
         for key, expected_shape in expected_shapes.items():
             actual_shape = tuple(rollout[key].shape)
             if actual_shape != expected_shape:

--- a/embodichain/learning/rl/evaluation.py
+++ b/embodichain/learning/rl/evaluation.py
@@ -27,15 +27,36 @@ from tensordict import TensorDict
 
 from embodichain.learning.rl.utils import (
     dict_to_tensordict,
-    flatten_dict_observation,
+    flatten_observation_groups,
 )
 
 __all__ = ["evaluate_episodes"]
 
 
-def _flat_observation(observation: Any, device: torch.device) -> torch.Tensor:
-    tensor_dict = dict_to_tensordict(observation, device)
-    return flatten_dict_observation(tensor_dict)
+def _policy_input(
+    observation: Any,
+    policy: torch.nn.Module,
+    device: torch.device,
+) -> TensorDict:
+    """Build actor and optional critic inputs from configured groups."""
+    observation_td = dict_to_tensordict(observation, device)
+    policy_module = getattr(policy, "module", policy)
+    fields = {
+        "obs": flatten_observation_groups(
+            observation_td,
+            getattr(policy_module, "actor_obs_groups", None),
+        )
+    }
+    if getattr(policy_module, "uses_separate_critic_obs", False):
+        fields["critic_obs"] = flatten_observation_groups(
+            observation_td,
+            getattr(policy_module, "critic_obs_groups", None),
+        )
+    return TensorDict(
+        fields,
+        batch_size=[fields["obs"].shape[0]],
+        device=device,
+    )
 
 
 def _action_for_env(env: Any, action: torch.Tensor) -> Any:
@@ -106,12 +127,7 @@ def evaluate_episodes(
     try:
         observation, _ = env.reset(seed=seed)
         while len(returns) < num_episodes:
-            flat_observation = _flat_observation(observation, device)
-            policy_input = TensorDict(
-                {"obs": flat_observation},
-                batch_size=[num_envs],
-                device=device,
-            )
+            policy_input = _policy_input(observation, policy, device)
             policy_output = policy.get_action(policy_input, deterministic=True)
             observation, reward, terminated, truncated, info = env.step(
                 _action_for_env(env, policy_output["action"])

--- a/embodichain/learning/rl/models/__init__.py
+++ b/embodichain/learning/rl/models/__init__.py
@@ -18,6 +18,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 import inspect
 from typing import Dict, Type
 
@@ -28,6 +29,7 @@ from .actor_critic import ActorCritic
 from .actor_only import ActorOnly
 from .policy import Policy
 from .mlp import MLP
+from .normalizer import EmpiricalNormalizer
 
 # In-module policy registry
 _POLICY_REGISTRY: Dict[str, Type[Policy]] = {}
@@ -58,6 +60,48 @@ def _resolve_space_dim(space_or_dim: spaces.Space | int, name: str) -> int:
     )
 
 
+def resolve_policy_obs_groups(
+    policy_block: Mapping[str, object],
+) -> tuple[tuple[str, ...] | None, tuple[str, ...] | None]:
+    """Resolve actor and critic observation groups from policy configuration.
+
+    Args:
+        policy_block: Policy configuration containing an optional
+            ``obs_groups`` mapping.
+
+    Returns:
+        Actor and critic observation group names. Both are ``None`` when the
+        existing flatten-all behavior is selected.
+
+    Raises:
+        TypeError: If the observation-group configuration is malformed.
+        ValueError: If the actor observation set is empty.
+    """
+    raw_groups = policy_block.get("obs_groups")
+    if raw_groups is None:
+        return None, None
+    if not isinstance(raw_groups, Mapping):
+        raise TypeError("policy.obs_groups must be a mapping.")
+
+    def _normalize(name: str, value: object) -> tuple[str, ...] | None:
+        if value is None:
+            return None
+        if isinstance(value, str) or not isinstance(value, Sequence):
+            raise TypeError(f"policy.obs_groups.{name} must be a list of names.")
+        groups = tuple(value)
+        if not all(isinstance(group, str) for group in groups):
+            raise TypeError(f"policy.obs_groups.{name} must contain only string names.")
+        if len(groups) == 0:
+            raise ValueError(f"policy.obs_groups.{name} cannot be empty.")
+        return groups
+
+    actor_groups = _normalize("actor", raw_groups.get("actor"))
+    if actor_groups is None:
+        raise ValueError("policy.obs_groups.actor is required when obs_groups is set.")
+    critic_groups = _normalize("critic", raw_groups.get("critic"))
+    return actor_groups, actor_groups if critic_groups is None else critic_groups
+
+
 def build_policy(
     policy_block: dict,
     obs_space: spaces.Space | int,
@@ -65,6 +109,7 @@ def build_policy(
     device: torch.device,
     actor: torch.nn.Module | None = None,
     critic: torch.nn.Module | None = None,
+    critic_obs_space: spaces.Space | int | None = None,
 ) -> Policy:
     """Build a policy from config using spaces for extensibility.
 
@@ -78,6 +123,7 @@ def build_policy(
             f"Policy '{name}' is not registered. Available policies: {available}"
         )
     policy_cls = _POLICY_REGISTRY[name]
+    actor_obs_groups, critic_obs_groups = resolve_policy_obs_groups(policy_block)
 
     if name == "actor_critic":
         if actor is None or critic is None:
@@ -85,6 +131,15 @@ def build_policy(
                 "ActorCritic policy requires external 'actor' and 'critic' modules."
             )
         obs_dim = _resolve_space_dim(obs_space, "obs_space")
+        critic_obs_dim = (
+            None
+            if critic_obs_space is None
+            else _resolve_space_dim(critic_obs_space, "critic_obs_space")
+        )
+        if actor_obs_groups != critic_obs_groups and critic_obs_dim is None:
+            raise ValueError(
+                "A distinct critic observation group requires critic_obs_space."
+            )
         action_dim = _resolve_space_dim(action_space, "action_space")
         return policy_cls(
             obs_dim=obs_dim,
@@ -92,6 +147,17 @@ def build_policy(
             device=device,
             actor=actor,
             critic=critic,
+            critic_obs_dim=critic_obs_dim,
+            actor_obs_groups=actor_obs_groups,
+            critic_obs_groups=critic_obs_groups,
+            actor_obs_normalization=bool(
+                policy_block.get("actor_obs_normalization", False)
+            ),
+            critic_obs_normalization=bool(
+                policy_block.get("critic_obs_normalization", False)
+            ),
+            initial_action_std=float(policy_block.get("initial_action_std", 1.0)),
+            action_std_range=tuple(policy_block.get("action_std_range", (1e-6, 1e6))),
         )
     elif name == "actor_only":
         if actor is None:
@@ -103,6 +169,7 @@ def build_policy(
             action_dim=action_dim,
             device=device,
             actor=actor,
+            actor_obs_groups=actor_obs_groups,
         )
 
     init_params = inspect.signature(policy_cls.__init__).parameters
@@ -164,6 +231,8 @@ __all__ = [
     "build_policy",
     "build_mlp_from_cfg",
     "get_policy_class",
+    "resolve_policy_obs_groups",
     "Policy",
     "MLP",
+    "EmpiricalNormalizer",
 ]

--- a/embodichain/learning/rl/models/actor_critic.py
+++ b/embodichain/learning/rl/models/actor_critic.py
@@ -16,30 +16,38 @@
 
 from __future__ import annotations
 
+import math
+from collections.abc import Sequence
+
 import torch
 import torch.nn as nn
 from torch.distributions.normal import Normal
 from tensordict import TensorDict
 
 from .mlp import MLP
+from .normalizer import EmpiricalNormalizer
 from .policy import Policy
 
 __all__ = ["ActorCritic"]
 
 
 class ActorCritic(Policy):
-    """Actor-Critic with learnable log_std for Gaussian policy.
+    """TensorDict actor-critic with a learnable Gaussian action distribution.
 
-    This is a placeholder implementation of the Policy interface that:
-    - Encapsulates MLP networks (actor + critic) that need to be trained by RL algorithms
-    - Handles internal computation: MLP output → mean + learnable log_std → Normal distribution
-    - Provides a uniform interface for RL algorithms (PPO, SAC, etc.)
-
-    This allows seamless swapping with other policy implementations (e.g., VLAPolicy)
-    without modifying RL algorithm code.
-
-    Implements TensorDict-native interfaces while preserving `get_action()`
-    compatibility for evaluation and legacy call-sites.
+    Args:
+        obs_dim: Actor observation dimension.
+        action_dim: Action dimension.
+        device: Device used by the policy modules and distribution parameters.
+        actor: Module that maps actor observations to action means.
+        critic: Module that maps critic observations to scalar values.
+        critic_obs_dim: Separate critic observation dimension. ``None`` reuses
+            actor observations.
+        actor_obs_groups: Ordered observation groups consumed by the actor.
+        critic_obs_groups: Ordered observation groups consumed by the critic.
+        actor_obs_normalization: Whether to normalize actor observations.
+        critic_obs_normalization: Whether to normalize critic observations.
+        initial_action_std: Initial standard deviation for every action.
+        action_std_range: Inclusive clamp range applied to standard deviation.
     """
 
     def __init__(
@@ -49,26 +57,113 @@ class ActorCritic(Policy):
         device: torch.device,
         actor: nn.Module,
         critic: nn.Module,
-    ):
+        critic_obs_dim: int | None = None,
+        actor_obs_groups: Sequence[str] | None = None,
+        critic_obs_groups: Sequence[str] | None = None,
+        actor_obs_normalization: bool = False,
+        critic_obs_normalization: bool = False,
+        initial_action_std: float = 1.0,
+        action_std_range: tuple[float, float] = (1e-6, 1e6),
+    ) -> None:
         super().__init__()
         self.obs_dim = obs_dim
+        self.actor_obs_dim = obs_dim
+        self.critic_obs_dim = obs_dim if critic_obs_dim is None else int(critic_obs_dim)
+        self.uses_separate_critic_obs = critic_obs_dim is not None
+        self.actor_obs_groups = (
+            None if actor_obs_groups is None else tuple(actor_obs_groups)
+        )
+        self.critic_obs_groups = (
+            self.actor_obs_groups
+            if critic_obs_groups is None
+            else tuple(critic_obs_groups)
+        )
         self.action_dim = action_dim
+        self.distribution_param_dim = action_dim
         self.device = device
+        self.actor_obs_normalization = bool(actor_obs_normalization)
+        self.critic_obs_normalization = bool(critic_obs_normalization)
+        if initial_action_std <= 0.0:
+            raise ValueError("initial_action_std must be positive.")
+        if (
+            len(action_std_range) != 2
+            or action_std_range[0] <= 0.0
+            or action_std_range[1] < action_std_range[0]
+        ):
+            raise ValueError(
+                "action_std_range must contain positive increasing bounds."
+            )
+        self.action_std_range = (
+            float(action_std_range[0]),
+            float(action_std_range[1]),
+        )
 
         self.actor = actor
         self.critic = critic
         self.actor.to(self.device)
         self.critic.to(self.device)
+        self.actor_obs_normalizer: nn.Module = (
+            EmpiricalNormalizer(self.actor_obs_dim).to(self.device)
+            if self.actor_obs_normalization
+            else nn.Identity()
+        )
+        self.critic_obs_normalizer: nn.Module = (
+            EmpiricalNormalizer(self.critic_obs_dim).to(self.device)
+            if self.critic_obs_normalization
+            else nn.Identity()
+        )
 
-        self.log_std = nn.Parameter(torch.zeros(self.action_dim, device=self.device))
-        self.log_std_min = -5.0
-        self.log_std_max = 2.0
+        initial_std = torch.full(
+            (self.action_dim,),
+            float(initial_action_std),
+            device=self.device,
+        )
+        self.log_std = nn.Parameter(initial_std.log())
 
     def _distribution(self, obs: torch.Tensor) -> Normal:
-        mean = self.actor(obs)
-        log_std = self.log_std.clamp(self.log_std_min, self.log_std_max)
-        std = log_std.exp().expand(mean.shape[0], -1)
-        return Normal(mean, std)
+        mean = self.actor(self.actor_obs_normalizer(obs))
+        std = self.action_std.expand(mean.shape[0], -1)
+        return Normal(mean, std, validate_args=False)
+
+    @property
+    def action_std(self) -> torch.Tensor:
+        """Return the clamped state-independent action standard deviation."""
+        lower, upper = self.action_std_range
+        log_lower = math.log(lower)
+        log_upper = math.log(upper)
+        return self.log_std.clamp(log_lower, log_upper).exp()
+
+    def optimization_parameter_groups(
+        self,
+    ) -> tuple[tuple[nn.Parameter, ...], tuple[nn.Parameter, ...]]:
+        """Return actor-side and critic-side trainable parameter groups."""
+        actor_parameters = (*self.actor.parameters(), self.log_std)
+        critic_parameters = tuple(self.critic.parameters())
+        return actor_parameters, critic_parameters
+
+    def _value(self, observation: torch.Tensor) -> torch.Tensor:
+        """Evaluate the critic after applying its observation normalizer."""
+        return self.critic(self.critic_obs_normalizer(observation)).squeeze(-1)
+
+    @torch.no_grad()
+    def update_normalization(self, tensordict: TensorDict) -> None:
+        """Update actor and critic observation statistics from environment data."""
+        if self.actor_obs_normalization:
+            self.actor_obs_normalizer.update(tensordict["obs"])
+        if self.critic_obs_normalization:
+            self.critic_obs_normalizer.update(self._critic_observation(tensordict))
+
+    def _critic_observation(self, tensordict: TensorDict) -> torch.Tensor:
+        """Return the observation selected for value estimation."""
+        if self.uses_separate_critic_obs:
+            if "critic_obs" not in tensordict.keys():
+                raise KeyError(
+                    "ActorCritic requires 'critic_obs' because the critic uses "
+                    f"{self.critic_obs_dim} inputs while the actor uses "
+                    f"{self.actor_obs_dim}."
+                )
+            return tensordict["critic_obs"]
+        return tensordict["obs"]
 
     def forward(
         self, tensordict: TensorDict, deterministic: bool = False
@@ -96,8 +191,9 @@ class ActorCritic(Policy):
         deterministic: bool,
         reparameterized: bool,
     ) -> TensorDict:
-        obs = tensordict["obs"]
-        dist = self._distribution(obs)
+        actor_obs = tensordict["obs"]
+        critic_obs = self._critic_observation(tensordict)
+        dist = self._distribution(actor_obs)
         mean = dist.mean
         if deterministic:
             action = mean
@@ -107,24 +203,30 @@ class ActorCritic(Policy):
             action = dist.sample()
         tensordict["action"] = action
         tensordict["sample_log_prob"] = dist.log_prob(action).sum(dim=-1)
+        tensordict["action_mean"] = dist.mean
+        tensordict["action_std"] = dist.stddev
         if reparameterized:
             tensordict["entropy"] = dist.entropy().sum(dim=-1)
-        tensordict["value"] = self.critic(obs).squeeze(-1)
+        tensordict["value"] = self._value(critic_obs)
         return tensordict
 
     def get_value(self, tensordict: TensorDict) -> TensorDict:
-        tensordict["value"] = self.critic(tensordict["obs"]).squeeze(-1)
+        critic_obs = self._critic_observation(tensordict)
+        tensordict["value"] = self._value(critic_obs)
         return tensordict
 
     def evaluate_actions(self, tensordict: TensorDict) -> TensorDict:
-        obs = tensordict["obs"]
+        actor_obs = tensordict["obs"]
+        critic_obs = self._critic_observation(tensordict)
         action = tensordict["action"]
-        dist = self._distribution(obs)
+        dist = self._distribution(actor_obs)
         return TensorDict(
             {
                 "sample_log_prob": dist.log_prob(action).sum(dim=-1),
                 "entropy": dist.entropy().sum(dim=-1),
-                "value": self.critic(obs).squeeze(-1),
+                "value": self._value(critic_obs),
+                "action_mean": dist.mean,
+                "action_std": dist.stddev,
             },
             batch_size=tensordict.batch_size,
             device=tensordict.device,

--- a/embodichain/learning/rl/models/actor_only.py
+++ b/embodichain/learning/rl/models/actor_only.py
@@ -16,6 +16,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 import torch
 import torch.nn as nn
 from torch.distributions.normal import Normal
@@ -39,9 +41,14 @@ class ActorOnly(Policy):
         action_dim: int,
         device: torch.device,
         actor: nn.Module,
-    ):
+        actor_obs_groups: Sequence[str] | None = None,
+    ) -> None:
         super().__init__()
         self.obs_dim = obs_dim
+        self.actor_obs_dim = obs_dim
+        self.actor_obs_groups = (
+            None if actor_obs_groups is None else tuple(actor_obs_groups)
+        )
         self.action_dim = action_dim
         self.device = device
 

--- a/embodichain/learning/rl/models/normalizer.py
+++ b/embodichain/learning/rl/models/normalizer.py
@@ -1,0 +1,77 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+"""Running observation normalization for reinforcement-learning policies."""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+__all__ = ["EmpiricalNormalizer"]
+
+
+class EmpiricalNormalizer(nn.Module):
+    """Normalize observations with online mean and variance estimates.
+
+    Statistics are stored as module buffers so policy checkpoints preserve the
+    exact transformation used during training and evaluation.
+
+    Args:
+        feature_dim: Number of features in the final observation dimension.
+        epsilon: Stabilizer added to the running standard deviation.
+    """
+
+    def __init__(self, feature_dim: int, epsilon: float = 1e-2) -> None:
+        super().__init__()
+        if feature_dim <= 0:
+            raise ValueError("feature_dim must be positive")
+        if epsilon <= 0.0:
+            raise ValueError("epsilon must be positive")
+        self.epsilon = float(epsilon)
+        self.register_buffer("mean", torch.zeros(1, feature_dim))
+        self.register_buffer("variance", torch.ones(1, feature_dim))
+        self.register_buffer("standard_deviation", torch.ones(1, feature_dim))
+        self.register_buffer("count", torch.zeros((), dtype=torch.long))
+
+    def forward(self, value: torch.Tensor) -> torch.Tensor:
+        """Return observations normalized by the current running moments."""
+        return (value - self.mean) / (self.standard_deviation + self.epsilon)
+
+    @torch.no_grad()
+    def update(self, value: torch.Tensor) -> None:
+        """Merge one observation batch into the running moments."""
+        if not self.training:
+            return
+        if value.ndim != 2 or value.shape[-1] != self.mean.shape[-1]:
+            raise ValueError(
+                "normalizer input must have shape [batch, feature_dim], got "
+                f"{tuple(value.shape)}"
+            )
+        batch_count = int(value.shape[0])
+        if batch_count == 0:
+            return
+        batch_mean = value.mean(dim=0, keepdim=True)
+        batch_variance = value.var(dim=0, unbiased=False, keepdim=True)
+        self.count.add_(batch_count)
+        rate = batch_count / self.count
+        delta = batch_mean - self.mean
+        self.mean.add_(rate * delta)
+        self.variance.add_(
+            rate * (batch_variance - self.variance + delta * (batch_mean - self.mean))
+        )
+        self.variance.clamp_min_(0.0)
+        self.standard_deviation.copy_(torch.sqrt(self.variance))

--- a/embodichain/learning/rl/models/policy.py
+++ b/embodichain/learning/rl/models/policy.py
@@ -53,7 +53,8 @@ class Policy(nn.Module, ABC):
         """Sample actions into the provided TensorDict without gradients.
 
         Args:
-            tensordict: Input TensorDict containing `obs`.
+            tensordict: Input TensorDict containing ``obs`` and, for policies
+                with a privileged critic, ``critic_obs``.
             deterministic: If True, return the mean action; otherwise sample
 
         Returns:
@@ -73,7 +74,8 @@ class Policy(nn.Module, ABC):
         ``sample()`` call from silently producing zero pathwise gradients.
 
         Args:
-            tensordict: Input TensorDict containing ``obs``.
+            tensordict: Input TensorDict containing ``obs`` and, for policies
+                with a privileged critic, ``critic_obs``.
             deterministic: If True, return a differentiable deterministic
                 action.
 
@@ -100,7 +102,8 @@ class Policy(nn.Module, ABC):
         """Write value estimate for the given observations into the TensorDict.
 
         Args:
-            tensordict: Input TensorDict containing `obs`.
+            tensordict: Input TensorDict containing ``obs`` and, for policies
+                with a privileged critic, ``critic_obs``.
 
         Returns:
             TensorDict with `value` populated.
@@ -112,7 +115,8 @@ class Policy(nn.Module, ABC):
         """Evaluate actions and return current policy outputs.
 
         Args:
-            tensordict: TensorDict containing `obs` and `action`.
+            tensordict: TensorDict containing ``obs``, ``action``, and
+                optional ``critic_obs``.
 
         Returns:
             A new TensorDict containing `sample_log_prob`, `entropy`, and `value`.

--- a/embodichain/learning/rl/train.py
+++ b/embodichain/learning/rl/train.py
@@ -21,16 +21,21 @@ import os
 import random
 import time
 from collections.abc import Sequence
+from copy import deepcopy
 from pathlib import Path
 
+from gymnasium import spaces
 import numpy as np
 import torch
 import wandb
 from torch.utils.tensorboard import SummaryWriter
-from copy import deepcopy
 
-from embodichain.learning.rl.models import build_policy, get_registered_policy_names
-from embodichain.learning.rl.models import build_mlp_from_cfg
+from embodichain.learning.rl.models import (
+    build_mlp_from_cfg,
+    build_policy,
+    get_registered_policy_names,
+    resolve_policy_obs_groups,
+)
 from embodichain.learning.rl.algo import (
     RolloutKind,
     build_algo,
@@ -42,7 +47,10 @@ from embodichain.learning.rl.differentiable_trainer import (
 )
 from embodichain.learning.rl.env import build_learning_env
 from embodichain.learning.rl.routing import get_trainer_class
-from embodichain.learning.rl.utils import dict_to_tensordict, flatten_dict_observation
+from embodichain.learning.rl.utils import (
+    dict_to_tensordict,
+    flatten_observation_groups,
+)
 from embodichain.learning.rl.utils.trainer import Trainer
 from embodichain.utils import logger
 from embodichain.lab.gym.utils.registration import (
@@ -124,35 +132,82 @@ def _resolve_profile_output(
     return str(output.with_name(f"{output.stem}_rank{rank}{output.suffix}"))
 
 
+def _set_initial_log_std(policy: torch.nn.Module, policy_block: dict) -> None:
+    """Apply an explicit initial Gaussian log standard deviation."""
+    if "initial_log_std" not in policy_block or not hasattr(policy, "log_std"):
+        return
+    with torch.no_grad():
+        policy.log_std.fill_(float(policy_block["initial_log_std"]))
+
+
+def _observation_space_dim(
+    observation_space: spaces.Space,
+    groups: tuple[str, ...] | None,
+) -> int:
+    """Return the flattened size of selected observation groups."""
+    if groups is None:
+        return int(spaces.utils.flatdim(observation_space))
+
+    total = 0
+    for group in groups:
+        selected_space = observation_space
+        for key in group.split("."):
+            if not isinstance(selected_space, spaces.Dict):
+                raise TypeError(
+                    f"Observation group '{group}' requires a Dict space at '{key}'."
+                )
+            if key not in selected_space.spaces:
+                raise KeyError(
+                    f"Observation group '{group}' was not found in the environment space."
+                )
+            selected_space = selected_space.spaces[key]
+        total += int(spaces.utils.flatdim(selected_space))
+    return total
+
+
 def _build_learning_policy(
     policy_block: dict,
     env,
     device: torch.device,
 ):
-    obs_dim = int(env.single_observation_space.shape[-1])
+    actor_obs_groups, critic_obs_groups = resolve_policy_obs_groups(policy_block)
+    actor_obs_dim = _observation_space_dim(
+        env.single_observation_space, actor_obs_groups
+    )
+    uses_separate_critic_obs = actor_obs_groups != critic_obs_groups
+    critic_obs_dim = (
+        _observation_space_dim(env.single_observation_space, critic_obs_groups)
+        if uses_separate_critic_obs
+        else actor_obs_dim
+    )
     action_dim = int(env.single_action_space.shape[-1])
     policy_name = policy_block["name"].lower()
     actor_cfg = policy_block.get("actor")
     critic_cfg = policy_block.get("critic")
     actor = (
-        build_mlp_from_cfg(actor_cfg, obs_dim, action_dim)
+        build_mlp_from_cfg(actor_cfg, actor_obs_dim, action_dim)
         if actor_cfg is not None
         else None
     )
     critic = (
-        build_mlp_from_cfg(critic_cfg, obs_dim, 1) if critic_cfg is not None else None
+        build_mlp_from_cfg(critic_cfg, critic_obs_dim, 1)
+        if critic_cfg is not None
+        else None
     )
     policy = build_policy(
         policy_block,
-        env.single_observation_space,
+        (
+            actor_obs_dim
+            if policy_name in {"actor_critic", "actor_only"}
+            else env.single_observation_space
+        ),
         env.single_action_space,
         device,
         actor=actor,
         critic=critic,
+        critic_obs_space=critic_obs_dim if uses_separate_critic_obs else None,
     )
-    if "initial_log_std" in policy_block and hasattr(policy, "log_std"):
-        with torch.no_grad():
-            policy.log_std.fill_(float(policy_block["initial_log_std"]))
+    _set_initial_log_std(policy, policy_block)
     return policy
 
 
@@ -296,6 +351,9 @@ def _train_learning_env(
                 eval_seed=eval_seed,
                 best_eval_metric=trainer_cfg.get("best_eval_metric", "eval/avg_reward"),
                 best_eval_mode=trainer_cfg.get("best_eval_mode", "max"),
+                save_frequency_updates=int(
+                    trainer_cfg.get("save_frequency_updates", 0)
+                ),
             )
             default_steps = iterations * buffer_size * num_envs
         total_timesteps = int(trainer_cfg.get("total_timesteps", default_steps))
@@ -381,7 +439,11 @@ def train_from_config(
     )
     enable_eval = bool(trainer_cfg.get("enable_eval", False))
     eval_freq = int(trainer_cfg.get("eval_freq", 10000))
-    save_freq = int(trainer_cfg.get("save_freq", 50000))
+    save_freq = int(
+        trainer_cfg.get(
+            "save_freq", 0 if "save_frequency_updates" in trainer_cfg else 50000
+        )
+    )
     num_eval_episodes = int(trainer_cfg.get("num_eval_episodes", 5))
     eval_seed = int(trainer_cfg.get("eval_seed", seed + 10_000))
     headless = bool(trainer_cfg.get("headless", True))
@@ -491,8 +553,17 @@ def train_from_config(
     env = build_env(gym_config_data["id"], base_env_cfg=gym_env_cfg)
     sample_obs, _ = env.reset(seed=effective_seed)
     sample_obs_td = dict_to_tensordict(sample_obs, device)
-    obs_dim = flatten_dict_observation(sample_obs_td).shape[-1]
-    flat_obs_space = env.flattened_observation_space
+    actor_obs_groups, critic_obs_groups = resolve_policy_obs_groups(policy_block)
+    actor_obs_dim = flatten_observation_groups(
+        sample_obs_td,
+        actor_obs_groups,
+    ).shape[-1]
+    uses_separate_critic_obs = actor_obs_groups != critic_obs_groups
+    critic_obs_dim = (
+        flatten_observation_groups(sample_obs_td, critic_obs_groups).shape[-1]
+        if uses_separate_critic_obs
+        else actor_obs_dim
+    )
 
     # Create evaluation environment only if enabled
     eval_env = None
@@ -534,16 +605,17 @@ def train_from_config(
                 "ActorCritic requires 'actor' and 'critic' definitions in JSON (policy.actor / policy.critic)."
             )
 
-        actor = build_mlp_from_cfg(actor_cfg, obs_dim, action_dim)
-        critic = build_mlp_from_cfg(critic_cfg, obs_dim, 1)
+        actor = build_mlp_from_cfg(actor_cfg, actor_obs_dim, action_dim)
+        critic = build_mlp_from_cfg(critic_cfg, critic_obs_dim, 1)
 
         policy = build_policy(
             policy_block,
-            flat_obs_space,
+            actor_obs_dim,
             env.action_space,
             device,
             actor=actor,
             critic=critic,
+            critic_obs_space=(critic_obs_dim if uses_separate_critic_obs else None),
         )
     elif policy_name.lower() == "actor_only":
         actor_cfg = policy_block.get("actor")
@@ -552,11 +624,11 @@ def train_from_config(
                 "ActorOnly requires 'actor' definition in JSON (policy.actor)."
             )
 
-        actor = build_mlp_from_cfg(actor_cfg, obs_dim, action_dim)
+        actor = build_mlp_from_cfg(actor_cfg, actor_obs_dim, action_dim)
 
         policy = build_policy(
             policy_block,
-            flat_obs_space,
+            actor_obs_dim,
             env.action_space,
             device,
             actor=actor,
@@ -565,6 +637,8 @@ def train_from_config(
         policy = build_policy(
             policy_block, env.observation_space, env.action_space, device
         )
+
+    _set_initial_log_std(policy, policy_block)
 
     # Build Algorithm via factory
     algo_name = algo_block["name"].lower()
@@ -633,6 +707,7 @@ def train_from_config(
         writer=writer,
         eval_freq=eval_freq if enable_eval else 0,  # Disable eval if not enabled
         save_freq=save_freq,
+        save_frequency_updates=int(trainer_cfg.get("save_frequency_updates", 0)),
         checkpoint_dir=checkpoint_dir,
         exp_name=exp_name,
         use_wandb=use_wandb,

--- a/embodichain/learning/rl/utils/__init__.py
+++ b/embodichain/learning/rl/utils/__init__.py
@@ -16,8 +16,14 @@
 
 """RL helper utilities: algorithm config, optimizers, and observation helpers."""
 
+from __future__ import annotations
+
 from .config import AlgorithmCfg, LRSchedulerCfg, OptimizerCfg
-from .helper import dict_to_tensordict, flatten_dict_observation
+from .helper import (
+    dict_to_tensordict,
+    flatten_dict_observation,
+    flatten_observation_groups,
+)
 from .optimizer import (
     bind_scheduler_horizon,
     build_lr_scheduler,
@@ -40,6 +46,7 @@ __all__ = [
     "coerce_optimizer_cfg",
     "dict_to_tensordict",
     "flatten_dict_observation",
+    "flatten_observation_groups",
     "get_registered_lr_scheduler_names",
     "get_registered_optimizer_names",
     "scheduler_needs_horizon",

--- a/embodichain/learning/rl/utils/helper.py
+++ b/embodichain/learning/rl/utils/helper.py
@@ -16,7 +16,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from typing import Any
 
 import torch
@@ -25,6 +25,7 @@ from tensordict import TensorDict
 __all__ = [
     "dict_to_tensordict",
     "flatten_dict_observation",
+    "flatten_observation_groups",
 ]
 
 
@@ -53,6 +54,56 @@ def flatten_dict_observation(obs: TensorDict) -> torch.Tensor:
         raise ValueError("No tensors found in observation TensorDict.")
 
     return torch.cat(obs_list, dim=-1)
+
+
+def flatten_observation_groups(
+    obs: TensorDict,
+    groups: Sequence[str] | None,
+) -> torch.Tensor:
+    """Flatten selected observation groups in the configured order.
+
+    A group name selects one top-level TensorDict key. Dot-separated names may
+    select nested keys, for example ``"robot.qpos"``. When ``groups`` is
+    ``None``, every tensor is flattened using
+    :func:`flatten_dict_observation` for compatibility with existing tasks.
+
+    Args:
+        obs: Observation TensorDict with batch dimension ``[num_envs]``.
+        groups: Observation group names consumed by one model.
+
+    Returns:
+        Concatenated observation tensor with shape ``[num_envs, obs_dim]``.
+
+    Raises:
+        ValueError: If ``groups`` is empty or a selected group has no tensors.
+        KeyError: If a configured group is absent from ``obs``.
+    """
+    if groups is None:
+        return flatten_dict_observation(obs)
+    if len(groups) == 0:
+        raise ValueError("Observation groups cannot be empty.")
+
+    flattened: list[torch.Tensor] = []
+    for group in groups:
+        value: TensorDict | torch.Tensor = obs
+        for key in group.split("."):
+            if not isinstance(value, TensorDict) or key not in value.keys():
+                raise KeyError(
+                    f"Observation group '{group}' was not found. "
+                    f"Available top-level groups: {list(obs.keys())}."
+                )
+            value = value[key]
+        if isinstance(value, TensorDict):
+            flattened.append(flatten_dict_observation(value))
+        elif isinstance(value, torch.Tensor):
+            flattened.append(value.flatten(start_dim=1))
+        else:
+            raise TypeError(
+                f"Observation group '{group}' must contain tensors, got "
+                f"{type(value)!r}."
+            )
+
+    return torch.cat(flattened, dim=-1)
 
 
 def dict_to_tensordict(

--- a/embodichain/learning/rl/utils/trainer.py
+++ b/embodichain/learning/rl/utils/trainer.py
@@ -32,6 +32,8 @@ from embodichain.learning.rl.buffer import RolloutBuffer
 from embodichain.learning.rl.collector import SyncCollector
 from embodichain.learning.rl.evaluation import evaluate_episodes
 
+__all__ = ["Trainer"]
+
 
 class Trainer:
     """Algorithm-agnostic trainer that coordinates training loop, logging, and evaluation."""
@@ -59,6 +61,7 @@ class Trainer:
         eval_seed: int | None = None,
         best_eval_metric: str = "eval/avg_reward",
         best_eval_mode: str = "max",
+        save_frequency_updates: int = 0,
     ):
         if best_eval_mode not in {"min", "max"}:
             raise ValueError("best_eval_mode must be 'min' or 'max'.")
@@ -74,6 +77,7 @@ class Trainer:
         self.writer = writer
         self.eval_freq = eval_freq
         self.save_freq = save_freq
+        self.save_frequency_updates = save_frequency_updates
         self.checkpoint_dir = checkpoint_dir
         self.exp_name = exp_name
         self.use_wandb = use_wandb
@@ -91,6 +95,7 @@ class Trainer:
 
         self.device = self.algorithm.device
         self.global_step = 0
+        self.num_updates = 0
         self.start_time = time.time()
         self.ret_window = deque(maxlen=100)
         self.len_window = deque(maxlen=100)
@@ -104,10 +109,16 @@ class Trainer:
         num_envs = getattr(self.env, "num_envs", None)
         if num_envs is None:
             raise RuntimeError("Env must expose num_envs for trainer statistics.")
-        obs_dim = getattr(self.policy, "obs_dim", None)
-        action_dim = getattr(self.policy, "action_dim", None)
+        policy_module = getattr(self.policy, "module", self.policy)
+        obs_dim = getattr(policy_module, "obs_dim", None)
+        action_dim = getattr(policy_module, "action_dim", None)
         if obs_dim is None or action_dim is None:
             raise RuntimeError("Policy must expose obs_dim and action_dim.")
+        critic_obs_dim = (
+            getattr(policy_module, "critic_obs_dim", None)
+            if getattr(policy_module, "uses_separate_critic_obs", False)
+            else None
+        )
 
         self.buffer = RolloutBuffer(
             num_envs=num_envs,
@@ -115,6 +126,12 @@ class Trainer:
             obs_dim=obs_dim,
             action_dim=action_dim,
             device=self.device,
+            critic_obs_dim=critic_obs_dim,
+            distribution_param_dim=getattr(
+                policy_module,
+                "distribution_param_dim",
+                None,
+            ),
         )
         self.collector = SyncCollector(
             env=self.env,
@@ -171,6 +188,7 @@ class Trainer:
         while self.global_step < total_timesteps:
             self._collect_rollout()
             losses = self.algorithm.update(self.buffer.get(flatten=False))
+            self.num_updates += 1
             self._log_train(losses)
             if (
                 self._next_eval_step is not None
@@ -187,6 +205,11 @@ class Trainer:
                 self.save_checkpoint()
                 while self._next_save_step <= self.global_step:
                     self._next_save_step += self.save_freq
+            if (
+                self.save_frequency_updates > 0
+                and self.num_updates % self.save_frequency_updates == 0
+            ):
+                self.save_checkpoint()
         return self.get_summary()
 
     @torch.no_grad()
@@ -418,6 +441,7 @@ class Trainer:
         )
         checkpoint = {
             "global_step": self.global_step,
+            "num_updates": self.num_updates,
             "policy": policy_state,
             "best_eval_value": self.best_eval_value,
         }
@@ -442,6 +466,7 @@ class Trainer:
         elapsed = max(1e-6, time.time() - self.start_time)
         return {
             "global_step": int(self.global_step),
+            "num_updates": int(self.num_updates),
             "elapsed_time_sec": float(elapsed),
             "training_fps": float(self.global_step / elapsed),
             "last_train_metrics": dict(self.last_train_metrics),

--- a/tests/learning/test_evaluation.py
+++ b/tests/learning/test_evaluation.py
@@ -128,3 +128,33 @@ def test_trainer_rewinds_external_eval_event_manager() -> None:
         call(123),
         call(123),
     ]
+
+
+def test_evaluation_preserves_separate_actor_and_critic_inputs() -> None:
+    """Evaluation uses the observation groups configured on the policy."""
+
+    class GroupedEnv(_AsyncAutoResetEnv):
+        def reset(self, *, seed=None, options=None):
+            observation, info = super().reset(seed=seed, options=options)
+            return {"policy": observation, "critic": observation + 10.0}, info
+
+    class GroupedPolicy(_DeterministicPolicy):
+        actor_obs_groups = ("policy",)
+        critic_obs_groups = ("critic",)
+        uses_separate_critic_obs = True
+
+        def get_action(self, tensordict, deterministic: bool = False):
+            torch.testing.assert_close(tensordict["obs"], torch.zeros(3, 1))
+            torch.testing.assert_close(
+                tensordict["critic_obs"], torch.full((3, 1), 10.0)
+            )
+            return super().get_action(tensordict, deterministic=deterministic)
+
+    result = evaluate_episodes(
+        policy=GroupedPolicy(),
+        env=GroupedEnv(),
+        num_episodes=1,
+        device="cpu",
+    )
+
+    assert result["eval/avg_length"] == 1.0

--- a/tests/learning/test_point_mass.py
+++ b/tests/learning/test_point_mass.py
@@ -31,6 +31,7 @@ from embodichain.learning.rl.env import (
     build_learning_env,
 )
 from embodichain.learning.rl.models import ActorCritic
+from embodichain.learning.rl.train import _build_learning_policy
 from embodichain.learning.rl.train import train_from_config
 from embodichain.learning.rl.utils import OptimizerCfg
 from embodichain.learning.rl.utils.trainer import Trainer
@@ -144,6 +145,9 @@ def test_unified_train_entry_runs_apg_and_ppo(
         "max_grad_norm": 1.0,
     }
     if policy_name == "actor_critic":
+        policy["actor_obs_normalization"] = True
+        policy["critic_obs_normalization"] = True
+        policy["initial_log_std"] = -2.0
         policy["critic"] = {
             "type": "mlp",
             "network_cfg": {"hidden_sizes": [8], "activation": "tanh"},
@@ -178,11 +182,30 @@ def test_unified_train_entry_runs_apg_and_ppo(
     }
     config_path = tmp_path / f"{algorithm_name}.json"
     config_path.write_text(json.dumps(config), encoding="utf-8")
+    if algorithm_name == "ppo":
+        initial = _build_learning_policy(
+            policy, PointMassEnv(num_envs=2), torch.device("cpu")
+        )
+        torch.testing.assert_close(
+            initial.log_std,
+            torch.full_like(initial.log_std, -2.0),
+        )
 
     summary = train_from_config(str(config_path))
 
     assert summary["global_step"] == 8
     assert summary["latest_checkpoint_path"] is not None
+    if algorithm_name == "ppo":
+        checkpoint = torch.load(summary["latest_checkpoint_path"], weights_only=True)
+        restored = _build_learning_policy(
+            policy, PointMassEnv(num_envs=2), torch.device("cpu")
+        )
+        restored.load_state_dict(checkpoint["policy"], strict=True)
+        assert int(restored.actor_obs_normalizer.count) > 0
+        assert int(restored.critic_obs_normalizer.count) > 0
+        assert "log_std" in checkpoint["policy"]
+        assert "std" not in checkpoint["policy"]
+        assert checkpoint["num_updates"] == 1
 
 
 def test_sync_collector_accepts_tensor_point_mass_observations() -> None:
@@ -250,3 +273,44 @@ def test_trainer_saves_best_checkpoint_from_eval(tmp_path: Path) -> None:
     assert "eval/avg_reward" in summary["last_eval_metrics"]
     assert summary["best_checkpoint_path"] is not None
     assert Path(summary["best_checkpoint_path"]).is_file()
+
+
+def test_trainer_saves_checkpoint_by_update_count(tmp_path: Path) -> None:
+    env = PointMassEnv(num_envs=2, max_episode_steps=4)
+    policy = ActorCritic(
+        14,
+        2,
+        env.device,
+        actor=nn.Linear(14, 2),
+        critic=nn.Linear(14, 1),
+    )
+    algorithm = PPO(
+        PPOCfg(
+            device="cpu",
+            optimizer=OptimizerCfg(learning_rate=1e-3),
+            n_epochs=1,
+            batch_size=8,
+        ),
+        policy,
+    )
+    trainer = Trainer(
+        policy=policy,
+        env=env,
+        algorithm=algorithm,
+        buffer_size=4,
+        batch_size=8,
+        writer=None,
+        eval_freq=0,
+        save_freq=0,
+        save_frequency_updates=2,
+        checkpoint_dir=str(tmp_path),
+        exp_name="point_mass_updates",
+        use_wandb=False,
+    )
+    saved_steps: list[int] = []
+    trainer.save_checkpoint = lambda path=None: saved_steps.append(trainer.global_step)
+
+    summary = trainer.train(total_timesteps=24)
+
+    assert saved_steps == [16]
+    assert summary["num_updates"] == 3

--- a/tests/learning/test_ppo_stability.py
+++ b/tests/learning/test_ppo_stability.py
@@ -1,0 +1,345 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn as nn
+from gymnasium import spaces
+from tensordict import TensorDict
+
+from embodichain.learning.rl.algo import PPO, PPOCfg, compute_gae
+from embodichain.learning.rl.buffer import RolloutBuffer
+from embodichain.learning.rl.collector import SyncCollector
+from embodichain.learning.rl.models import (
+    ActorCritic,
+    EmpiricalNormalizer,
+    build_policy,
+)
+from embodichain.learning.rl.train import _build_learning_policy
+from embodichain.learning.rl.utils import (
+    LRSchedulerCfg,
+    OptimizerCfg,
+    flatten_observation_groups,
+)
+
+
+class _NormalizationEnv:
+    """Small vector environment that exposes distinct actor and critic inputs."""
+
+    num_envs = 2
+    device = torch.device("cpu")
+    action_manager = None
+    single_observation_space = spaces.Dict(
+        {
+            "policy": spaces.Box(low=-1.0, high=1.0, shape=(2,)),
+            "critic": spaces.Box(low=-1.0, high=1.0, shape=(3,)),
+        }
+    )
+    single_action_space = spaces.Box(low=-1.0, high=1.0, shape=(1,))
+
+    def __init__(self) -> None:
+        self.step_count = 0
+
+    def _observation(self) -> dict[str, torch.Tensor]:
+        return {
+            "policy": torch.full((self.num_envs, 2), float(self.step_count)),
+            "critic": torch.full((self.num_envs, 3), float(self.step_count + 2)),
+        }
+
+    def reset(self) -> tuple[dict[str, torch.Tensor], dict]:
+        self.step_count = 0
+        return self._observation(), {}
+
+    def step(self, action: torch.Tensor) -> tuple[
+        dict[str, torch.Tensor],
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        dict,
+    ]:
+        self.step_count += 1
+        zeros = torch.zeros(self.num_envs)
+        return (
+            self._observation(),
+            action.sum(dim=-1),
+            zeros.bool(),
+            zeros.bool(),
+            {},
+        )
+
+
+def _policy(*, normalize: bool = False) -> ActorCritic:
+    return ActorCritic(
+        obs_dim=2,
+        action_dim=1,
+        device=torch.device("cpu"),
+        actor=nn.Linear(2, 1),
+        critic=nn.Linear(3, 1),
+        critic_obs_dim=3,
+        actor_obs_groups=("policy",),
+        critic_obs_groups=("critic",),
+        actor_obs_normalization=normalize,
+        critic_obs_normalization=normalize,
+    )
+
+
+def _algorithm(policy: ActorCritic, **overrides: object) -> PPO:
+    cfg = {
+        "device": "cpu",
+        "optimizer": OptimizerCfg(learning_rate=1e-3),
+        "n_epochs": 1,
+        "batch_size": 4,
+        "ent_coef": 0.0,
+        "vf_coef": 1.0,
+        **overrides,
+    }
+    return PPO(PPOCfg(**cfg), policy)
+
+
+def test_empirical_normalizer_tracks_and_restores_moments() -> None:
+    normalizer = EmpiricalNormalizer(2)
+    samples = torch.tensor([[1.0, 2.0], [3.0, 6.0]])
+
+    normalizer.update(samples)
+
+    torch.testing.assert_close(normalizer.mean, torch.tensor([[2.0, 4.0]]))
+    torch.testing.assert_close(normalizer.variance, torch.tensor([[1.0, 4.0]]))
+    restored = EmpiricalNormalizer(2)
+    restored.load_state_dict(normalizer.state_dict())
+    torch.testing.assert_close(restored(samples), normalizer(samples))
+    assert int(restored.count) == 2
+
+
+def test_collector_updates_normalizers_and_records_old_distribution() -> None:
+    env = _NormalizationEnv()
+    policy = _policy(normalize=True)
+    buffer = RolloutBuffer(
+        num_envs=env.num_envs,
+        rollout_len=2,
+        obs_dim=2,
+        action_dim=1,
+        device=env.device,
+        critic_obs_dim=3,
+        distribution_param_dim=1,
+    )
+    collector = SyncCollector(env, policy, env.device)
+
+    rollout = collector.collect(2, rollout=buffer.start_rollout())
+
+    assert int(policy.actor_obs_normalizer.count) == 4
+    assert int(policy.critic_obs_normalizer.count) == 4
+    assert rollout["critic_obs"].shape == (2, 3, 3)
+    assert torch.isfinite(rollout["action_mean"][:, :-1]).all()
+    assert torch.isfinite(rollout["action_std"][:, :-1]).all()
+    losses = _algorithm(policy).update(rollout)
+    assert all(torch.isfinite(torch.tensor(value)) for value in losses.values())
+
+
+def test_observation_groups_preserve_order_and_configure_policy() -> None:
+    observation = TensorDict(
+        {
+            "first": torch.ones(2, 2),
+            "second": torch.full((2, 1), 2.0),
+        },
+        batch_size=[2],
+    )
+
+    flattened = flatten_observation_groups(observation, ("second", "first"))
+    policy = build_policy(
+        {
+            "name": "actor_critic",
+            "obs_groups": {"actor": ["first"], "critic": ["second"]},
+        },
+        2,
+        1,
+        torch.device("cpu"),
+        actor=nn.Linear(2, 1),
+        critic=nn.Linear(1, 1),
+        critic_obs_space=1,
+    )
+
+    torch.testing.assert_close(flattened[:, 0], torch.full((2,), 2.0))
+    torch.testing.assert_close(flattened[:, 1:], torch.ones(2, 2))
+    assert policy.actor_obs_groups == ("first",)
+    assert policy.critic_obs_groups == ("second",)
+    with pytest.raises(KeyError, match="critic_obs"):
+        policy.get_value(TensorDict({"obs": torch.zeros(2, 2)}, batch_size=[2]))
+
+
+def test_lightweight_policy_builds_distinct_actor_and_critic_inputs() -> None:
+    policy = _build_learning_policy(
+        {
+            "name": "actor_critic",
+            "obs_groups": {"actor": ["policy"], "critic": ["critic"]},
+            "actor": {
+                "type": "mlp",
+                "network_cfg": {"hidden_sizes": [4], "activation": "tanh"},
+            },
+            "critic": {
+                "type": "mlp",
+                "network_cfg": {"hidden_sizes": [4], "activation": "tanh"},
+            },
+        },
+        _NormalizationEnv(),
+        torch.device("cpu"),
+    )
+
+    assert policy.obs_dim == 2
+    assert policy.critic_obs_dim == 3
+    assert policy.actor[0].in_features == 2
+    assert policy.critic[0].in_features == 3
+
+
+def test_adaptive_kl_reduces_learning_rate() -> None:
+    policy = _policy()
+    algorithm = _algorithm(policy, schedule="adaptive", desired_kl=0.01)
+    batch = TensorDict(
+        {
+            "action_mean": torch.zeros(4, 1),
+            "action_std": torch.ones(4, 1),
+        },
+        batch_size=[4],
+    )
+    evaluated = TensorDict(
+        {
+            "action_mean": torch.ones(4, 1),
+            "action_std": torch.ones(4, 1),
+        },
+        batch_size=[4],
+    )
+
+    kl = algorithm._update_adaptive_learning_rate(batch, evaluated)
+
+    assert kl == pytest.approx(0.5)
+    assert algorithm.current_learning_rate() == pytest.approx(1e-3 / 1.5)
+
+
+def test_adaptive_kl_rejects_separate_learning_rate_scheduler() -> None:
+    with pytest.raises(ValueError, match="cannot be combined"):
+        _algorithm(
+            _policy(),
+            schedule="adaptive",
+            desired_kl=0.01,
+            lr_scheduler=LRSchedulerCfg(name="step", kwargs={"step_size": 1}),
+        )
+
+
+def test_clipped_value_loss_uses_larger_error() -> None:
+    policy = _policy()
+    algorithm = _algorithm(policy, use_clipped_value_loss=True, clip_coef=0.2)
+
+    loss = algorithm._value_loss(
+        values=torch.tensor([1.0]),
+        returns=torch.tensor([1.0]),
+        old_values=torch.tensor([0.0]),
+    )
+
+    assert float(loss) == pytest.approx(0.64)
+
+
+def test_action_bound_loss_penalizes_policy_means_outside_unit_range() -> None:
+    action_mean = torch.tensor([[-2.0], [-0.5], [0.5], [2.0]])
+
+    loss = PPO._action_bound_loss(action_mean)
+
+    assert float(loss) == pytest.approx(0.5)
+
+
+def test_negative_action_bound_coefficient_is_rejected() -> None:
+    with pytest.raises(ValueError, match="action_bound_coef must be non-negative"):
+        _algorithm(_policy(), action_bound_coef=-1.0)
+
+
+def test_minibatch_count_preserves_every_transition() -> None:
+    algorithm = _algorithm(_policy(), num_mini_batches=3)
+
+    batches = algorithm._minibatch_indices(10)
+
+    assert len(batches) == 3
+    torch.testing.assert_close(
+        torch.cat(batches).sort().values,
+        torch.arange(10),
+    )
+
+
+def test_non_finite_gradient_is_rejected_before_optimizer_step() -> None:
+    policy = _policy()
+    algorithm = _algorithm(policy)
+    first_parameter = next(policy.actor.parameters())
+    first_parameter.grad = torch.full_like(first_parameter, float("inf"))
+
+    with pytest.raises(FloatingPointError, match="optimizer step skipped"):
+        algorithm._clip_gradients()
+
+
+def test_actor_and_critic_gradients_are_clipped_separately() -> None:
+    policy = _policy()
+    algorithm = _algorithm(policy, max_grad_norm=1.0)
+    actor_parameter = next(policy.actor.parameters())
+    critic_parameter = next(policy.critic.parameters())
+    actor_parameter.grad = torch.full_like(actor_parameter, 2.0)
+    critic_parameter.grad = torch.full_like(critic_parameter, 2.0)
+
+    algorithm._clip_gradients()
+
+    actor_norm = torch.linalg.vector_norm(actor_parameter.grad)
+    critic_norm = torch.linalg.vector_norm(critic_parameter.grad)
+    assert float(actor_norm) == pytest.approx(1.0, rel=1e-5)
+    assert float(critic_norm) == pytest.approx(1.0, rel=1e-5)
+
+
+def test_log_action_standard_deviation_uses_configured_range() -> None:
+    policy = ActorCritic(
+        obs_dim=2,
+        action_dim=1,
+        device=torch.device("cpu"),
+        actor=nn.Linear(2, 1),
+        critic=nn.Linear(2, 1),
+        initial_action_std=0.5,
+        action_std_range=(0.1, 1.0),
+    )
+
+    torch.testing.assert_close(policy.action_std, torch.tensor([0.5]))
+    with torch.no_grad():
+        policy.log_std.fill_(torch.log(torch.tensor(2.0)))
+    torch.testing.assert_close(policy.action_std, torch.tensor([1.0]))
+
+
+@pytest.mark.parametrize(
+    ("terminated", "truncated", "expected_return"),
+    [(False, True, 1.0 + 0.99 * 2.0), (True, False, 1.0)],
+)
+def test_gae_handles_episode_boundaries(
+    terminated: bool,
+    truncated: bool,
+    expected_return: float,
+) -> None:
+    rollout = TensorDict(
+        {
+            "reward": torch.tensor([[1.0, 0.0]]),
+            "value": torch.tensor([[2.0, 10.0]]),
+            "done": torch.tensor([[True, False]]),
+            "terminated": torch.tensor([[terminated, False]]),
+            "truncated": torch.tensor([[truncated, False]]),
+        },
+        batch_size=[1, 2],
+    )
+
+    _, returns = compute_gae(rollout, gamma=0.99, gae_lambda=0.95)
+
+    torch.testing.assert_close(returns, torch.tensor([[expected_return]]))


### PR DESCRIPTION
# Description

This PR improves EmbodiChain's PPO implementation while preserving the existing default observation behavior.

- Add separate actor and critic observation groups with independently checkpointed running normalization.
- Add adaptive learning rates from Gaussian KL, clipped value loss, action-mean bounds, and finite-gradient rejection.
- Apply timeout bootstrapping at episode boundaries.
- Preserve policy distribution parameters and critic observations through rollout collection and evaluation.
- Add update-based checkpoint intervals and keep the update counter in checkpoints and training summaries.
- Cover normalization, grouped observations, minibatch partitioning, timeout bootstrapping, checkpoint restoration, and PPO update stability with focused tests.

No new dependencies are required.

### Validation results

- `pytest tests/learning -q`: 78 passed, 3 deselected.
- Local CLI smoke test: completed 2 PPO updates and 64 environment steps, including evaluation and checkpoint creation; checkpoint counters, normalization state, and tensors were valid.
- `black --check --diff --color ./`: passed with Black 26.3.1.
- `python docs/scripts/check_api_docs.py`: 1863/1863 public exports documented.
- Changed-file structure checks passed for headers, future annotations, and public-module exports across 18 Python files.

## Type of change

- Enhancement (non-breaking change which improves an existing functionality)

## Screenshots

Not applicable.

## Checklist

- [x] I have run the `black .` command to format the code base.
- [x] I have made corresponding changes to the documentation
- [x] Public API changes are reflected in the API docs (`python docs/scripts/check_api_docs.py`), if applicable
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Dependencies have been updated, if applicable.
